### PR TITLE
feat(browser,context): window tool results; wire ToolResultWindowProcessor with browser agent

### DIFF
--- a/openjiuwen/core/context_engine/__init__.py
+++ b/openjiuwen/core/context_engine/__init__.py
@@ -17,6 +17,10 @@ from openjiuwen.core.context_engine.processor.offloader.tool_result_budget_proce
     ToolResultBudgetProcessor,
     ToolResultBudgetProcessorConfig,
 )
+from openjiuwen.core.context_engine.processor.offloader.tool_result_window_processor import (
+    ToolResultWindowProcessor,
+    ToolResultWindowProcessorConfig,
+)
 from openjiuwen.core.context_engine.processor.offloader.message_summary_offloader import (
     MessageSummaryOffloader,
     MessageSummaryOffloaderConfig
@@ -63,6 +67,9 @@ _PROCESSORS_CLASSES = [
     "ContextProcessor",
     "ToolResultBudgetProcessor",
     "ToolResultBudgetProcessorConfig",
+    # tool result window
+    "ToolResultWindowProcessor",
+    "ToolResultWindowProcessorConfig",
     # message offloader
     "MessageOffloader",
     "MessageOffloaderConfig",

--- a/openjiuwen/core/context_engine/processor/offloader/__init__.py
+++ b/openjiuwen/core/context_engine/processor/offloader/__init__.py
@@ -10,6 +10,10 @@ from openjiuwen.core.context_engine.processor.offloader.tool_result_budget_proce
     ToolResultBudgetProcessor,
     ToolResultBudgetProcessorConfig,
 )
+from openjiuwen.core.context_engine.processor.offloader.tool_result_window_processor import (
+    ToolResultWindowProcessor,
+    ToolResultWindowProcessorConfig,
+)
 
 __all__ = [
     "MessageOffloader",
@@ -18,4 +22,6 @@ __all__ = [
     "MessageSummaryOffloaderConfig",
     "ToolResultBudgetProcessor",
     "ToolResultBudgetProcessorConfig",
+    "ToolResultWindowProcessor",
+    "ToolResultWindowProcessorConfig",
 ]

--- a/openjiuwen/core/context_engine/processor/offloader/tool_result_window_processor.py
+++ b/openjiuwen/core/context_engine/processor/offloader/tool_result_window_processor.py
@@ -65,7 +65,7 @@ class ToolResultWindowProcessorConfig(BaseModel):
 
 @ContextEngine.register_processor()
 class ToolResultWindowProcessor(ToolResultBudgetProcessor):
-    """Offload older results of selected tools, keeping only the newest ``keep_last_k`` in context."""
+    """Offload older results of selected tools, keeping at most the newest ``keep_last_k`` in context."""
 
     @property
     def config(self) -> ToolResultWindowProcessorConfig:
@@ -141,7 +141,7 @@ class ToolResultWindowProcessor(ToolResultBudgetProcessor):
         if not isinstance(getattr(message, "content", None), str):
             return False
         tool_name = self._resolve_target_tool_name(message, context_messages)
-        return bool(tool_name and tool_name in allowlist)
+        return bool(tool_name and any(tool_name.endswith(suffix) for suffix in allowlist))
 
     @staticmethod
     def _resolve_target_tool_name(

--- a/openjiuwen/core/context_engine/processor/offloader/tool_result_window_processor.py
+++ b/openjiuwen/core/context_engine/processor/offloader/tool_result_window_processor.py
@@ -1,0 +1,155 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+from __future__ import annotations
+
+from typing import Any, List, Optional, Tuple
+
+from pydantic import BaseModel, Field
+
+from openjiuwen.core.context_engine.base import ModelContext
+from openjiuwen.core.context_engine.context.context_utils import ContextUtils
+from openjiuwen.core.context_engine.context_engine import ContextEngine
+from openjiuwen.core.context_engine.processor.base import ContextEvent
+from openjiuwen.core.context_engine.processor.offloader.tool_result_budget_processor import (
+    ToolResultBudgetProcessor,
+)
+from openjiuwen.core.foundation.llm import BaseMessage, ToolMessage
+
+
+class ToolResultWindowProcessorConfig(BaseModel):
+    """Keep only the most recent ``keep_last_k`` results of selected tools in context.
+
+    This processor maintains a single global sliding window across all tools in
+    ``tool_names``: every time a matching tool result is added, results that fall
+    outside the newest ``keep_last_k`` are offloaded (persisted) so the message
+    history only ever shows the last ``keep_last_k`` full results.
+
+    The persist logic is inherited from :class:`ToolResultBudgetProcessor` --
+    the original tool output is written to the workspace offload directory and
+    replaced in context by a ``<persisted-output>`` preview placeholder.
+    """
+
+    tool_names: list[str] = Field(
+        default_factory=list,
+        description="Tool names whose results are managed by the sliding window. Empty means no-op.",
+    )
+    """Tools eligible for windowed offload. A result matches when its tool name is in this list."""
+
+    keep_last_k: int = Field(
+        default=3,
+        gt=0,
+        description="Number of most recent matching tool results kept in context with full content.",
+    )
+    """Window size. Matching results older than the newest ``keep_last_k`` are offloaded."""
+
+    trim_size: int = Field(
+        default=3000,
+        gt=0,
+        description="Number of leading characters kept in the context placeholder after offloading.",
+    )
+    """Preview length retained in the placeholder message."""
+
+    offload_file_prefix: str = Field(
+        default="ToolResultWindowProcessor",
+        description="Processor-specific filename prefix used under the workspace offload directory.",
+    )
+    """Filename prefix used to separate files produced by this processor."""
+
+    messages_threshold: int | None = Field(default=None, gt=0)
+    """Compatibility placeholder; this processor does not use message-count triggering."""
+
+    messages_to_keep: int | None = Field(default=None, gt=0)
+    """Compatibility placeholder; this processor keeps a per-tool-result window, not a message tail."""
+
+
+@ContextEngine.register_processor()
+class ToolResultWindowProcessor(ToolResultBudgetProcessor):
+    """Offload older results of selected tools, keeping only the newest ``keep_last_k`` in context."""
+
+    @property
+    def config(self) -> ToolResultWindowProcessorConfig:
+        return self._config
+
+    def _validate_config(self) -> None:
+        # Window processor has no size-threshold invariants; skip the base offloader checks.
+        return
+
+    async def trigger_add_messages(
+        self,
+        context: ModelContext,
+        messages_to_add: List[BaseMessage],
+        **kwargs: Any,
+    ) -> bool:
+        all_messages = context.get_messages() + messages_to_add
+        matched = self._matched_indices(all_messages)
+        if len(matched) <= self.config.keep_last_k:
+            return False
+        outside_window = matched[: -self.config.keep_last_k]
+        return any(not self._is_already_offloaded(all_messages[idx]) for idx in outside_window)
+
+    async def on_add_messages(
+        self,
+        context: ModelContext,
+        messages_to_add: List[BaseMessage],
+        **kwargs: Any,
+    ) -> Tuple[ContextEvent | None, List[BaseMessage]]:
+        self.sys_operation = kwargs.get("sys_operation")
+
+        context_messages = context.get_messages() + messages_to_add
+        context_size = len(context)
+        updated_messages = list(context_messages)
+
+        matched = self._matched_indices(updated_messages)
+        if len(matched) <= self.config.keep_last_k:
+            return None, messages_to_add
+
+        modified_indices: List[int] = []
+        for idx in matched[: -self.config.keep_last_k]:
+            message = updated_messages[idx]
+            if self._is_already_offloaded(message):
+                continue
+            updated_messages[idx] = await self._offload_tool_message(message, context)
+            modified_indices.append(idx)
+
+        if not modified_indices:
+            return None, messages_to_add
+
+        context.set_messages(updated_messages[:context_size])
+        event = ContextEvent(
+            event_type=self.processor_type(),
+            messages_to_modify=sorted(modified_indices),
+        )
+        return event, updated_messages[context_size:]
+
+    def _matched_indices(self, messages: List[BaseMessage]) -> List[int]:
+        allowlist = set(self.config.tool_names)
+        if not allowlist:
+            return []
+        return [
+            idx for idx, message in enumerate(messages) if self._is_target_tool_result(message, messages, allowlist)
+        ]
+
+    def _is_target_tool_result(
+        self,
+        message: BaseMessage,
+        context_messages: List[BaseMessage],
+        allowlist: set[str],
+    ) -> bool:
+        if not isinstance(message, ToolMessage):
+            return False
+        if not isinstance(getattr(message, "content", None), str):
+            return False
+        tool_name = self._resolve_target_tool_name(message, context_messages)
+        return bool(tool_name and tool_name in allowlist)
+
+    @staticmethod
+    def _resolve_target_tool_name(
+        message: ToolMessage,
+        context_messages: List[BaseMessage],
+    ) -> Optional[str]:
+        tool_name = ContextUtils.resolve_tool_name_from_message(message, context_messages)
+        if tool_name:
+            return tool_name
+        name = getattr(message, "name", None)
+        return name if isinstance(name, str) and name else None

--- a/openjiuwen/harness/subagents/browser_agent.py
+++ b/openjiuwen/harness/subagents/browser_agent.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import dataclasses
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from openjiuwen.core.context_engine import ToolResultWindowProcessorConfig
 from openjiuwen.core.foundation.llm.model import Model
 from openjiuwen.core.foundation.tool import McpServerConfig, Tool, ToolCard
 from openjiuwen.core.single_agent.rail.base import AgentRail
@@ -14,6 +15,7 @@ from openjiuwen.core.single_agent.schema.agent_card import AgentCard
 from openjiuwen.core.sys_operation import SysOperation
 from openjiuwen.harness.deep_agent import DeepAgent
 from openjiuwen.harness.factory import create_deep_agent
+from openjiuwen.harness.rails.context_engineer import ContextProcessorRail
 from openjiuwen.harness.schema.config import SubAgentConfig
 from openjiuwen.harness.tools.browser_move.playwright_runtime.config import (
     BrowserInstanceConfig,
@@ -43,6 +45,16 @@ if TYPE_CHECKING:
 
 
 BROWSER_AGENT_FACTORY_NAME = "browser_agent"
+
+# Browser probe/snapshot tools emit large results; keep only the most recent
+# few in context and persist older ones via ToolResultWindowProcessor.
+# Snapshot is exposed through the Playwright MCP server, so it carries the
+# ``mcp_playwright-official_`` prefix in its resolved tool name.
+BROWSER_WINDOWED_TOOL_NAMES = [
+    "browser_probe_interactives",
+    "browser_probe_cards",
+    "mcp_playwright-official_browser_snapshot",
+]
 
 DEFAULT_BROWSER_AGENT_SYSTEM_PROMPT_EN = (
     "You are a browser automation agent responsible for executing web tasks directly. "
@@ -269,7 +281,24 @@ def create_browser_agent(
         instance=resolved_settings.instance,
     )
     injected_tools = build_browser_runtime_tools(browser_backend, language=resolved_language)
-    injected_rails = [BrowserRuntimeRail(browser_backend)]
+    injected_rails: List[AgentRail] = [BrowserRuntimeRail(browser_backend)]
+    # Window the large browser probe/snapshot results unless the caller already
+    # manages context processors via their own ContextProcessorRail.
+    if not any(isinstance(rail, ContextProcessorRail) for rail in (rails or [])):
+        injected_rails.append(
+            ContextProcessorRail(
+                processors=[
+                    (
+                        "ToolResultWindowProcessor",
+                        ToolResultWindowProcessorConfig(
+                            tool_names=BROWSER_WINDOWED_TOOL_NAMES,
+                            keep_last_k=1,
+                        ),
+                    )
+                ],
+                preset=False,
+            )
+        )
     final_tools = list(tools or []) + injected_tools
     final_mcps = list(mcps or [])
     final_rails = list(rails or []) + injected_rails

--- a/openjiuwen/harness/subagents/browser_agent.py
+++ b/openjiuwen/harness/subagents/browser_agent.py
@@ -46,16 +46,6 @@ if TYPE_CHECKING:
 
 BROWSER_AGENT_FACTORY_NAME = "browser_agent"
 
-# Browser probe/snapshot tools emit large results; keep only the most recent
-# few in context and persist older ones via ToolResultWindowProcessor.
-# Snapshot is exposed through the Playwright MCP server, so it carries the
-# ``mcp_playwright-official_`` prefix in its resolved tool name.
-BROWSER_WINDOWED_TOOL_NAMES = [
-    "browser_probe_interactives",
-    "browser_probe_cards",
-    "mcp_playwright-official_browser_snapshot",
-]
-
 DEFAULT_BROWSER_AGENT_SYSTEM_PROMPT_EN = (
     "You are a browser automation agent responsible for executing web tasks directly. "
     "Plan and decide at this agent level, then use Playwright browser tools and approved runtime "
@@ -282,8 +272,16 @@ def create_browser_agent(
     )
     injected_tools = build_browser_runtime_tools(browser_backend, language=resolved_language)
     injected_rails: List[AgentRail] = [BrowserRuntimeRail(browser_backend)]
+
     # Window the large browser probe/snapshot results unless the caller already
     # manages context processors via their own ContextProcessorRail.
+    # Browser probe/snapshot tools emit large results; keep only the most recent
+    # few in context and persist older ones via ToolResultWindowProcessor.
+    browser_windowed_tool_names = [
+        "browser_probe_interactives",
+        "browser_probe_cards",
+        "browser_snapshot"
+    ]
     if not any(isinstance(rail, ContextProcessorRail) for rail in (rails or [])):
         injected_rails.append(
             ContextProcessorRail(
@@ -291,7 +289,7 @@ def create_browser_agent(
                     (
                         "ToolResultWindowProcessor",
                         ToolResultWindowProcessorConfig(
-                            tool_names=BROWSER_WINDOWED_TOOL_NAMES,
+                            tool_names=browser_windowed_tool_names,
                             keep_last_k=1,
                         ),
                     )

--- a/tests/unit_tests/core/context_engine/test_tool_result_window_processor.py
+++ b/tests/unit_tests/core/context_engine/test_tool_result_window_processor.py
@@ -121,6 +121,23 @@ class TestToolResultWindowProcessor:
         assert not isinstance(by_name["grep"][1], OffloadToolMessage)
 
     @pytest.mark.asyncio
+    async def test_matches_tool_name_by_suffix(self, tmp_path):
+        # A bare suffix matches a registry-prefixed tool name.
+        config = ToolResultWindowProcessorConfig(tool_names=["browser_snapshot"], keep_last_k=1)
+        context, _ = await build_context(str(tmp_path), config)
+
+        mcp_name = "mcp_playwright-official_browser_snapshot"
+        msgs: List = [UserMessage(content="browse")]
+        msgs += tool_round("s0", mcp_name, "snap-old-" + "x" * 100)
+        msgs += tool_round("s1", mcp_name, "snap-new-" + "x" * 100)
+        await context.add_messages(msgs)
+
+        result = [m for m in context.get_messages() if isinstance(m, ToolMessage)]
+        assert isinstance(result[0], OffloadToolMessage)  # oldest offloaded via suffix match
+        assert not isinstance(result[1], OffloadToolMessage)
+        assert result[1].content.startswith("snap-new-")
+
+    @pytest.mark.asyncio
     async def test_no_offload_when_within_window(self, tmp_path):
         config = ToolResultWindowProcessorConfig(tool_names=["grep"], keep_last_k=3)
         context, mock_fs = await build_context(str(tmp_path), config)

--- a/tests/unit_tests/core/context_engine/test_tool_result_window_processor.py
+++ b/tests/unit_tests/core/context_engine/test_tool_result_window_processor.py
@@ -1,0 +1,218 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Unit tests for ToolResultWindowProcessor sliding-window offload."""
+
+from __future__ import annotations
+
+from typing import List
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from openjiuwen.core.context_engine import ContextEngine, ContextEngineConfig
+from openjiuwen.core.context_engine.processor.offloader.tool_result_budget_processor import (
+    PERSISTED_OUTPUT_TAG,
+)
+from openjiuwen.core.context_engine.processor.offloader.tool_result_window_processor import (
+    ToolResultWindowProcessorConfig,
+)
+from openjiuwen.core.context_engine.schema.messages import OffloadToolMessage
+from openjiuwen.core.foundation.llm import (
+    AssistantMessage,
+    ToolCall,
+    ToolMessage,
+    UserMessage,
+)
+from openjiuwen.core.session.agent import Session
+from tests.unit_tests.core.context_engine._stream_state_helpers import (
+    assert_context_state_pair,
+    capture_context_compression_states,
+)
+
+
+def create_mock_sys_operation():
+    mock_sys_op = MagicMock()
+    mock_fs = MagicMock()
+    mock_fs.write_file = AsyncMock()
+    mock_sys_op.fs.return_value = mock_fs
+    return mock_sys_op, mock_fs
+
+
+class MockWorkspace:
+    def __init__(self, root_path: str):
+        self.root_path = root_path
+
+
+def tool_round(call_id: str, tool_name: str, content: str) -> List:
+    """One assistant tool call + the matching tool result."""
+    return [
+        AssistantMessage(
+            content="",
+            tool_calls=[ToolCall(id=call_id, name=tool_name, type="function", arguments="")],
+        ),
+        ToolMessage(content=content, tool_call_id=call_id, name=tool_name),
+    ]
+
+
+async def build_context(workspace_root: str, config: ToolResultWindowProcessorConfig):
+    workspace = MockWorkspace(root_path=workspace_root)
+    mock_sys_op, mock_fs = create_mock_sys_operation()
+    engine = ContextEngine(
+        ContextEngineConfig(default_window_message_num=100),
+        workspace=workspace,
+        sys_operation=mock_sys_op,
+    )
+    context = await engine.create_context(
+        context_id="test_ctx",
+        session=None,
+        history_messages=[],
+        processors=[("ToolResultWindowProcessor", config)],
+    )
+    return context, mock_fs
+
+
+class TestToolResultWindowProcessor:
+    @pytest.mark.asyncio
+    async def test_keeps_last_k_and_offloads_older(self, tmp_path):
+        config = ToolResultWindowProcessorConfig(tool_names=["grep"], keep_last_k=2, trim_size=10)
+        context, _ = await build_context(str(tmp_path), config)
+
+        msgs: List = [UserMessage(content="search please")]
+        for i in range(4):
+            msgs += tool_round(f"tc-{i}", "grep", f"result-{i}-" + "x" * 100)
+        await context.add_messages(msgs)
+
+        result = context.get_messages()
+        grep_results = [m for m in result if isinstance(m, ToolMessage) and m.name == "grep"]
+        assert len(grep_results) == 4
+        # Oldest two are offloaded; newest two keep full content.
+        assert isinstance(grep_results[0], OffloadToolMessage)
+        assert isinstance(grep_results[1], OffloadToolMessage)
+        assert grep_results[0].content.startswith(PERSISTED_OUTPUT_TAG)
+        assert not isinstance(grep_results[2], OffloadToolMessage)
+        assert not isinstance(grep_results[3], OffloadToolMessage)
+        assert grep_results[2].content.startswith("result-2-")
+        assert grep_results[3].content.startswith("result-3-")
+
+    @pytest.mark.asyncio
+    async def test_only_listed_tools_are_windowed(self, tmp_path):
+        config = ToolResultWindowProcessorConfig(tool_names=["grep"], keep_last_k=1)
+        context, _ = await build_context(str(tmp_path), config)
+
+        msgs: List = [UserMessage(content="mixed")]
+        msgs += tool_round("g0", "grep", "grep-old-" + "x" * 100)
+        msgs += tool_round("r0", "read_file", "read-" + "x" * 100)
+        msgs += tool_round("g1", "grep", "grep-new-" + "x" * 100)
+        await context.add_messages(msgs)
+
+        result = context.get_messages()
+        by_name = {}
+        for m in result:
+            if isinstance(m, ToolMessage):
+                by_name.setdefault(m.name, []).append(m)
+
+        # read_file is not in tool_names -> untouched.
+        assert len(by_name["read_file"]) == 1
+        assert not isinstance(by_name["read_file"][0], OffloadToolMessage)
+        # grep window (k=1): oldest offloaded, newest kept.
+        assert isinstance(by_name["grep"][0], OffloadToolMessage)
+        assert not isinstance(by_name["grep"][1], OffloadToolMessage)
+
+    @pytest.mark.asyncio
+    async def test_no_offload_when_within_window(self, tmp_path):
+        config = ToolResultWindowProcessorConfig(tool_names=["grep"], keep_last_k=3)
+        context, mock_fs = await build_context(str(tmp_path), config)
+
+        msgs: List = [UserMessage(content="search")]
+        for i in range(2):
+            msgs += tool_round(f"tc-{i}", "grep", f"result-{i}-" + "x" * 100)
+        await context.add_messages(msgs)
+
+        result = context.get_messages()
+        grep_results = [m for m in result if isinstance(m, ToolMessage)]
+        assert all(not isinstance(m, OffloadToolMessage) for m in grep_results)
+        mock_fs.write_file.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_incremental_add_offloads_one_per_new_result(self, tmp_path):
+        config = ToolResultWindowProcessorConfig(tool_names=["grep"], keep_last_k=2)
+        context, _ = await build_context(str(tmp_path), config)
+
+        await context.add_messages([UserMessage(content="start")])
+        # First two: within window, nothing offloaded.
+        await context.add_messages(tool_round("tc-0", "grep", "r0-" + "x" * 100))
+        await context.add_messages(tool_round("tc-1", "grep", "r1-" + "x" * 100))
+        offloaded = [m for m in context.get_messages() if isinstance(m, OffloadToolMessage)]
+        assert len(offloaded) == 0
+
+        # Third result pushes the oldest (r0) out of the window.
+        await context.add_messages(tool_round("tc-2", "grep", "r2-" + "x" * 100))
+        result = context.get_messages()
+        grep_results = [m for m in result if isinstance(m, ToolMessage)]
+        assert isinstance(grep_results[0], OffloadToolMessage)
+        assert not isinstance(grep_results[1], OffloadToolMessage)
+        assert not isinstance(grep_results[2], OffloadToolMessage)
+
+    @pytest.mark.asyncio
+    async def test_empty_tool_names_is_noop(self, tmp_path):
+        config = ToolResultWindowProcessorConfig(tool_names=[], keep_last_k=1)
+        context, mock_fs = await build_context(str(tmp_path), config)
+
+        msgs: List = [UserMessage(content="search")]
+        for i in range(4):
+            msgs += tool_round(f"tc-{i}", "grep", f"result-{i}-" + "x" * 100)
+        await context.add_messages(msgs)
+
+        result = context.get_messages()
+        assert all(not isinstance(m, OffloadToolMessage) for m in result)
+        mock_fs.write_file.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_streams_state_when_processor_triggers(self):
+        session = Session(session_id="tool-result-window-stream-session")
+        engine = ContextEngine(ContextEngineConfig(default_window_message_num=100))
+        context = await engine.create_context(
+            context_id="test_ctx",
+            session=session,
+            history_messages=[],
+            processors=[
+                (
+                    "ToolResultWindowProcessor",
+                    ToolResultWindowProcessorConfig(tool_names=["grep"], keep_last_k=1),
+                )
+            ],
+        )
+
+        _, states = await capture_context_compression_states(
+            session,
+            lambda: context.add_messages(
+                [
+                    UserMessage(content="Run grep"),
+                    *tool_round("tc-0", "grep", "r0-" + "x" * 100),
+                    *tool_round("tc-1", "grep", "r1-" + "x" * 100),
+                    AssistantMessage(content="done"),
+                ]
+            ),
+        )
+
+        assert_context_state_pair(states, processor_type="ToolResultWindowProcessor")
+        # k=1 with two grep results -> the oldest one is offloaded.
+        assert "modified 1 messages" in states[1].summary
+
+
+class TestToolResultWindowProcessorConfig:
+    def test_default_config_values(self):
+        config = ToolResultWindowProcessorConfig()
+        assert config.tool_names == []
+        assert config.keep_last_k == 3
+        assert config.trim_size == 3000
+        assert config.offload_file_prefix == "ToolResultWindowProcessor"
+
+    def test_non_positive_window_and_trim_are_rejected(self):
+        # keep_last_k / trim_size declare gt=0; guard that constraint.
+        with pytest.raises(ValidationError):
+            ToolResultWindowProcessorConfig(tool_names=["grep"], keep_last_k=0)
+        with pytest.raises(ValidationError):
+            ToolResultWindowProcessorConfig(tool_names=["grep"], trim_size=0)

--- a/tests/unit_tests/core/context_engine/test_tool_result_window_processor.py
+++ b/tests/unit_tests/core/context_engine/test_tool_result_window_processor.py
@@ -173,6 +173,29 @@ class TestToolResultWindowProcessor:
         assert not isinstance(grep_results[2], OffloadToolMessage)
 
     @pytest.mark.asyncio
+    async def test_second_round_skips_already_offloaded(self, tmp_path):
+        # An already-offloaded result stays in the window count but must not be
+        # re-offloaded on the next round (only the newly-outside one is).
+        config = ToolResultWindowProcessorConfig(tool_names=["grep"], keep_last_k=2)
+        context, mock_fs = await build_context(str(tmp_path), config)
+
+        await context.add_messages([UserMessage(content="start")])
+        for i in range(3):
+            await context.add_messages(tool_round(f"tc-{i}", "grep", f"r{i}-" + "x" * 100))
+        # Round 1 offloaded r0.
+        offloaded_r0 = context.get_messages()[2]
+        assert isinstance(offloaded_r0, OffloadToolMessage)
+        r0_content = offloaded_r0.content
+        assert mock_fs.write_file.call_count == 1
+
+        # Round 2: r3 arrives -> r1 offloaded, r0 skipped (not re-processed).
+        await context.add_messages(tool_round("tc-3", "grep", "r3-" + "x" * 100))
+        grep_results = [m for m in context.get_messages() if isinstance(m, ToolMessage)]
+        assert [isinstance(m, OffloadToolMessage) for m in grep_results] == [True, True, False, False]
+        assert grep_results[0].content == r0_content  # r0 untouched
+        assert mock_fs.write_file.call_count == 2  # only r1 written this round
+
+    @pytest.mark.asyncio
     async def test_empty_tool_names_is_noop(self, tmp_path):
         config = ToolResultWindowProcessorConfig(tool_names=[], keep_last_k=1)
         context, mock_fs = await build_context(str(tmp_path), config)

--- a/tests/unit_tests/harness/tools/browser_move/test_create_browser_agent.py
+++ b/tests/unit_tests/harness/tools/browser_move/test_create_browser_agent.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 
 from openjiuwen.core.foundation.llm.model import Model
 from openjiuwen.core.foundation.tool import McpServerConfig
+from openjiuwen.harness.rails.context_engineer import ContextProcessorRail
 from openjiuwen.harness.schema.config import SubAgentConfig
 from openjiuwen.harness.subagents.browser_agent import (
     BROWSER_AGENT_FACTORY_NAME,
@@ -136,6 +137,41 @@ def test_default_wiring_main_agent_has_browser_runtime_rail() -> None:
 
     rails = calls[0].get("rails", [])
     assert any(isinstance(rail, BrowserRuntimeRail) for rail in rails)
+
+
+def test_default_wiring_windows_browser_probe_and_snapshot_results() -> None:
+    calls, fake = _capture_create_deep_agent()
+    with _patch_all(fake)[0]:
+        create_browser_agent(_fake_model(), settings=_fake_settings())
+
+    rails = calls[0].get("rails", [])
+    context_rails = [rail for rail in rails if isinstance(rail, ContextProcessorRail)]
+    assert len(context_rails) == 1
+
+    processors = context_rails[0]._user_processors
+    assert len(processors) == 1
+    key, config = processors[0]
+    assert key == "ToolResultWindowProcessor"
+    # Pin the intended contract literally (not against the source constant) so a
+    # regression like the plain "browser_snapshot" name is actually caught.
+    assert config.tool_names == [
+        "browser_probe_interactives",
+        "browser_probe_cards",
+        "mcp_playwright-official_browser_snapshot",
+    ]
+    assert config.keep_last_k == 1
+
+
+def test_caller_context_processor_rail_suppresses_injection() -> None:
+    calls, fake = _capture_create_deep_agent()
+    caller_rail = ContextProcessorRail(preset=False)
+    with _patch_all(fake)[0]:
+        create_browser_agent(_fake_model(), settings=_fake_settings(), rails=[caller_rail])
+
+    rails = calls[0].get("rails", [])
+    context_rails = [rail for rail in rails if isinstance(rail, ContextProcessorRail)]
+    # Only the caller's rail is present; the browser agent does not add its own.
+    assert context_rails == [caller_rail]
 
 
 def test_default_wiring_does_not_add_sys_operation_rail() -> None:

--- a/tests/unit_tests/harness/tools/browser_move/test_create_browser_agent.py
+++ b/tests/unit_tests/harness/tools/browser_move/test_create_browser_agent.py
@@ -157,7 +157,7 @@ def test_default_wiring_windows_browser_probe_and_snapshot_results() -> None:
     assert config.tool_names == [
         "browser_probe_interactives",
         "browser_probe_cards",
-        "mcp_playwright-official_browser_snapshot",
+        "browser_snapshot",
     ]
     assert config.keep_last_k == 1
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openJiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
Choose one label from `bug`, `task`, `feature` and `refactor`, and replace `<label>` below the comment block. 

If this pr is not only bugfix/task/feature and also a refactor, you can append `/kind refactor` label after `/kind bug`, `/kind task` and `/kind feature`.
-->
/kind feature


**What does this PR do / why do we need it**:
* Need to describe clearly

## Background

Webpage snapshots (`browser_probe_interactives`, `browser_probe_cards`, etc.) occupy a large number of context windows, slowing down the application.

## Solution

Create a `ToolResultWindowProcessor` that only retains the last window for tool results that consume large tokens.

Example:

``` window_size=1

[tool] [persisted(large result)] | [tool] [result] | [tool] [persisted(large result)] | [tool] [result] | [tool] [persisted(large result)] | [tool] [result] | [tool] [large result]

```

`large result` refers to tool call results that occupy a large number of context windows but do not contribute to agent 

## Scope of Impact

- Add `tool_result_window_processor.py`.

- Link `ContextProcessorRail` in `browser_agent.py`.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #12


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：
* Need to describe clearly


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->
