### PR TITLE
fix:修QA压缩机制的首尾压缩行为，导致有效信息丢失问题

### DIFF
--- a/openjiuwen/core/context_engine/qa_block/config.py
+++ b/openjiuwen/core/context_engine/qa_block/config.py
@@ -11,8 +11,10 @@ from pydantic import BaseModel, Field
 class QABlockConfig(BaseModel):
     enabled: bool = True
     l1_inline_max_chars: int = Field(default=500, gt=0)
-    l1_summary_max_chars: int = Field(default=300, gt=0)
+    l1_summary_max_chars: int = Field(default=800, gt=0)
     l1_llm_min_chars: int = Field(default=1500, gt=0)
+    l1_corpus_per_tool_max_chars: int = Field(default=600, gt=0)
+    l1_corpus_max_tool_results: int = Field(default=12, gt=0)
     history_qa_buffer_size: int = Field(default=3, gt=0)
     async_freeze_persist: bool = True
     freeze_overview_await_s: float = Field(

--- a/openjiuwen/core/context_engine/qa_block/freezer.py
+++ b/openjiuwen/core/context_engine/qa_block/freezer.py
@@ -16,6 +16,7 @@ from openjiuwen.core.context_engine.qa_block.config import QABlockConfig
 from openjiuwen.core.context_engine.qa_block.freezer_lifecycle import register_qa_block_freezer
 from openjiuwen.core.context_engine.qa_block.history_buffer import HistoryQABuffer
 from openjiuwen.core.context_engine.qa_block.messages import (
+    build_compaction_corpus,
     estimate_messages_tokens,
     extract_final_answer,
     extract_qa_native_messages,
@@ -174,10 +175,16 @@ class QABlockFreezer:
 
         user_query = extract_user_query(native_messages)
         final_answer = extract_final_answer(native_messages)
+        corpus = build_compaction_corpus(
+            native_messages,
+            per_tool_max_chars=self._config.l1_corpus_per_tool_max_chars,
+            max_tool_results=self._config.l1_corpus_max_tool_results,
+        )
         l1_text, l1_source = await self._summarizer.generate_l1(
             user_query,
             final_answer,
             allow_llm=False,
+            corpus=corpus,
         )
         had_compact = had_full_compact_in_messages(native_messages)
         l0_mode: Literal["delta", "compact_summary_tail"] = "compact_summary_tail" if had_compact else "delta"
@@ -259,12 +266,18 @@ class QABlockFreezer:
             )
             user_query = extract_user_query(native_messages)
             final_answer = extract_final_answer(native_messages)
+            corpus = build_compaction_corpus(
+                native_messages,
+                per_tool_max_chars=self._config.l1_corpus_per_tool_max_chars,
+                max_tool_results=self._config.l1_corpus_max_tool_results,
+            )
             prior_l1 = entry.l1_text
             l1_text, l1_source = await self._summarizer.generate_l1(
                 user_query,
                 final_answer,
                 model=summarizer_model,
                 allow_llm=True,
+                corpus=corpus,
             )
 
             entry.l0_store = L0Store(path=rel_path, handle=entry.qa_id)

--- a/openjiuwen/core/context_engine/qa_block/messages.py
+++ b/openjiuwen/core/context_engine/qa_block/messages.py
@@ -12,7 +12,7 @@ from openjiuwen.core.context_engine.qa_block.schema import (
     QA_ID_METADATA_KEY,
     SOURCE_QA_ID_METADATA_KEY,
 )
-from openjiuwen.core.foundation.llm import AssistantMessage, BaseMessage, SystemMessage, UserMessage
+from openjiuwen.core.foundation.llm import AssistantMessage, BaseMessage, SystemMessage, ToolMessage, UserMessage
 
 if TYPE_CHECKING:
     from openjiuwen.core.context_engine.base import ModelContext
@@ -89,6 +89,61 @@ def extract_final_answer(messages: list[BaseMessage]) -> str:
         if text:
             return text
     return ""
+
+
+def _tool_call_brief(message: BaseMessage) -> str:
+    """One-line brief of an assistant tool-call: 'tool_name(arg_excerpt)'."""
+    tool_calls = getattr(message, "tool_calls", None) or []
+    parts: list[str] = []
+    for tc in tool_calls:
+        name = getattr(tc, "name", "") or ""
+        args = getattr(tc, "arguments", "") or ""
+        if isinstance(args, str) and len(args) > 120:
+            args = args[:120] + "…"
+        parts.append(f"{name}({args})")
+    return "; ".join(parts)
+
+
+def build_compaction_corpus(
+    messages: list[BaseMessage],
+    *,
+    per_tool_max_chars: int = 600,
+    max_tool_results: int = 12,
+) -> str:
+    """Build a corpus string for L1 summarization.
+
+    Unlike extract_user_query + extract_final_answer (首尾两端 only), this
+    includes one-line briefs of every tool_call and truncated tool_result
+    bodies, so parallel sub-task outputs (e.g. multi-bank deep research) are
+    not silently dropped from the compaction summary.
+    """
+    user_query = extract_user_query(messages)
+    final_answer = extract_final_answer(messages)
+    chunks: list[str] = [f"Q: {user_query}", f"A: {final_answer}"]
+
+    tool_results_seen = 0
+    for message in messages:
+        # assistant tool calls -> brief
+        if isinstance(message, AssistantMessage):
+            tool_calls = getattr(message, "tool_calls", None)
+            if tool_calls:
+                brief = _tool_call_brief(message)
+                if brief:
+                    chunks.append(f"[tool_call] {brief}")
+                continue
+        # tool results -> truncated body
+        if isinstance(message, ToolMessage):
+            if tool_results_seen >= max_tool_results:
+                continue
+            text = _message_text(message).strip()
+            if not text:
+                continue
+            if len(text) > per_tool_max_chars:
+                text = text[:per_tool_max_chars] + "…"
+            chunks.append(f"[tool_result] {text}")
+            tool_results_seen += 1
+
+    return "\n".join(chunks)
 
 
 def message_id_range(messages: list[BaseMessage]) -> tuple[str, str] | None:

--- a/openjiuwen/core/context_engine/qa_block/summarizer.py
+++ b/openjiuwen/core/context_engine/qa_block/summarizer.py
@@ -10,9 +10,11 @@ from openjiuwen.core.context_engine.qa_block.config import QABlockConfig
 from openjiuwen.core.foundation.llm import Model, ModelClientConfig, ModelRequestConfig, UserMessage
 
 _L1_SUMMARY_PROMPT = (
-    "将以下单次问答（Q+A）压缩为不超过 {max_chars} 字的目录摘要，"
-    "保留用户诉求与最终结论要点。只输出摘要正文，格式：\n"
-    "Q: ...\nA: ...\n\n"
+    "将以下本轮完整语料压缩为不超过 {max_chars} 字的目录摘要。"
+    "必须覆盖：用户诉求、每一个 [tool_call] 的工具名与核心参数、"
+    "每一个 [tool_result] 的关键结论（尤其是并行子任务的各自产出），"
+    "以及最终结论要点。不得只复述末尾 A: 而遗漏中间工具产出。"
+    "只输出摘要正文，格式：\nQ: ...\n[工具与产出要点]: ...\nA: ...\n\n"
     "待压缩内容：\n{text}"
 )
 
@@ -39,6 +41,7 @@ class QABlockSummarizer:
         *,
         model: Any | None = None,
         allow_llm: bool = True,
+        corpus: str | None = None,
     ) -> tuple[str, Literal["inline", "compressed"]]:
         """Generate L1 catalog line from Q+A.
 
@@ -50,9 +53,10 @@ class QABlockSummarizer:
         user_query = (user_query or "").strip()
         final_answer = (final_answer or "").strip()
         inline_text = f"Q: {user_query}\nA: {final_answer}".strip()
-        combined_len = len(user_query) + len(final_answer)
+        source_text = corpus or inline_text
+        combined_len = len(source_text)
 
-        if combined_len <= self._config.l1_inline_max_chars:
+        if combined_len <= self._config.l1_inline_max_chars and corpus is None:
             logger.info(
                 "[QABlockSummarizer] inline L1 chars=%s allow_llm=%s",
                 len(inline_text),
@@ -61,10 +65,10 @@ class QABlockSummarizer:
             return inline_text, "inline"
 
         if not allow_llm or combined_len < self._config.l1_llm_min_chars:
-            summary = self._truncate_summary(inline_text)
+            summary = self._truncate_summary(source_text)
             logger.info(
                 "[QABlockSummarizer] truncated L1 source_chars=%s summary_chars=%s allow_llm=%s",
-                len(inline_text),
+                len(source_text),
                 len(summary),
                 allow_llm,
             )
@@ -74,26 +78,26 @@ class QABlockSummarizer:
         if llm_model is None:
             logger.warning(
                 "[QABlockSummarizer] llm unavailable, fallback truncated source_chars=%s",
-                len(inline_text),
+                len(source_text),
             )
         else:
-            summary = await self._summarize_with_llm(inline_text, llm_model)
+            summary = await self._summarize_with_llm(source_text, llm_model)
             if summary:
                 logger.info(
                     "[QABlockSummarizer] llm L1 source_chars=%s summary_chars=%s",
-                    len(inline_text),
+                    len(source_text),
                     len(summary),
                 )
                 return summary, "compressed"
             logger.warning(
                 "[QABlockSummarizer] llm empty response, fallback truncated source_chars=%s",
-                len(inline_text),
+                len(source_text),
             )
 
-        summary = self._truncate_summary(inline_text)
+        summary = self._truncate_summary(source_text)
         logger.info(
             "[QABlockSummarizer] fallback truncated L1 source_chars=%s summary_chars=%s",
-            len(inline_text),
+            len(source_text),
             len(summary),
         )
         return summary, "compressed"
@@ -106,11 +110,12 @@ class QABlockSummarizer:
         return summary
 
     async def _summarize_with_llm(self, inline_text: str, model: Any) -> str:
-        prompt = _L1_SUMMARY_PROMPT.format(
-            max_chars=self._config.l1_summary_max_chars,
-            text=inline_text[:8000],
-        )
         try:
+            cap = max(8000, self._config.l1_summary_max_chars * 4)
+            prompt = _L1_SUMMARY_PROMPT.format(
+                max_chars=self._config.l1_summary_max_chars,
+                text=inline_text[:cap],
+            )
             invoke = getattr(model, "invoke", None)
             if not callable(invoke):
                 return ""

--- a/openjiuwen/harness/prompts/sections/todo.py
+++ b/openjiuwen/harness/prompts/sections/todo.py
@@ -30,6 +30,9 @@ Identify the planning need and call todo_create BEFORE starting execution.
 **When NOT to use todo tools — do not call todo_create, todo_modify, or todo_list when:**
 - User only wants a task list displayed and explicitly says no execution is needed now (e.g. list only, do not execute, not yet) → present the list in your reply as text or a table; do not call any todo tools
 
+**No echo rule:**
+ - When starting a task, give a brief one-sentence summary of what you will do — never copy the full task description verbatim
+
 **Task management rules:**
 - Update status in real-time: call todo_modify the moment a task status changes
 - Only one task can be in_progress at a time; complete it before starting the next
@@ -70,6 +73,9 @@ TODO_SYSTEM_PROMPT_CN = """
 
 **何时不使用 todo 工具 — 以下情况不要调用 todo_create、todo_modify、todo_list：**
 - 用户仅要求列出/展示任务清单，且明确表示不需要执行、暂不执行、先不要做等 → 直接在回复中以文本或表格呈现清单，勿调用 todo 工具
+
+**禁止回显规则：**
+- 开始执行任务时，用一句简短的话概括你要做什么即可，不要把完整任务描述复述一遍。
 
 **任务管理规则：**
 - 实时更新状态：任务状态变化时立即调用 todo_modify


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/community/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openjiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
选择下面一种标签替换下方 `/kind <label>`，可选标签类型有：
- /kind bug 
- /kind task
- /kind feature
- /kind refactor
- /kind clean_code
如PR描述不符合规范，修改PR描述后需要/check-pr重新检查PR规范。
-->
/kind bug

  ### 修复前
  inline_text = f"Q: {user_query}\nA: {final_answer}".strip()
  source_text = inline_text  # 只有首尾两端

  L1 摘要只拿 extract_user_query（首个 UserMessage）+ extract_final_answer（最后一条无 tool_calls 的
  AssistantMessage）拼接。中间所有 tool_call / tool_result 消息完全不可见。
  对于有复杂工具链的 QA（如多银行深度研究、并行子任务），L1 摘要会丢失全部中间产出信息。
  ### 修复
  修复引入 build_compaction_corpus()，构建完整语料：
  Q: {user_query}
  A: {final_answer}
  [tool_call] tool_name(arg_excerpt)      ← 新增
  [tool_result] truncated_tool_body        ← 新增
  
  - L1 摘要现在能覆盖全部中间工具调用和产出
  - LLM prompt 也更新了，明确要求"不得只复述末尾 A 而遗漏中间工具产出"
  - l1_summary_max_chars 从 300 提升到 800，给摘要更多空间容纳工具信息

**Self-checklist**:（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

+ - [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
+ - [ ] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
+ - [ ] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
+ - [ ] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
+ - [ ] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] 是否导致无法前向兼容 -->
<!-- + - [ ] 是否涉及依赖的三方库变更 -->