### PR TITLE
fix(react_agent): 超上限重试机制调整output tokens

### DIFF
--- a/openjiuwen/core/single_agent/agents/react_agent.py
+++ b/openjiuwen/core/single_agent/agents/react_agent.py
@@ -1449,6 +1449,39 @@ class ReActAgent(BaseAgent):
         ctx.extra[RESUME_START_ITERATION_KEY] = resume_iteration + 1
         return None
 
+    async def _inject_truncation_notice(
+        self,
+        ai_message: AssistantMessage,
+        context: ModelContext,
+        ctx: AgentCallbackContext,
+    ) -> None:
+        """Inject the truncated AssistantMessage and a TRUNCATION_NOTICE
+        UserMessage into context so the model knows its previous response
+        was truncated and can adjust accordingly."""
+        await context.add_messages(
+            AssistantMessage(
+                content=ai_message.content or "",
+                tool_calls=ai_message.tool_calls,
+                reasoning_content=getattr(ai_message, "reasoning_content", None),
+                usage_metadata=ai_message.usage_metadata,
+                finish_reason=ai_message.finish_reason,
+            ),
+            system_messages=ctx.extra.get("_active_system_messages") or [],
+            tools=ctx.extra.get("_active_tools") or [],
+        )
+        await context.add_messages(
+            UserMessage(
+                content=(
+                    "[TRUNCATION_NOTICE] Your previous response was "
+                    "truncated due to output length limits. Please "
+                    "continue from where you left off, or provide a "
+                    "more concise response."
+                ),
+            ),
+            system_messages=ctx.extra.get("_active_system_messages") or [],
+            tools=ctx.extra.get("_active_tools") or [],
+        )
+
     def _extract_user_text(self, user_input: Any) -> str:
         """Extract plain text from user_input (supports InteractiveInput or str)."""
         from openjiuwen.core.session import InteractiveInput
@@ -1755,7 +1788,8 @@ class ReActAgent(BaseAgent):
                                     getattr(ai_message.usage_metadata, "output_tokens", 16384)
                                     or 16384
                                 )
-                                ctx.extra["_max_tokens_override"] = _truncated_output_tokens * 2
+                                ctx.extra["_max_tokens_override"] = _truncated_output_tokens
+                                await self._inject_truncation_notice(ai_message, context, ctx)
                                 ai_message = await self._call_model(
                                     ctx,
                                     context,
@@ -1786,29 +1820,7 @@ class ReActAgent(BaseAgent):
                                     _session_id,
                                     iteration + 1,
                                 )
-                                await context.add_messages(
-                                    AssistantMessage(
-                                        content=ai_message.content or "",
-                                        tool_calls=ai_message.tool_calls,
-                                        reasoning_content=getattr(ai_message, "reasoning_content", None),
-                                        usage_metadata=ai_message.usage_metadata,
-                                        finish_reason=ai_message.finish_reason,
-                                    ),
-                                    system_messages=ctx.extra.get("_active_system_messages") or [],
-                                    tools=ctx.extra.get("_active_tools") or [],
-                                )
-                                await context.add_messages(
-                                    UserMessage(
-                                        content=(
-                                            "[TRUNCATION_NOTICE] Your previous response was "
-                                            "truncated due to output length limits. Please "
-                                            "continue from where you left off, or provide a "
-                                            "more concise response."
-                                        ),
-                                    ),
-                                    system_messages=ctx.extra.get("_active_system_messages") or [],
-                                    tools=ctx.extra.get("_active_tools") or [],
-                                )
+                                await self._inject_truncation_notice(ai_message, context, ctx)
                                 await session.write_stream(OutputSchema(
                                     type="truncation_retry",
                                     index=0,

--- a/tests/unit_tests/agent/react_agent/test_react_agent_truncation.py
+++ b/tests/unit_tests/agent/react_agent/test_react_agent_truncation.py
@@ -344,8 +344,10 @@ class TestTruncationRetryIntegration(unittest.IsolatedAsyncioTestCase):
         assert truncation_frames[0].payload["truncated_content"] == "Truncated partial..."
         assert truncation_frames[0].payload["phase"] == "retry_attempt"
 
-    async def test_truncation_retry_doubles_output_tokens(self):
-        """_max_tokens_override should equal output_tokens * 2 during retry."""
+    async def test_truncation_retry_uses_output_tokens(self):
+        """Retry max_tokens should equal the truncated output_tokens,
+        not output_tokens*2, preventing BadRequest on models with
+        a max_tokens ceiling (e.g. deepseek-v3.2 max 32768)."""
         truncated_msg = AssistantMessage(
             content="Truncated...",
             finish_reason="length",
@@ -379,7 +381,69 @@ class TestTruncationRetryIntegration(unittest.IsolatedAsyncioTestCase):
 
         assert mock_llm.call_count == 2
         retry_kwargs = captured_kwargs[1]
-        assert retry_kwargs.get("max_tokens") == 10000
+        assert retry_kwargs.get("max_tokens") == 5000
+
+    async def test_truncation_retry_injects_failure_reason_into_context(self):
+        """Before retry, _inject_truncation_notice is called so the
+        truncated AssistantMessage and TRUNCATION_NOTICE UserMessage
+        are added to context, giving the model context about why it failed."""
+        truncated_msg = AssistantMessage(
+            content="Truncated partial output...",
+            finish_reason="length",
+            usage_metadata=UsageMetadata(
+                model_name="mock-model",
+                output_tokens=5000,
+            ),
+        )
+        successful_msg = AssistantMessage(
+            content="Complete response after retry",
+            finish_reason="stop",
+        )
+
+        mock_llm = MockLLMModel()
+        mock_llm.set_responses([truncated_msg, successful_msg])
+
+        add_messages_calls = []
+        self.mock_context.add_messages = AsyncMock(
+            side_effect=lambda msg, **kw: add_messages_calls.append((msg, kw)),
+        )
+
+        with patch.object(self.agent, "_get_llm", return_value=mock_llm):
+            await self.agent.invoke(
+                {"query": "long story"},
+                session=self.mock_session,
+            )
+
+        from openjiuwen.core.foundation.llm import UserMessage
+
+        truncation_assistant_calls = [
+            (msg, kw) for msg, kw in add_messages_calls
+            if isinstance(msg, AssistantMessage)
+            and msg.finish_reason == "length"
+            and msg.content == "Truncated partial output..."
+        ]
+        assert len(truncation_assistant_calls) >= 1, \
+            "Truncated AssistantMessage must be injected before retry"
+
+        truncation_notice_calls = [
+            (msg, kw) for msg, kw in add_messages_calls
+            if isinstance(msg, UserMessage)
+            and "[TRUNCATION_NOTICE]" in (msg.content or "")
+        ]
+        assert len(truncation_notice_calls) >= 1, \
+            "TRUNCATION_NOTICE UserMessage must be injected before retry"
+
+        assistant_idx = None
+        notice_idx = None
+        for i, (msg, kw) in enumerate(add_messages_calls):
+            if isinstance(msg, AssistantMessage) and msg.finish_reason == "length" and msg.content == "Truncated partial output...":
+                assistant_idx = i
+            if isinstance(msg, UserMessage) and "[TRUNCATION_NOTICE]" in (msg.content or ""):
+                notice_idx = i
+
+        assert assistant_idx is not None and notice_idx is not None
+        assert notice_idx == assistant_idx + 1, \
+            "TRUNCATION_NOTICE must immediately follow truncated AssistantMessage"
 
     async def test_truncation_retry_count_limited_to_one(self):
         """Only one retry attempt is allowed (_truncation_retry_count < 1).
@@ -634,7 +698,7 @@ class TestTruncationRetryIntegration(unittest.IsolatedAsyncioTestCase):
 
     async def test_truncated_output_tokens_fallback_when_usage_metadata_missing(self):
         """When usage_metadata is missing, _max_tokens_override falls back
-        to 16384 * 2 = 32768."""
+        to the default output_tokens value (16384), not 16384*2."""
         truncated_msg = AssistantMessage(
             content="Truncated without metadata...",
             finish_reason="length",
@@ -664,4 +728,4 @@ class TestTruncationRetryIntegration(unittest.IsolatedAsyncioTestCase):
 
         assert mock_llm.call_count == 2
         retry_kwargs = captured_kwargs[1]
-        assert retry_kwargs.get("max_tokens") == 32768
+        assert retry_kwargs.get("max_tokens") == 16384


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/community/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openjiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
选择下面一种标签替换下方 `/kind <label>`，可选标签类型有：
- /kind bug 
- /kind task
- /kind feature
- /kind refactor
- /kind clean_code
如PR描述不符合规范，修改PR描述后需要/check-pr重新检查PR规范。
-->
/kind <label>


**Self-checklist**:（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

+ - [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
+ - [ ] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
+ - [ ] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
+ - [ ] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
+ - [ ] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] 是否导致无法前向兼容 -->
<!-- + - [ ] 是否涉及依赖的三方库变更 -->
## 现象
  ![image.png](https://raw.gitcode.com/user-images/assets/8766961/fa1281ce-22ee-4692-ab3b-86062d0a976d/image.png 'image.png')
  
## 根因
  原来模型输出超上限截断的重试机制中，output token*2重试太粗暴，超过模型output token上限了
 
## 解决方法
  调整重试时output token值，当前各种截断情况时output_tokens值如下
  
 | 条件|	含义	|重试max_tokens|
  |  ----  | ----  |  ----  |
|max_tokens 未配置|	模型上限截断	|output_tokens
|output_tokens < max_tokens	|模型上限截断|	output_tokens
|output_tokens == max_tokens|	不确定（配置限制or模型上限）|	output_tokens（保守，不*2）