### PR TITLE
fix(agent_evolving): validate skill package install paths

### DIFF
--- a/openjiuwen/agent_evolving/checkpointing/evolution_store.py
+++ b/openjiuwen/agent_evolving/checkpointing/evolution_store.py
@@ -31,6 +31,7 @@ from openjiuwen.core.sys_operation import SysOperation
 
 _EVOLUTION_FILENAME = "evolutions.json"
 _TOTAL_WARNING_THRESHOLD = 30
+_SKILL_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 _EVOLUTION_INDEX_PATTERN = re.compile(
     r"<!-- evolution-index-start -->.*?<!-- evolution-index-end -->",
     re.DOTALL,
@@ -231,6 +232,9 @@ class EvolutionStore:
             if not resolved_name:
                 logger.warning("[EvolutionStore] install_skill_package: cannot infer skill name")
                 return None
+            if _SKILL_NAME_PATTERN.fullmatch(resolved_name) is None:
+                logger.warning("[EvolutionStore] install_skill_package: rejected unsafe skill name")
+                return None
 
             dest_dir = self.resolve_skill_dir(resolved_name, create=True)
             if dest_dir is None:
@@ -254,6 +258,8 @@ class EvolutionStore:
         subject_kind: Optional[str] = None,
     ) -> Optional[Path]:
         candidates = [base / name for base in self._base_dirs]
+        if create:
+            candidates = [candidate for candidate in candidates if self._is_safe_skill_destination(candidate)]
         if subject_kind is not None:
             normalized_kind = self._normalize_subject_kind(subject_kind)
             for candidate in candidates:
@@ -268,9 +274,17 @@ class EvolutionStore:
         for candidate in candidates:
             if candidate.is_dir():
                 return candidate
-        if create and self._base_dirs:
-            return self._base_dirs[0] / name
+        if create and candidates:
+            return candidates[0]
         return None
+
+    def _is_safe_skill_destination(self, path: Path) -> bool:
+        """Return whether *path* resolves to a strict child of a configured base directory."""
+        try:
+            resolved = path.expanduser().resolve()
+        except (OSError, RuntimeError):
+            return False
+        return any(resolved != base_dir and resolved.is_relative_to(base_dir) for base_dir in self._base_dirs)
 
     def resolve_subject_payload(self, name: str) -> Optional[dict[str, str]]:
         """Resolve a skill-like subject from its on-disk definition."""

--- a/tests/unit_tests/agent_evolving/checkpointing/test_evolution_store.py
+++ b/tests/unit_tests/agent_evolving/checkpointing/test_evolution_store.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from openjiuwen.agent_evolving.checkpointing import EvolutionStore
+from openjiuwen.agent_evolving.checkpointing.skill_package import pack_skill_directory
 from openjiuwen.agent_evolving.checkpointing.store_records import MergeRecordsRequest, StoreRecordsHelper
 from openjiuwen.agent_evolving.checkpointing.types import (
     EvolutionLog,
@@ -75,6 +76,21 @@ def write_invalid_evolution_log(
 
 def assert_no_files(path: Path, pattern: str = "*") -> None:
     assert not path.exists() or not any(path.glob(pattern))
+
+
+def make_skill_package(tmp_path: Path) -> bytes:
+    source_dir = prepare_skill(tmp_path / "package-source", "source-skill")
+    return pack_skill_directory(source_dir)
+
+
+def make_named_member_package(member_name: str) -> bytes:
+    payload = b"# Skill\n"
+    member = tarfile.TarInfo(name=member_name)
+    member.size = len(payload)
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        archive.addfile(member, io.BytesIO(payload))
+    return buffer.getvalue()
 
 
 class TestEvolutionStoreBasics:
@@ -923,6 +939,90 @@ class TestPackSkillForSharing:
         assert "evolution-index-end" not in packed_skill_md
         assert "Experience Index" not in packed_skill_md
         assert "# Skill A" in packed_skill_md
+
+
+class TestInstallSkillPackage:
+    @staticmethod
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "unsafe_name",
+        [
+            "../outside",
+            "nested/name",
+            r"nested\name",
+            ".",
+            "..",
+            "skill.name",
+            "skill name",
+        ],
+    )
+    async def test_rejects_unsafe_explicit_name(tmp_path: Path, unsafe_name: str):
+        root = tmp_path / "skills"
+        store = EvolutionStore(str(root))
+
+        installed = await store.install_skill_package(
+            make_skill_package(tmp_path),
+            skill_name=unsafe_name,
+        )
+
+        assert installed is None
+        assert_no_files(root)
+        assert not (tmp_path / "outside").exists()
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_rejects_absolute_explicit_name(tmp_path: Path):
+        root = tmp_path / "skills"
+        outside = tmp_path / "absolute-target"
+        store = EvolutionStore(str(root))
+
+        installed = await store.install_skill_package(
+            make_skill_package(tmp_path),
+            skill_name=str(outside),
+        )
+
+        assert installed is None
+        assert_no_files(root)
+        assert not outside.exists()
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_rejects_unsafe_inferred_name(tmp_path: Path):
+        root = tmp_path / "skills"
+        store = EvolutionStore(str(root))
+
+        installed = await store.install_skill_package(make_named_member_package("./SKILL.md"))
+
+        assert installed is None
+        assert_no_files(root)
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_rejects_symlinked_destination_outside_root(tmp_path: Path):
+        root = tmp_path / "skills"
+        outside = tmp_path / "outside"
+        root.mkdir()
+        outside.mkdir()
+        try:
+            (root / "linked-skill").symlink_to(outside, target_is_directory=True)
+        except (NotImplementedError, OSError):
+            pytest.skip("directory symlinks are unavailable")
+        store = EvolutionStore(str(root))
+
+        installed = await store.install_skill_package(
+            make_skill_package(tmp_path),
+            skill_name="linked-skill",
+        )
+
+        assert installed is None
+        assert_no_files(outside)
+
+    @staticmethod
+    def test_create_resolution_rejects_path_outside_root(tmp_path: Path):
+        root = tmp_path / "skills"
+        store = EvolutionStore(str(root))
+
+        assert store.resolve_skill_dir("../outside", create=True) is None
 
 
 class TestEvolutionStoreArchiveAndCreate:

--- a/tests/unit_tests/agent_evolving/sharing/test_sharing_module.py
+++ b/tests/unit_tests/agent_evolving/sharing/test_sharing_module.py
@@ -330,6 +330,32 @@ async def test_search_skills_and_install(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_install_skill_rejects_unsafe_hub_metadata_name(tmp_path):
+    backend = LocalFileBackend(hub_path=tmp_path / "hub")
+    publisher_root = tmp_path / "publisher"
+    skill_dir = _write_skill_dir(publisher_root, "safe-skill")
+    package = pack_skill_directory(skill_dir)
+    skill_id = "sk_unsafe_name"
+    await backend.upload_skill_package(
+        skill_id,
+        package,
+        SkillPackageMeta(
+            skill_id=skill_id,
+            skill_name="../outside",
+            description="unsafe metadata regression fixture",
+        ),
+    )
+    installer_root = tmp_path / "consumer" / "skills"
+    client = ExperienceHubClient(backend, EvolutionStore(str(installer_root)))
+
+    installed = await client.install_skill(skill_id)
+
+    assert installed is None
+    assert not (tmp_path / "consumer" / "outside").exists()
+    assert not installer_root.exists() or not any(installer_root.iterdir())
+
+
+@pytest.mark.asyncio
 async def test_share_stager_drops_execution_failure_without_successful_tool(tmp_path):
     backend = LocalFileBackend(hub_path=tmp_path / "hub")
     sharer = ExperienceSharer(backend=backend, local_cache_dir=None)


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/community/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openjiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
选择下面一种标签替换下方 `/kind <label>`，可选标签类型有：
- /kind bug 
- /kind task
- /kind feature
- /kind refactor
- /kind clean_code
如PR描述不符合规范，修改PR描述后需要/check-pr重新检查PR规范。
-->
/kind bug


**Self-checklist**:（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

+ - [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
+ - [x] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
+ - [x] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
+ - [ ] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
+ - [ ] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] 是否导致无法前向兼容 -->
<!-- + - [ ] 是否涉及依赖的三方库变更 -->


**问题背景**

EvolutionStore 在安装 Skill 包时，安装名称可能来自调用方、Hub 元数据或包内容。原有流程未充分校验安装名称及最终目标目录，存在目标目录逃出配置 skills root 的风险。


**修复方案**

- 对显式或推导得到的 Skill 名称执行统一校验。
- 对创建目标进行规范化路径解析，确保其为配置 skills root 的严格子目录。
- 拒绝解析到 skills root 外部的路径及符号链接目标。
- 保持既有 Skill 查找行为和公开接口签名不变。
- 增加相关安全回归测试。


**验证结果**

```text
uv run pytest tests/unit_tests/agent_evolving/checkpointing tests/unit_tests/agent_evolving/sharing -q

124 passed
```