### PR TITLE
Feat(agent_ras): 新增Agent-RAS Agent可靠性框架，集成工具死循环、LLM思考死循环检测与恢复

### DIFF
--- a/openjiuwen/core/single_agent/agents/react_agent.py
+++ b/openjiuwen/core/single_agent/agents/react_agent.py
@@ -889,52 +889,88 @@ class ReActAgent(BaseAgent):
             len(ctx.inputs.messages or []),
             len(ctx.inputs.tools or []),
         )
-        async for chunk in llm.stream(
+        stream_iter = llm.stream(
                 model=self._config.model_name,
                 messages=ctx.inputs.messages,
                 tools=ctx.inputs.tools or None,
                 **extra_kwargs,
-        ):
-            if accumulated_chunk is None:
-                accumulated_chunk = chunk
-            else:
-                accumulated_chunk = accumulated_chunk + chunk
-
-            if chunk.reasoning_content:
-                await session.write_stream(OutputSchema(
-                    type="llm_reasoning",
-                    index=chunk_index,
-                    payload={"content": chunk.reasoning_content, "result_type": "answer"},
-                ))
-                chunk_index += 1
-            if chunk.content:
-                await session.write_stream(OutputSchema(
-                    type="llm_output",
-                    index=chunk_index,
-                    payload={"content": chunk.content, "result_type": "answer"},
-                ))
-                chunk_index += 1
-            if chunk.tool_calls:
-                await session.write_stream(OutputSchema(
-                    type="tool_calls.delta",
-                    index=chunk_index,
-                    payload={
-                        "tool_calls": [
-                            serialize_tool_call_delta(tc)
-                            for tc in chunk.tool_calls
-                        ],
-                        "result_type": "answer",
-                    },
-                ))
-                chunk_index += 1
-            # 每个chunk结束时，判断是否构成完整tool_call
-            self._stream_schedule_ready_tool_calls(
-                executor, accumulated_chunk, finalize=False,
-            )
-        # 所有chuck结束时，做一次最终检查和去重（finalize=True）
-        self._stream_schedule_ready_tool_calls(
-            executor, accumulated_chunk, finalize=True,
         )
+        stream_aborted = False
+        try:
+            async for chunk in stream_iter:
+                if ctx.has_abort_stream_request:
+                    ctx.consume_abort_stream()
+                    stream_aborted = True
+                    logger.info(
+                        "[ReActAgent] llm.stream aborted session_id=%s",
+                        _session_id,
+                    )
+                    break
+
+                if accumulated_chunk is None:
+                    accumulated_chunk = chunk
+                else:
+                    accumulated_chunk = accumulated_chunk + chunk
+
+                if chunk.reasoning_content:
+                    await session.write_stream(OutputSchema(
+                        type="llm_reasoning",
+                        index=chunk_index,
+                        payload={"content": chunk.reasoning_content, "result_type": "answer"},
+                    ))
+                    chunk_index += 1
+                if chunk.content:
+                    await session.write_stream(OutputSchema(
+                        type="llm_output",
+                        index=chunk_index,
+                        payload={"content": chunk.content, "result_type": "answer"},
+                    ))
+                    chunk_index += 1
+                if chunk.tool_calls:
+                    await session.write_stream(OutputSchema(
+                        type="tool_calls.delta",
+                        index=chunk_index,
+                        payload={
+                            "tool_calls": [
+                                serialize_tool_call_delta(tc)
+                                for tc in chunk.tool_calls
+                            ],
+                            "result_type": "answer",
+                        },
+                    ))
+                    chunk_index += 1
+                # 每个chunk结束时，判断是否构成完整tool_call
+                self._stream_schedule_ready_tool_calls(
+                    executor, accumulated_chunk, finalize=False,
+                )
+
+                if ctx.has_abort_stream_request:
+                    ctx.consume_abort_stream()
+                    stream_aborted = True
+                    logger.info(
+                        "[ReActAgent] llm.stream aborted after chunk session_id=%s",
+                        _session_id,
+                    )
+                    break
+        finally:
+            if stream_aborted:
+                aclose = getattr(stream_iter, "aclose", None)
+                if callable(aclose):
+                    try:
+                        await aclose()
+                    except Exception:
+                        logger.warning(
+                            "[ReActAgent] llm.stream aclose failed "
+                            "session_id=%s model=%s",
+                            _session_id,
+                            getattr(self._config, "model_name", "") or "",
+                            exc_info=True,
+                        )
+        # 正常结束时做最终检查和去重；abort 后不再调度半成品 tool_calls（CR-007）
+        if not stream_aborted:
+            self._stream_schedule_ready_tool_calls(
+                executor, accumulated_chunk, finalize=True,
+            )
 
         if accumulated_chunk is None:
             ai_message = AssistantMessage(content="", tool_calls=[], finish_reason="null")
@@ -1587,6 +1623,9 @@ class ReActAgent(BaseAgent):
             session: Session object (required for tool execution)
             **kwargs: Internal flags. _streaming=True selects
                 the llm.stream() path inside _railed_model_call.
+                Outer-loop may pass ``_steering_queue`` in the inputs
+                dict; it is bound to ctx then popped so it does not
+                linger on the business inputs dict.
 
         Returns:
             Dict with output and result_type
@@ -1622,7 +1661,7 @@ class ReActAgent(BaseAgent):
             ctx.extra["user_id"] = inputs.get("user_id", "")
             ctx.extra["run_kind"] = inputs.get("run_kind", "")
             ctx.extra["run_context"] = inputs.get("run_context", "")
-            _sq = inputs.get("_steering_queue")
+            _sq = inputs.pop("_steering_queue", None)
             if _sq is not None:
                 ctx.bind_steering_queue(_sq)
 
@@ -1726,6 +1765,15 @@ class ReActAgent(BaseAgent):
                         steering = ctx.drain_steering()
                         if steering:
                             combined = "\n".join(steering)
+                            logger.info(
+                                "[ReActAgent] STEERING injected session_id=%s "
+                                "iteration=%s count=%s chars=%s prefix=%r",
+                                _session_id,
+                                iteration + 1,
+                                len(steering),
+                                len(combined),
+                                combined[:80],
+                            )
                             await context.add_messages(
                                 UserMessage(
                                     content=(
@@ -2011,7 +2059,8 @@ class ReActAgent(BaseAgent):
             self,
             inputs: Any,
             session: Optional[Session] = None,
-            stream_modes: Optional[List[StreamMode]] = None
+            stream_modes: Optional[List[StreamMode]] = None,
+            **kwargs,
     ) -> AsyncIterator[Any]:
         """Stream execute ReAct process
 
@@ -2044,14 +2093,18 @@ class ReActAgent(BaseAgent):
                 inputs=inputs if isinstance(inputs, dict) else None
             )
 
-        async for chunk in self._inner_stream(session=session, inputs=inputs, need_cleanup=need_cleanup):
+        async for chunk in self._inner_stream(
+            session=session, inputs=inputs, need_cleanup=need_cleanup, **kwargs
+        ):
             yield chunk
 
     @with_session()
-    async def _inner_stream(self, session, inputs, need_cleanup):
+    async def _inner_stream(self, session, inputs, need_cleanup, **kwargs):
         async def stream_process():
             try:
-                final_result = await self.invoke(inputs, session, _streaming=True)
+                final_result = await self.invoke(
+                    inputs, session, _streaming=True, **kwargs
+                )
                 if isinstance(final_result, list):
                     for schema in final_result:
                         await session.write_stream(schema)

--- a/openjiuwen/core/single_agent/rail/base.py
+++ b/openjiuwen/core/single_agent/rail/base.py
@@ -268,6 +268,7 @@ class AgentCallbackContext:
     _force_finish_request: Optional[ForceFinishRequest] = field(
         default=None, init=False, repr=False
     )
+    _abort_stream: bool = field(default=False, init=False, repr=False)
     _steering_queue: Optional[asyncio.Queue] = field(
         default=None, init=False, repr=False
     )
@@ -325,6 +326,25 @@ class AgentCallbackContext:
     def has_force_finish_request(self) -> bool:
         """Check whether a force-finish request is pending."""
         return self._force_finish_request is not None
+
+    def request_abort_stream(self) -> None:
+        """Request the in-flight ``llm.stream`` loop to break after the current chunk.
+
+        Used by reliability (and similar) to stop generation on anomaly hit
+        without waiting for the provider stream to end naturally.
+        """
+        self._abort_stream = True
+
+    def consume_abort_stream(self) -> bool:
+        """Read and clear a pending stream-abort request."""
+        flag = self._abort_stream
+        self._abort_stream = False
+        return flag
+
+    @property
+    def has_abort_stream_request(self) -> bool:
+        """Check whether a stream-abort request is pending."""
+        return self._abort_stream
 
     # ---- Steering runtime control ----
 

--- a/openjiuwen/harness/agent_ras/__init__.py
+++ b/openjiuwen/harness/agent_ras/__init__.py
@@ -1,0 +1,55 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Stable public API for in-process Agent RAS."""
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+from openjiuwen.harness.agent_ras.config import AgentRASConfig
+from openjiuwen.harness.agent_ras.detectors.base import Detector
+from openjiuwen.harness.agent_ras.models import (
+    Anomaly,
+    AnomalyKind,
+    Severity,
+    Signal,
+    SignalKind,
+)
+from openjiuwen.harness.agent_ras.recovery.engine import RecoveryAction
+
+if TYPE_CHECKING:
+    from openjiuwen.harness.agent_ras.factory import build_agent_ras_rail
+    from openjiuwen.harness.rails.agent_ras_rail import AgentRASRail
+
+__all__ = [
+    "AgentRASConfig",
+    "AgentRASRail",
+    "Anomaly",
+    "AnomalyKind",
+    "Detector",
+    "RecoveryAction",
+    "Severity",
+    "Signal",
+    "SignalKind",
+    "build_agent_ras_rail",
+]
+
+# AgentRASRail / build_agent_ras_rail stay lazy: importing them eagerly in this
+# package __init__ re-enters agent_ras_rail while it is still loading via
+# agent_ras_rail → agent_ras.config → agent_ras.__init__.
+_LAZY_EXPORTS = {
+    "AgentRASRail": ("openjiuwen.harness.rails.agent_ras_rail", "AgentRASRail"),
+    "build_agent_ras_rail": (
+        "openjiuwen.harness.agent_ras.factory",
+        "build_agent_ras_rail",
+    ),
+}
+
+
+def __getattr__(name: str) -> Any:
+    target = _LAZY_EXPORTS.get(name)
+    if target is None:
+        raise AttributeError(name)
+    module_name, symbol_name = target
+    value = getattr(import_module(module_name), symbol_name)
+    globals()[name] = value
+    return value

--- a/openjiuwen/harness/agent_ras/agents/__init__.py
+++ b/openjiuwen/harness/agent_ras/agents/__init__.py
@@ -1,0 +1,38 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Agent runtime layer for Agent RAS semantic skills."""
+from openjiuwen.harness.agent_ras.agents.base import (
+    AGENT_RAS_SKILL_ROLES,
+    FAULT_DOMAIN_LLM_THINKING_LOOP,
+    FAULT_DOMAIN_SKILLS,
+    AgentAdapter,
+    NoOpAgentAdapter,
+    fault_domain_for_kind,
+    load_skill_body,
+    skill_for,
+    skills_dir_for_role,
+)
+from openjiuwen.harness.agent_ras.agents.deep_agent_adapter import (
+    AdapterConfig,
+    DeepAgentAdapter,
+    adapter_config_from_agent_ras,
+)
+from openjiuwen.harness.agent_ras.agents.ras_agents import (
+    RASAgents,
+)
+
+__all__ = [
+    "AGENT_RAS_SKILL_ROLES",
+    "AdapterConfig",
+    "AgentAdapter",
+    "DeepAgentAdapter",
+    "FAULT_DOMAIN_LLM_THINKING_LOOP",
+    "FAULT_DOMAIN_SKILLS",
+    "NoOpAgentAdapter",
+    "RASAgents",
+    "adapter_config_from_agent_ras",
+    "fault_domain_for_kind",
+    "load_skill_body",
+    "skill_for",
+    "skills_dir_for_role",
+]

--- a/openjiuwen/harness/agent_ras/agents/base.py
+++ b/openjiuwen/harness/agent_ras/agents/base.py
@@ -1,0 +1,147 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Shared Agent RAS agent port, fault-domain skill registry, and skill layout."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from openjiuwen.harness.agent_ras.models import AnomalyKind
+
+# Fault domain ids align with detector.name / config detector keys.
+FAULT_DOMAIN_LLM_THINKING_LOOP = "llm_thinking_loop"
+
+AGENT_RAS_SKILL_ROLES: tuple[str, ...] = ("detection", "recovery")
+
+# Internal member / async-recovery knobs (not host-configurable).
+MEMBER_MAX_ITERATIONS: int = 30
+ASYNC_RECOVERY_TIMEOUT_SECONDS: float = 60.0
+SKILL_TIMEOUT_SECONDS: float = 30.0
+
+FAULT_DOMAIN_SKILLS: dict[str, dict[str, str]] = {
+    FAULT_DOMAIN_LLM_THINKING_LOOP: {
+        "detection": "llm-loop-detection",
+        "recovery": "llm-loop-review",
+    },
+}
+
+_KIND_TO_FAULT_DOMAIN: dict[str, str] = {
+    AnomalyKind.LLM_THINKING_LOOP.value: FAULT_DOMAIN_LLM_THINKING_LOOP,
+    AnomalyKind.LLM_THINKING_DEAD_LOOP.value: FAULT_DOMAIN_LLM_THINKING_LOOP,
+}
+
+
+def fault_domain_for_kind(kind: AnomalyKind | str) -> str | None:
+    """Map an anomaly kind to its fault domain, or None if unregistered."""
+    if isinstance(kind, AnomalyKind):
+        key = kind.value
+    else:
+        key = str(kind or "").strip()
+    return _KIND_TO_FAULT_DOMAIN.get(key)
+
+
+def skill_for(fault_domain: str, role: str) -> str:
+    """Resolve skill name for ``fault_domain`` × ``role``.
+
+    Raises:
+        ValueError: unknown domain or role for that domain.
+    """
+    domain = str(fault_domain or "").strip()
+    role_key = str(role or "").strip()
+    if not domain or domain not in FAULT_DOMAIN_SKILLS:
+        raise ValueError(f"unknown fault domain: {fault_domain!r}")
+    skills = FAULT_DOMAIN_SKILLS[domain]
+    if role_key not in skills:
+        raise ValueError(
+            f"unknown role {role!r} for fault domain {domain!r}; "
+            f"known={sorted(skills)}"
+        )
+    return skills[role_key]
+
+
+_AGENT_RAS_ROOT = Path(__file__).resolve().parent.parent
+
+ROLE_SKILL_DIRS: dict[str, Path] = {
+    "detection": _AGENT_RAS_ROOT / "detectors" / "skills",
+    "recovery": _AGENT_RAS_ROOT / "recovery" / "skills",
+}
+
+ROLE_PROMPTS: dict[str, str] = {
+    "detection": (
+        "你是可靠性语义检测器。必须经 skill_tool 加载指定 SKILL，"
+        "最终回复只输出 SKILL 规定的 JSON 对象，禁止其他文字，禁止调用 skill_complete。"
+    ),
+    "recovery": (
+        "你是可靠性恢复侧成员。必须经 skill_tool 加载指定 SKILL，"
+        "最终回复只输出 SKILL 规定的 JSON 对象，禁止其他文字，禁止调用 skill_complete。"
+    ),
+}
+
+
+@runtime_checkable
+class AgentAdapter(Protocol):
+    """Invoke an Agent RAS skill via a backing agent implementation."""
+
+    async def invoke_skill(
+        self,
+        *,
+        role: str,
+        skill_name: str,
+        payload: str,
+        timeout: float,
+    ) -> dict:
+        ...
+
+    async def warmup_members(self, roles: tuple[str, ...]) -> None:
+        ...
+
+
+class NoOpAgentAdapter:
+    """Fail-open adapter used when semantic skills are disabled."""
+
+    async def invoke_skill(
+        self,
+        *,
+        role: str,
+        skill_name: str,
+        payload: str,
+        timeout: float,
+    ) -> dict:
+        return {}
+
+    async def warmup_members(self, roles: tuple[str, ...]) -> None:
+        return None
+
+
+def skills_dir_for_role(role: str) -> Path:
+    return ROLE_SKILL_DIRS.get(role, _AGENT_RAS_ROOT / "detectors" / "skills")
+
+
+def _skills_path(role: str, skill_name: str) -> Path:
+    return skills_dir_for_role(role) / skill_name / "SKILL.md"
+
+
+def load_skill_body(role: str, skill_name: str) -> str:
+    """Load SKILL.md body for tests and lightweight invoke paths."""
+    skill_path = _skills_path(role, skill_name)
+    if not skill_path.is_file():
+        return ""
+    return skill_path.read_text(encoding="utf-8")
+
+
+__all__ = [
+    "AGENT_RAS_SKILL_ROLES",
+    "ASYNC_RECOVERY_TIMEOUT_SECONDS",
+    "FAULT_DOMAIN_LLM_THINKING_LOOP",
+    "FAULT_DOMAIN_SKILLS",
+    "MEMBER_MAX_ITERATIONS",
+    "ROLE_PROMPTS",
+    "ROLE_SKILL_DIRS",
+    "SKILL_TIMEOUT_SECONDS",
+    "AgentAdapter",
+    "NoOpAgentAdapter",
+    "fault_domain_for_kind",
+    "load_skill_body",
+    "skill_for",
+    "skills_dir_for_role",
+]

--- a/openjiuwen/harness/agent_ras/agents/deep_agent_adapter.py
+++ b/openjiuwen/harness/agent_ras/agents/deep_agent_adapter.py
@@ -1,0 +1,255 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""DeepAgentAdapter — AgentAdapter backed by short-lived DeepAgent members."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Optional
+
+from openjiuwen.core.foundation.llm.model import Model
+from openjiuwen.core.single_agent.schema.agent_card import AgentCard
+from openjiuwen.harness.rails.skill_use_rail import SkillUseRail
+from openjiuwen.harness.agent_ras.agents.base import (
+    FAULT_DOMAIN_LLM_THINKING_LOOP,
+    MEMBER_MAX_ITERATIONS,
+    ROLE_PROMPTS,
+    skill_for,
+    skills_dir_for_role,
+)
+from openjiuwen.harness.agent_ras.config import AgentRASConfig
+from openjiuwen.harness.agent_ras.detectors.skill_verdicts import (
+    extract_invoke_output_payload,
+    extract_json_object_from_text,
+    parse_skill_verdict,
+    verdict_to_dict,
+)
+
+InvokeFn = Callable[[str, str, str], Awaitable[str]]
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AdapterConfig:
+    """Runtime knobs for DeepAgentAdapter (skill names from fault-domain registry)."""
+
+    max_iterations: int = MEMBER_MAX_ITERATIONS
+    default_fault_domain: str = FAULT_DOMAIN_LLM_THINKING_LOOP
+
+    def skill_for_role(
+        self,
+        role: str,
+        fault_domain: str | None = None,
+    ) -> str:
+        domain = fault_domain or self.default_fault_domain
+        return skill_for(domain, role)
+
+
+def adapter_config_from_agent_ras(config: AgentRASConfig) -> AdapterConfig:
+    """Build adapter knobs from ``AgentRASConfig`` (member limits are internal)."""
+    _ = config
+    return AdapterConfig()
+
+
+def _describe_invoke_failure(result: Any) -> str:
+    if not isinstance(result, dict):
+        return "invoke result is not a dict"
+    result_type = str(result.get("result_type") or "")
+    output = str(result.get("output") or "")
+    if result_type == "error" and "Max iterations reached" in output:
+        return (
+            "member exhausted max_iterations before a JSON-only final answer; "
+            "check skill contract (no skill_complete on verdict turn)"
+        )
+    if result_type == "answer" and output.strip():
+        preview = output.strip().replace("\n", " ")[:120]
+        return f"invoke output is not valid verdict JSON: {preview!r}"
+    return f"invoke result_type={result_type!r} has no parseable output"
+
+
+def _extract_invoke_payload(result: Any) -> str | dict[str, Any]:
+    """Extract structured JSON from invoke result output (auto_harness style)."""
+    payload = extract_invoke_output_payload(result)
+    if payload is not None:
+        return payload
+    if isinstance(result, str):
+        parsed = extract_json_object_from_text(result)
+        return parsed if parsed is not None else result
+    logger.warning(
+        "[DeepAgentAdapter] skill verdict extract failed: %s",
+        _describe_invoke_failure(result),
+    )
+    return "{}"
+
+
+class DeepAgentAdapter:
+    """Default AgentAdapter using lazy DeepAgent members + SkillUseRail."""
+
+    def __init__(
+        self,
+        cfg: Optional[AdapterConfig] = None,
+        model: Optional[Model] = None,
+        invoke_fn: Optional[InvokeFn] = None,
+    ) -> None:
+        self._cfg = cfg or AdapterConfig()
+        self._model = model
+        self._invoke_fn = invoke_fn
+        self._members: dict[str, Any] = {}
+
+    @staticmethod
+    def register_skills(role: str) -> Path:
+        """Return the skill root directory for ``role`` (SkillUseRail scans it)."""
+        return skills_dir_for_role(role)
+
+    async def get_or_create_member(self, role: str) -> Any | None:
+        """Lazy-create a short-lived DeepAgent with SkillUseRail for ``role``.
+
+        Workspace aligns to ``ROLE_SKILL_DIRS[role]`` so SKILL paths stay inside the
+        jiuwenclaw sandbox. ``auto_create_workspace=False`` matches auto_harness
+        stage agents and prevents DirectoryBuilder from polluting the package
+        skills tree.
+        """
+        if self._invoke_fn is not None:
+            return None
+        cached = self._members.get(role)
+        if cached is not None:
+            return cached
+        if self._model is None:
+            return None
+        from openjiuwen.harness.factory import create_deep_agent
+        from openjiuwen.harness.workspace.workspace import Workspace
+
+        skills_root = skills_dir_for_role(role).resolve()
+        if not skills_root.is_dir():
+            logger.warning("Agent RAS skill directory missing: %s", skills_root)
+            return None
+        skills_dir = str(skills_root)
+        skill_name = self._cfg.skill_for_role(role)
+        rail = SkillUseRail(
+            skills_dir=skills_dir,
+            skill_mode=SkillUseRail.SKILL_MODE_ALL,
+            enabled_skills=[skill_name],
+            include_tools=True,
+            include_skill_body_tools=True,
+        )
+        agent = create_deep_agent(
+            model=self._model,
+            card=AgentCard(
+                name=f"reliability_{role}",
+                description=f"Reliability {role} semantic member",
+            ),
+            system_prompt=ROLE_PROMPTS.get(role, ROLE_PROMPTS["detection"]),
+            rails=[rail],
+            workspace=Workspace(root_path=skills_dir),
+            enable_task_loop=False,
+            max_iterations=self._cfg.max_iterations,
+            auto_create_workspace=False,
+        )
+        self._members[role] = agent
+        return agent
+
+    async def warmup_members(self, roles: tuple[str, ...]) -> None:
+        for role in roles:
+            try:
+                await self.get_or_create_member(role)
+            except Exception:
+                logger.warning(
+                    "Agent RAS warmup failed for role=%s",
+                    role,
+                    exc_info=True,
+                )
+
+    async def _invoke_member(
+        self,
+        role: str,
+        *,
+        skill_name: str,
+        user_content: str,
+        timeout: float,
+    ) -> str | dict[str, Any]:
+        if self._invoke_fn is not None:
+            raw = await self._invoke_fn(role, skill_name, user_content)
+            if isinstance(raw, dict) and "output" in raw:
+                return _extract_invoke_payload(raw)
+            return raw
+        agent = await self.get_or_create_member(role)
+        if agent is None:
+            return "{}"
+        user_msg = (
+            f"{user_content}\n"
+            f"请加载 Skill `{skill_name}`，按 SKILL 要求最终只输出 JSON，"
+            f"不要调用 skill_complete。"
+        )
+        result = await agent.invoke({"query": user_msg})
+        return _extract_invoke_payload(result)
+
+    async def invoke_skill(
+        self,
+        *,
+        role: str,
+        skill_name: str,
+        payload: str,
+        timeout: float,
+    ) -> dict:
+        if role == "recovery":
+            user_msg = (
+                f"恢复材料:\n{payload}\n"
+                f"请加载 Skill `{skill_name}` 并输出 JSON。"
+            )
+        else:
+            user_msg = (
+                f"待判定 excerpt:\n{payload}\n"
+                f"请加载 Skill `{skill_name}` 并输出 JSON。"
+            )
+        if timeout <= 0:
+            logger.warning(
+                "Agent RAS semantic %s skill=%s fail_open=True reason=non_positive_timeout",
+                role,
+                skill_name,
+            )
+            return {}
+        try:
+            raw = await asyncio.wait_for(
+                self._invoke_member(
+                    role,
+                    skill_name=skill_name,
+                    user_content=user_msg,
+                    timeout=timeout,
+                ),
+                timeout=timeout,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Agent RAS semantic %s skill=%s timed out fail_open=True",
+                role,
+                skill_name,
+            )
+            return {}
+        except Exception:
+            logger.warning(
+                "Agent RAS semantic %s skill=%s failed fail_open=True",
+                role,
+                skill_name,
+                exc_info=True,
+            )
+            return {}
+        if raw in ("{}", "", None) or raw == {}:
+            logger.warning(
+                "Agent RAS semantic %s skill=%s fail_open=True reason=empty_result",
+                role,
+                skill_name,
+            )
+            return {}
+        verdict = parse_skill_verdict(skill_name, raw)
+        if verdict.fail_open_reason:
+            logger.warning(
+                "Agent RAS semantic %s skill=%s fail_open=True reason=%s",
+                role,
+                skill_name,
+                verdict.fail_open_reason,
+            )
+        if role in ("detection", "recovery"):
+            return verdict_to_dict(verdict)
+        return verdict.raw or {}

--- a/openjiuwen/harness/agent_ras/agents/ras_agents.py
+++ b/openjiuwen/harness/agent_ras/agents/ras_agents.py
@@ -1,0 +1,46 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""RASAgents facade — routes skill invocations to AgentAdapter."""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from openjiuwen.harness.agent_ras.agents.base import (
+    AgentAdapter,
+    NoOpAgentAdapter,
+)
+
+
+class RASAgents:
+    """Facade over ``AgentAdapter`` for detector skill members."""
+
+    def __init__(self, adapter: AgentAdapter | None = None) -> None:
+        self._adapter = adapter or NoOpAgentAdapter()
+
+    async def invoke_skill(
+        self,
+        *,
+        role: str,
+        skill_name: str,
+        payload: str,
+        timeout: float,
+    ) -> dict[str, Any]:
+        try:
+            result = await asyncio.wait_for(
+                self._adapter.invoke_skill(
+                    role=role,
+                    skill_name=skill_name,
+                    payload=payload,
+                    timeout=timeout,
+                ),
+                timeout=timeout,
+            )
+        except Exception:
+            return {}
+        return result if isinstance(result, dict) else {}
+
+    async def warmup_members(self, roles: tuple[str, ...]) -> None:
+        warmup = getattr(self._adapter, "warmup_members", None)
+        if callable(warmup):
+            await warmup(roles)

--- a/openjiuwen/harness/agent_ras/config.py
+++ b/openjiuwen/harness/agent_ras/config.py
@@ -1,0 +1,132 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Per-agent Agent RAS configuration (single-Agent)."""
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from openjiuwen.harness.agent_ras.models import AnomalyKind, Severity
+from openjiuwen.harness.agent_ras.recovery.engine import (
+    DEFAULT_SEVERITY_ACTIONS,
+    RecoveryAction,
+)
+
+
+class RepeatToolConfig(BaseModel):
+    """Thresholds for repeat / loop tool-call detection."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    warning_threshold: int = Field(default=5, ge=2)
+    critical_threshold: int = Field(default=10, ge=2)
+    global_breaker_threshold: int = Field(default=10, ge=2)
+    unknown_tool_threshold: int = Field(default=10, ge=2)
+
+    @property
+    def history_size(self) -> int:
+        return max(
+            4 * self.critical_threshold,
+            2 * self.global_breaker_threshold,
+            2 * self.unknown_tool_threshold,
+        )
+
+
+class LlmThinkingLoopConfig(BaseModel):
+    """Thresholds for LLM thinking-loop detection.
+
+    Character-based gates (``len(text)``), not word counts:
+
+    - ``detection_start_chars``: no L1/L2/L3 until cumulative stream length
+      reaches this threshold
+    - ``text_repetition`` (L1/L2): after start, scan every ``window_max_chars``
+      on a near-window of the same size (FIFO trim + scan gate + min length)
+    - ``plan_execution`` (L3): after start, semantic skill every
+      ``semantic_eval_chars`` incremental chars since last eval
+    - Detection / recovery skill names are bound by fault-domain registry
+      (``agents.base``), not host-configurable.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    detection_start_chars: int = Field(
+        default=30000, ge=1,
+        description="Cumulative chars before any L1/L2/L3 detection runs",
+    )
+    window_max_chars: int = Field(
+        default=2000, ge=100,
+        description="L1/L2 near-window size, scan interval, and min detect length",
+    )
+    loop_repeat_threshold: int = Field(default=5, ge=2)
+    similar_clause_sim_threshold: float = Field(default=0.95, ge=0.0, le=1.0)
+    semantic_eval_chars: int = Field(
+        default=10000, ge=1,
+        description="Incremental chars since last L3 eval before next detection",
+    )
+    semantic_content_enabled: bool = True
+
+
+class DetectorsConfig(BaseModel):
+    """Toggle + thresholds for every detector."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    repeat_tool: RepeatToolConfig = Field(default_factory=RepeatToolConfig)
+    llm_thinking_loop: LlmThinkingLoopConfig = Field(
+        default_factory=LlmThinkingLoopConfig,
+    )
+
+
+class RecoveryConfig(BaseModel):
+    """Recovery-side knobs (parallel to ``detectors``)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    # LOW 警告时是否向用户推送可见 notice（steering 始终按 policy 执行）
+    notify_user_on_warning: bool = True
+
+
+class RecoveryPolicyConfig(BaseModel):
+    """Severity-to-action mapping; optional per-kind overrides."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    severity_actions: dict[Severity, list[RecoveryAction]] = Field(
+        default_factory=lambda: dict(DEFAULT_SEVERITY_ACTIONS),
+    )
+    kind_overrides: dict[AnomalyKind, list[RecoveryAction]] = Field(
+        default_factory=dict,
+        description="Optional per-AnomalyKind action overrides (empty = use severity only)",
+    )
+
+
+def coerce_message_locale(language: str | None) -> str:
+    """Map DeepAgent / prompt language to Agent RAS message locale (cn/en).
+
+    Not a config field — mirrors how SecurityRail / SkillUseRail read
+    ``system_prompt_builder.language`` at runtime.
+    """
+    loc = (language or "cn").strip().lower()
+    if loc in ("en", "english"):
+        return "en"
+    if loc in ("zh", "zh-cn", "zhcn", "chinese", "cn"):
+        return "cn"
+    return "cn"
+
+
+class AgentRASConfig(BaseModel):
+    """Per-agent Agent RAS framework configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    detectors: DetectorsConfig = Field(default_factory=DetectorsConfig)
+    recovery: RecoveryConfig = Field(default_factory=RecoveryConfig)
+    policy: RecoveryPolicyConfig = Field(default_factory=RecoveryPolicyConfig)
+
+    @model_validator(mode="after")
+    def _validate_thresholds(self) -> "AgentRASConfig":
+        repeat = self.detectors.repeat_tool
+        if repeat.critical_threshold < repeat.warning_threshold:
+            raise ValueError("critical_threshold must be >= warning_threshold")
+        return self

--- a/openjiuwen/harness/agent_ras/detectors/__init__.py
+++ b/openjiuwen/harness/agent_ras/detectors/__init__.py
@@ -1,0 +1,18 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Agent RAS detectors: pure signal-to-anomaly logic."""
+from openjiuwen.harness.agent_ras.detectors.base import (
+    Detector,
+)
+from openjiuwen.harness.agent_ras.detectors.llm_thinking_loop import (
+    LlmThinkingLoopDetector,
+)
+from openjiuwen.harness.agent_ras.detectors.repeat_tool import (
+    RepeatToolCallDetector,
+)
+
+__all__ = [
+    "Detector",
+    "LlmThinkingLoopDetector",
+    "RepeatToolCallDetector",
+]

--- a/openjiuwen/harness/agent_ras/detectors/base.py
+++ b/openjiuwen/harness/agent_ras/detectors/base.py
@@ -1,0 +1,78 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Detector protocol and async-recovery capability.
+
+A ``Detector`` consumes the unified ``Signal`` stream and emits an ``Anomaly``
+when a threshold trips — pure logic, no I/O, trivially unit-testable.
+``AsyncRecoveryDetector`` is an optional capability for detectors that finish
+stream recovery after ``observe`` returns.
+"""
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Protocol, runtime_checkable
+
+from openjiuwen.harness.agent_ras.models import (
+    Anomaly,
+    Signal,
+)
+
+AsyncRecoveryHandler = Callable[[Any, str], Awaitable[None]]
+
+
+class Detector(Protocol):
+    """Consumes signals and emits anomalies when a threshold trips.
+
+    Every detector must implement:
+      - ``name`` property: stable identifier used for logging / evidence.
+      - ``observe(signal)``: sync or async; called by ``AgentRASMonitor.detection``.
+        Returning ``None`` means "no anomaly".
+      - ``reset()``: per-round cleanup; called by ``AgentRASMonitor.reset``.
+    """
+
+    @property
+    def name(self) -> str:
+        """Return the detector's stable identifier."""
+        ...
+
+    def observe(
+        self, signal: Signal,
+    ) -> Anomaly | None | Awaitable[Anomaly | None]:
+        """Consume one signal; return an Anomaly when a threshold trips."""
+        ...
+
+    def reset(self) -> None:
+        """Reset per-round detection state."""
+        ...
+
+
+@runtime_checkable
+class AsyncRecoveryDetector(Protocol):
+    """Optional Detector capability: finish stream recovery after ``observe`` returns.
+
+    Main implementation: ``LlmThinkingLoopDetector`` (async L3 skill evaluation).
+    ``AgentRASMonitor`` wires the completion handler at start and awaits on stop.
+    """
+
+    def has_async_recovery_in_flight(self) -> bool:
+        """Return True while an async evaluation / recovery task is pending."""
+        ...
+
+    async def await_async_recovery(self, timeout: float) -> None:
+        """Wait up to ``timeout`` seconds for in-flight async recovery."""
+        ...
+
+    def release_async_recovery(self) -> None:
+        """Force-release in-flight state (timeout / cancel path)."""
+        ...
+
+    def set_async_recovery_handler(
+        self,
+        handler: AsyncRecoveryHandler | None,
+    ) -> None:
+        """Install the Monitor callback invoked when async evaluation finishes."""
+        ...
+
+
+def is_async_recovery_detector(detector: Any) -> bool:
+    """Return True if ``detector`` structurally matches ``AsyncRecoveryDetector``."""
+    return isinstance(detector, AsyncRecoveryDetector)

--- a/openjiuwen/harness/agent_ras/detectors/llm_thinking_loop.py
+++ b/openjiuwen/harness/agent_ras/detectors/llm_thinking_loop.py
@@ -1,0 +1,798 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""LlmThinkingLoopDetector — aligned with ``thinking_loop_lock_rail.py`` (PR#3102).
+
+Per stream type, maintain independent eval channels that never mix char/time
+anchors across ``llm_output`` / ``llm_reasoning``:
+
+  - **text_repetition** (L1/L2): runs on **both** ``llm_output`` and
+    ``llm_reasoning`` via ``LoopDetector`` (suffix_cycle → similar_clauses),
+    gated by ``detection_start_chars`` then ``window_max_chars`` since last scan
+    (same value is the near-window FIFO size and min detect length).
+  - **plan_execution** (L3): semantic Skill via ``RASAgents.invoke_skill``,
+    runs on ``llm_reasoning`` and (temporarily) ``llm_output``, gated by
+    ``detection_start_chars`` then incremental chars >= ``semantic_eval_chars``
+    (default 10k).
+
+``tool_calls.delta`` may still be emitted by ``ReActAgent`` (enterprise-dev
+baseline), but this detector does not consume it — only visible assistant
+``llm_output`` / ``llm_reasoning`` text is scanned.
+
+``BEFORE_MODEL_CALL`` resets all channel state (per model_call isolation).
+"""
+from __future__ import annotations
+
+import asyncio
+import re
+import time
+from collections import Counter
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher
+from typing import Any, Optional
+
+from openjiuwen.core.common.logging import logger
+from openjiuwen.harness.agent_ras.agents.base import (
+    FAULT_DOMAIN_LLM_THINKING_LOOP,
+    NoOpAgentAdapter,
+    SKILL_TIMEOUT_SECONDS,
+    skill_for,
+)
+from openjiuwen.harness.agent_ras.agents.ras_agents import RASAgents
+from openjiuwen.harness.agent_ras.detectors.base import AsyncRecoveryHandler
+from openjiuwen.harness.agent_ras.config import LlmThinkingLoopConfig
+from openjiuwen.harness.agent_ras.models import (
+    Anomaly,
+    AnomalyKind,
+    Severity,
+    Signal,
+    SignalKind,
+)
+
+
+# Visible assistant token streams scanned for dead-loop text (L1/L2).
+STREAM_CHANNELS: tuple[str, ...] = (
+    "llm_output",
+    "llm_reasoning",
+)
+
+# L3 semantic / plan_execution: temporarily includes llm_output for models
+# that do not emit a separate reasoning stream (e.g. deepseek-chat).
+L3_STREAM_CHANNELS: frozenset[str] = frozenset({"llm_reasoning", "llm_output"})
+
+# --- LoopDetector constants (thinking_loop_lock_rail.py) ---
+MIN_CLAUSE_LEN = 5
+SUFFIX_CYCLE_MIN_PATTERN_LEN = 10
+SUFFIX_CYCLE_MAX_PATTERN_LEN = 150
+SUFFIX_CYCLE_TAIL_WINDOW = 600
+SIMILAR_CLAUSE_ENUM_TOP_RATIO = 0.7
+SIMILAR_CLAUSE_ENUM_STRICT_RATIO = 0.85
+
+_CODE_FENCE_RE = re.compile(r"```[\w]*\n.*?```", re.DOTALL)
+_CLAUSE_SPLIT_RE = re.compile(r"[。！？\n]+")
+_DIGIT_SKELETON_RE = re.compile(r"\d+")
+_LEXICAL_TOKEN_RE = re.compile(r"[a-zA-Z]+|[\u4e00-\u9fff]")
+_NORMALIZE_PREFIX_RE = re.compile(r"(^|\n)\s*(\d+[.)]\s*|step\s+[\dA-Z]+:\s*)")
+
+
+@dataclass
+class DetectionResult:
+    detected: bool = False
+    start_pos: int = 0
+    mode: str = ""
+    count: int = 0
+    threshold: int = 0
+
+
+def is_degenerate(text: str) -> bool:
+    if not text:
+        return True
+    stripped = text.strip()
+    if not stripped:
+        return True
+    unique_chars = set(stripped.replace(" ", "").replace("\n", "").replace("\t", ""))
+    if len(unique_chars) <= 2:
+        return True
+    total = len(text)
+    whitespace = sum(1 for c in text if c.isspace())
+    if total > 0 and whitespace / total >= 0.7:
+        return True
+    return False
+
+
+def _strip_code_fences(text: str) -> str:
+    return _CODE_FENCE_RE.sub("", text)
+
+
+def _extract_lexical_key(clause: str) -> str:
+    if not clause:
+        return ""
+    lowered = clause.lower()
+    tokens = _LEXICAL_TOKEN_RE.findall(lowered)
+    return " ".join(tokens)
+
+
+def _clause_lexical_char_len(clause: str) -> int:
+    return len(_extract_lexical_key(clause).replace(" ", ""))
+
+
+def _split_clauses(text: str) -> list[str]:
+    cleaned = _strip_code_fences(text)
+    parts = _CLAUSE_SPLIT_RE.split(cleaned)
+    clauses: list[str] = []
+    for part in parts:
+        stripped = part.strip()
+        if len(stripped) <= MIN_CLAUSE_LEN:
+            continue
+        if _clause_lexical_char_len(stripped) <= MIN_CLAUSE_LEN:
+            continue
+        clauses.append(stripped)
+    return clauses
+
+
+def _digit_skeleton(clause: str) -> str:
+    return _DIGIT_SKELETON_RE.sub("#", clause)
+
+
+def _is_enumeration_exempt(clauses: list[str]) -> bool:
+    if len(clauses) < 3:
+        return False
+    skels = [_digit_skeleton(c) for c in clauses]
+    cnt = Counter(skels)
+    dominant_skel, dominant_count = cnt.most_common(1)[0]
+    top_ratio = dominant_count / len(clauses)
+    if top_ratio < SIMILAR_CLAUSE_ENUM_TOP_RATIO or "#" not in dominant_skel:
+        return False
+    nums: list[int] = []
+    for clause in clauses:
+        if _digit_skeleton(clause) != dominant_skel:
+            continue
+        found = _DIGIT_SKELETON_RE.findall(clause)
+        if found:
+            nums.append(int(found[0]))
+    if len(nums) >= 3 and len(set(nums)) == len(nums):
+        sorted_nums = sorted(nums)
+        if sorted_nums[-1] - sorted_nums[0] == len(sorted_nums) - 1:
+            return True
+    return top_ratio >= SIMILAR_CLAUSE_ENUM_STRICT_RATIO
+
+
+def _clause_similarity(a: str, b: str) -> float:
+    if not a or not b:
+        return 0.0
+    key_a = _extract_lexical_key(a)
+    key_b = _extract_lexical_key(b)
+    if not key_a or not key_b:
+        return 0.0
+    if len(key_a.replace(" ", "")) <= MIN_CLAUSE_LEN or len(key_b.replace(" ", "")) <= MIN_CLAUSE_LEN:
+        return 0.0
+    return SequenceMatcher(None, key_a, key_b).ratio()
+
+
+def _clause_positions_in_text(text: str, clauses: list[str]) -> list[int]:
+    positions: list[int] = []
+    search_from = 0
+    for clause in clauses:
+        idx = text.find(clause, search_from)
+        if idx < 0:
+            idx = search_from
+        positions.append(idx)
+        search_from = idx + max(1, len(clause))
+    return positions
+
+
+def normalize(text: str) -> str:
+    if not text:
+        return text
+    try:
+        text = text.lower()
+        text = re.sub(r"[^\S\n]+", " ", text)
+        text = _NORMALIZE_PREFIX_RE.sub(r"\1", text)
+        return text
+    except Exception:
+        return text
+
+
+def _strategy_suffix_cycle(
+    text: str,
+    threshold: int,
+    tail: int = SUFFIX_CYCLE_TAIL_WINDOW,
+    min_p: int = SUFFIX_CYCLE_MIN_PATTERN_LEN,
+    max_p: int = SUFFIX_CYCLE_MAX_PATTERN_LEN,
+) -> Optional[DetectionResult]:
+    if len(text) < threshold * min_p:
+        return None
+    tail_text = text[-tail:]
+    max_period = min(max_p, len(tail_text) // threshold)
+    if max_period < min_p:
+        return None
+    for p_len in range(min_p, max_period + 1):
+        pat = tail_text[-p_len:]
+        if is_degenerate(pat):
+            continue
+        repeats = 0
+        i = len(tail_text) - p_len
+        while i >= 0:
+            if tail_text[i:i + p_len] == pat:
+                repeats += 1
+                if repeats >= threshold:
+                    break
+                i -= p_len
+            else:
+                break
+        if repeats >= threshold:
+            offset_in_tail = len(tail_text) - repeats * p_len
+            start_pos = max(0, len(text) - len(tail_text) + offset_in_tail)
+            return DetectionResult(
+                detected=True,
+                start_pos=start_pos,
+                mode="suffix_cycle",
+                count=repeats,
+                threshold=threshold,
+            )
+    return None
+
+
+def _strategy_similar_clauses(
+    text: str,
+    threshold: int,
+    sim_threshold: float,
+) -> Optional[DetectionResult]:
+    clauses = _split_clauses(text)
+    if len(clauses) < threshold:
+        return None
+    if _is_enumeration_exempt(clauses):
+        return None
+
+    similar_indices: set[int] = set()
+    clause_count = len(clauses)
+    for i in range(clause_count):
+        for j in range(i + 1, clause_count):
+            if _clause_similarity(clauses[i], clauses[j]) >= sim_threshold:
+                similar_indices.add(i)
+                similar_indices.add(j)
+
+    if len(similar_indices) < threshold:
+        return None
+
+    positions = _clause_positions_in_text(text, clauses)
+    start_pos = min(positions[i] for i in similar_indices)
+    return DetectionResult(
+        detected=True,
+        start_pos=start_pos,
+        mode="similar_clauses",
+        count=len(similar_indices),
+        threshold=threshold,
+    )
+
+
+@dataclass
+class LoopDetector:
+    """Literal loop detector — suffix_cycle → similar_clauses (stateless)."""
+
+    min_text_length: int = 80
+    similar_clause_sim_threshold: float = 0.95
+    _strategies: list = field(default_factory=list, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        sim_th = self.similar_clause_sim_threshold
+        self._strategies = [
+            ("suffix_cycle", _strategy_suffix_cycle),
+            (
+                "similar_clauses",
+                lambda text, threshold: _strategy_similar_clauses(
+                    text, threshold, sim_threshold=sim_th,
+                ),
+            ),
+        ]
+
+    def detect(self, text: str, threshold: int = 5) -> DetectionResult:
+        if not text or len(text) < self.min_text_length:
+            return DetectionResult(detected=False, threshold=threshold)
+        if is_degenerate(text):
+            return DetectionResult(detected=False, threshold=threshold)
+        norm = normalize(text)
+        for _mode_name, strategy in self._strategies:
+            try:
+                result = strategy(norm, threshold)
+            except Exception:
+                logger.debug(
+                    "[LoopDetector] strategy %s failed",
+                    _mode_name,
+                    exc_info=True,
+                )
+                result = None
+            if result is not None:
+                return result
+        return DetectionResult(detected=False, threshold=threshold)
+
+
+@dataclass
+class _TextRepetitionChannel:
+    buffer: str = ""
+    total_length: int = 0
+    last_scanned_pos: int = 0
+    detection_latched: bool = False
+
+
+@dataclass
+class _PlanExecutionChannel:
+    buffer: str = ""
+    total_length: int = 0
+    last_evaluated_pos: int = 0
+    last_evaluated_at: float = field(default_factory=time.monotonic)
+    model_call_start: float = field(default_factory=time.monotonic)
+    eval_in_flight: bool = False
+    detection_latched: bool = False
+
+
+@dataclass
+class _SemanticEvalJob:
+    ch: _PlanExecutionChannel
+    excerpt: str
+    trigger_buffer_len: int
+    chunk_type: str
+    member: str
+    generation: int
+
+
+class LlmThinkingLoopDetector:
+    """Dual-channel LLM thinking-loop detector aligned with ThinkingLoopLockRail."""
+
+    def __init__(
+        self,
+        config: LlmThinkingLoopConfig | None = None,
+        agents: RASAgents | None = None,
+    ) -> None:
+        self._config = config or LlmThinkingLoopConfig()
+        self._agents = agents or RASAgents(NoOpAgentAdapter())
+        self._text_rep: dict[str, _TextRepetitionChannel] = {}
+        self._plan_exec: dict[str, _PlanExecutionChannel] = {}
+        self._buffers: dict[str, tuple[str, int]] = {}
+        self._async_recovery_handler: AsyncRecoveryHandler | None = None
+        self._generation = 0
+        self._eval_tasks: set[asyncio.Task] = set()
+
+    @property
+    def name(self) -> str:
+        return "llm_thinking_loop"
+
+    def set_async_recovery_handler(
+        self,
+        handler: AsyncRecoveryHandler | None,
+    ) -> None:
+        self._async_recovery_handler = handler
+
+    def has_async_recovery_in_flight(self) -> bool:
+        return self.has_eval_in_flight()
+
+    async def await_async_recovery(self, timeout: float) -> None:
+        await self.await_in_flight_evals(timeout)
+
+    def release_async_recovery(self) -> None:
+        self.release_eval_in_flight()
+
+    def reset(self) -> None:
+        self._generation += 1
+        self._cancel_eval_tasks()
+        self._text_rep.clear()
+        self._plan_exec.clear()
+        self._buffers.clear()
+
+    def release_text_repetition_latch(self) -> None:
+        """Allow L1/L2 re-detection after recovery normal in the same model call.
+
+        Clears ``detection_latched`` and advances ``last_scanned_pos`` so the next
+        scan requires ``window_max_chars`` of new text (avoids instant re-fire
+        on the already-confirmed loop buffer).
+        """
+        for ch in self._text_rep.values():
+            ch.detection_latched = False
+            ch.last_scanned_pos = len(ch.buffer)
+
+    def release_plan_execution_latch(self) -> None:
+        """Allow L3 semantic re-detection after Reviewer normal / fail-open.
+
+        Clears ``detection_latched`` / ``eval_in_flight`` and advances the eval
+        cursor so the next skill invoke needs a fresh ``semantic_eval_chars``
+        window of new text.
+        """
+        now = time.monotonic()
+        for ch in self._plan_exec.values():
+            ch.detection_latched = False
+            ch.eval_in_flight = False
+            ch.last_evaluated_pos = len(ch.buffer)
+            ch.last_evaluated_at = now
+
+    def release_after_recovery_normal(self) -> None:
+        """Release L1/L2 and L3 latches after automatic recovery normal / fail-open."""
+        self.release_text_repetition_latch()
+        self.release_plan_execution_latch()
+
+    # Backward-compatible alias used by older tests / callers.
+    release_after_hitl_yes = release_after_recovery_normal
+
+    def _cancel_eval_tasks(self) -> None:
+        for task in list(self._eval_tasks):
+            task.cancel()
+        self._eval_tasks.clear()
+
+    async def aclose(self) -> None:
+        """Cancel and join semantic evaluation tasks."""
+        tasks = list(self._eval_tasks)
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self._eval_tasks.clear()
+
+    def has_eval_in_flight(self) -> bool:
+        if self._eval_tasks:
+            return True
+        return any(ch.eval_in_flight for ch in self._plan_exec.values())
+
+    def release_eval_in_flight(self) -> None:
+        self._cancel_eval_tasks()
+        for ch in self._plan_exec.values():
+            ch.eval_in_flight = False
+
+    async def await_in_flight_evals(self, timeout: float) -> None:
+        """Wait for in-progress L3 skill invocations (used by AgentRASRail.after_invoke)."""
+        if timeout <= 0:
+            return
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if not self.has_eval_in_flight():
+                return
+            pending = [t for t in self._eval_tasks if not t.done()]
+            if pending:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                done, _ = await asyncio.wait(
+                    pending,
+                    timeout=min(0.05, remaining),
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                for task in done:
+                    try:
+                        await task
+                    except asyncio.CancelledError:
+                        pass
+                    except Exception:
+                        logger.warning(
+                            "[LlmThinkingLoopDetector] eval task failed "
+                            "during await_in_flight_evals",
+                            exc_info=True,
+                        )
+            else:
+                await asyncio.sleep(0.05)
+
+        if self.has_eval_in_flight():
+            logger.warning(
+                "[LlmThinkingLoopDetector] await_in_flight_evals timed out after %.1fs",
+                timeout,
+            )
+            self.release_eval_in_flight()
+
+    def _text_rep_channel(self, chunk_type: str) -> _TextRepetitionChannel:
+        ch = self._text_rep.get(chunk_type)
+        if ch is None:
+            ch = _TextRepetitionChannel()
+            self._text_rep[chunk_type] = ch
+        return ch
+
+    def _plan_exec_channel(self, chunk_type: str) -> _PlanExecutionChannel:
+        ch = self._plan_exec.get(chunk_type)
+        if ch is None:
+            now = time.monotonic()
+            ch = _PlanExecutionChannel(
+                model_call_start=now,
+                last_evaluated_at=now,
+            )
+            self._plan_exec[chunk_type] = ch
+        return ch
+
+    def _channel(self, chunk_type: str) -> _PlanExecutionChannel:
+        return self._plan_exec_channel(chunk_type)
+
+    @staticmethod
+    def _trim_text_rep_buffer(
+        buffer: str,
+        max_chars: int,
+        pos_markers: list[int],
+    ) -> tuple[str, list[int]]:
+        if max_chars <= 0 or len(buffer) <= max_chars:
+            return buffer, pos_markers
+        overflow = len(buffer) - max_chars
+        buffer = buffer[overflow:]
+        pos_markers = [max(0, p - overflow) for p in pos_markers]
+        return buffer, pos_markers
+
+    @staticmethod
+    def _parse_skill_abnormal(result: Any) -> bool:
+        if not isinstance(result, dict):
+            return False
+        return result.get("abnormal") is True
+
+    async def observe(self, signal: Signal) -> Optional[Anomaly]:
+        try:
+            if signal.kind == SignalKind.STREAM_CHUNK:
+                return await self._observe_stream(signal)
+            if signal.kind == SignalKind.BEFORE_MODEL_CALL:
+                self.reset()
+                return None
+            return None
+        except Exception:
+            logger.warning(
+                "[LlmThinkingLoopDetector] observe failed member=%s kind=%s",
+                signal.member_name,
+                signal.kind,
+                exc_info=True,
+            )
+            return None
+
+    async def _observe_stream(self, signal: Signal) -> Optional[Anomaly]:
+        chunk_type = signal.chunk_type
+        if chunk_type not in STREAM_CHANNELS:
+            return None
+        text = signal.chunk_text or ""
+        if not text:
+            return None
+
+        tr = self._text_rep_channel(chunk_type)
+        run_l3 = chunk_type in L3_STREAM_CHANNELS
+        pe = self._plan_exec_channel(chunk_type) if run_l3 else None
+
+        if tr.detection_latched and (pe is None or pe.detection_latched):
+            return None
+
+        tr.buffer += text
+        tr.total_length += len(text)
+        tr.buffer, [tr.last_scanned_pos] = self._trim_text_rep_buffer(
+            tr.buffer,
+            self._config.window_max_chars,
+            [tr.last_scanned_pos],
+        )
+        self._buffers[chunk_type] = (tr.buffer, tr.total_length)
+
+        if pe is not None:
+            pe.buffer += text
+            pe.total_length += len(text)
+            semantic_window = max(
+                self._config.window_max_chars,
+                self._config.semantic_eval_chars * 2,
+            )
+            if len(pe.buffer) > semantic_window:
+                overflow = len(pe.buffer) - semantic_window
+                pe.buffer = pe.buffer[overflow:]
+                pe.last_evaluated_pos = max(0, pe.last_evaluated_pos - overflow)
+
+        start_chars = self._config.detection_start_chars
+
+        if (
+            not tr.detection_latched
+            and tr.total_length >= start_chars
+        ):
+            anomaly = self._run_text_repetition(
+                tr, chunk_type, signal.member_name, text,
+            )
+            if anomaly is not None:
+                return anomaly
+
+        if (
+            pe is not None
+            and not pe.detection_latched
+            and pe.total_length >= start_chars
+        ):
+            return await self._maybe_invoke_semantic_skill(
+                pe, chunk_type, signal.member_name,
+            )
+        return None
+
+    def _run_text_repetition(
+        self,
+        ch: _TextRepetitionChannel,
+        chunk_type: str,
+        member: str,
+        last_chunk_text: str,
+    ) -> Optional[Anomaly]:
+        pending = len(ch.buffer) - ch.last_scanned_pos
+        if pending < self._config.window_max_chars:
+            return None
+
+        ch.last_scanned_pos = len(ch.buffer)
+        detector = LoopDetector(
+            min_text_length=self._config.window_max_chars,
+            similar_clause_sim_threshold=self._config.similar_clause_sim_threshold,
+        )
+        result = detector.detect(ch.buffer, threshold=self._config.loop_repeat_threshold)
+        if not result.detected:
+            return None
+
+        ch.detection_latched = True
+        severity = Severity.LOW if result.mode == "suffix_cycle" else Severity.MEDIUM
+        chunk_start = len(ch.buffer) - len(last_chunk_text)
+        keep_len = (
+            max(0, result.start_pos - chunk_start)
+            if result.start_pos > chunk_start
+            else 0
+        )
+        return self._build_anomaly(
+            AnomalyKind.LLM_THINKING_LOOP,
+            severity,
+            member,
+            {
+                "mode": result.mode,
+                "channel": "text_repetition",
+                "recovery_profile": "thinking_loop_text_rep",
+                "count": result.count,
+                "start_pos": result.start_pos,
+                "threshold": result.threshold,
+                "buffer_len": ch.total_length,
+                "chunk_type": chunk_type,
+                "scanned_text": ch.buffer,
+                "stream_chunk_keep_len": keep_len,
+            },
+        )
+
+    async def _maybe_invoke_semantic_skill(
+        self,
+        ch: _PlanExecutionChannel,
+        chunk_type: str,
+        member: str,
+    ) -> Optional[Anomaly]:
+        if not self._config.semantic_content_enabled or ch.eval_in_flight:
+            return None
+
+        incremental_len = len(ch.buffer) - ch.last_evaluated_pos
+        if incremental_len < self._config.semantic_eval_chars:
+            return None
+
+        excerpt = ch.buffer[ch.last_evaluated_pos:]
+        if not excerpt.strip():
+            ch.last_evaluated_pos = len(ch.buffer)
+            ch.last_evaluated_at = time.monotonic()
+            return None
+
+        ch.eval_in_flight = True
+        trigger_buffer_len = len(ch.buffer)
+        excerpt_copy = excerpt
+        generation = self._generation
+        task = asyncio.create_task(
+            self._run_semantic_eval(
+                _SemanticEvalJob(
+                    ch=ch,
+                    excerpt=excerpt_copy,
+                    trigger_buffer_len=trigger_buffer_len,
+                    chunk_type=chunk_type,
+                    member=member,
+                    generation=generation,
+                )
+            )
+        )
+        self._eval_tasks.add(task)
+        task.add_done_callback(self._eval_tasks.discard)
+        return None
+
+    async def _run_semantic_eval(self, job: _SemanticEvalJob) -> None:
+        ch = job.ch
+        excerpt = job.excerpt
+        trigger_buffer_len = job.trigger_buffer_len
+        chunk_type = job.chunk_type
+        member = job.member
+        generation = job.generation
+        if generation != self._generation:
+            return
+        abnormal = False
+        skill_result: dict[str, Any] = {}
+        detection_skill = skill_for(FAULT_DOMAIN_LLM_THINKING_LOOP, "detection")
+        try:
+            result = await self._agents.invoke_skill(
+                role="detection",
+                skill_name=detection_skill,
+                payload=excerpt,
+                timeout=float(SKILL_TIMEOUT_SECONDS),
+            )
+            if isinstance(result, dict):
+                skill_result = result
+            abnormal = self._parse_skill_abnormal(skill_result)
+            if not abnormal:
+                fail_reason = (
+                    skill_result.get("fail_open_reason")
+                    if isinstance(skill_result, dict)
+                    else None
+                )
+                if not skill_result:
+                    logger.warning(
+                        "[LlmThinkingLoopDetector] semantic eval fail-open "
+                        "member=%s skill=%s reason=empty_result",
+                        member,
+                        detection_skill,
+                    )
+                elif fail_reason:
+                    logger.warning(
+                        "[LlmThinkingLoopDetector] semantic eval fail-open "
+                        "member=%s skill=%s reason=%s",
+                        member,
+                        detection_skill,
+                        fail_reason,
+                    )
+                else:
+                    logger.info(
+                        "[LlmThinkingLoopDetector] semantic eval normal "
+                        "member=%s skill=%s",
+                        member,
+                        detection_skill,
+                    )
+        except Exception:
+            logger.warning(
+                "[LlmThinkingLoopDetector] semantic evaluation failed member=%s",
+                member,
+                exc_info=True,
+            )
+            abnormal = False
+        finally:
+            stale = generation != self._generation
+            if not stale and not abnormal:
+                ch.eval_in_flight = False
+                ch.last_evaluated_pos = trigger_buffer_len
+                ch.last_evaluated_at = time.monotonic()
+
+        if generation != self._generation:
+            return
+
+        if not abnormal:
+            return
+
+        ch.detection_latched = True
+        primary_fault = str(skill_result.get("primary_fault") or "semantic_deadlock")
+        anomaly = self._build_anomaly(
+            AnomalyKind.LLM_THINKING_DEAD_LOOP,
+            Severity.HIGH,
+            member,
+            {
+                "mode": "plan_execution_loop_lock",
+                "channel": "plan_execution",
+                "recovery_profile": "thinking_loop_plan_exec",
+                "chunk_type": chunk_type,
+                "buffer_len": ch.total_length,
+                "incremental_len": len(excerpt),
+                "thinking_excerpt": excerpt,
+                "scanned_text": ch.buffer,
+                "skill_name": detection_skill,
+                "fault_domain": FAULT_DOMAIN_LLM_THINKING_LOOP,
+                "stream_chunk_keep_len": 0,
+                "primary_fault": primary_fault,
+                "skill_rationale": str(skill_result.get("rationale") or ""),
+                "skill_confidence": skill_result.get("confidence"),
+            },
+        )
+        handler = self._async_recovery_handler
+        if handler is None:
+            ch.eval_in_flight = False
+            return
+        try:
+            await handler(anomaly, chunk_type)
+        except Exception:
+            logger.warning(
+                "[LlmThinkingLoopDetector] async recovery failed member=%s",
+                member,
+                exc_info=True,
+            )
+            ch.eval_in_flight = False
+
+    @staticmethod
+    def _build_anomaly(
+        kind: AnomalyKind,
+        severity: Severity,
+        member: str,
+        evidence: dict[str, Any],
+    ) -> Anomaly:
+        return Anomaly(
+            detector="llm_thinking_loop",
+            kind=kind,
+            severity=severity,
+            member_name=member,
+            summary=f"{kind.value} ({evidence.get('mode', '?')})",
+            evidence=evidence,
+        )

--- a/openjiuwen/harness/agent_ras/detectors/repeat_tool.py
+++ b/openjiuwen/harness/agent_ras/detectors/repeat_tool.py
@@ -1,0 +1,539 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""RepeatToolCallDetector — fix/circuit_breaker_recovery-aligned tool-loop detection.
+
+Algorithms and thresholds match jiuwenswarm_enterprise branch
+``fix/circuit_breaker_recovery`` → ``circuit_breaker_rail.py``:
+
+  - generic_repeat:      same tool+args repeat (WARNING≥5)
+  - unknown_tool_repeat: failing tool streak (WARNING≥threshold/2, CRITICAL≥threshold)
+  - global_breaker:      no-progress streak (CRITICAL≥10)
+  - ping_pong:           A↔B alternation (WARNING≥5, CRITICAL≥10 + no_progress)
+
+Default thresholds: warning=5, critical=10, global_breaker=10, unknown_tool=10.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import re
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Any
+
+from openjiuwen.core.common.logging import logger
+from openjiuwen.harness.agent_ras.config import RepeatToolConfig
+from openjiuwen.harness.agent_ras.models import (
+    Anomaly,
+    AnomalyKind,
+    Severity,
+    Signal,
+    SignalKind,
+)
+
+_TOOL_ARGUMENTS_MAX_LEN = 400
+
+
+@dataclass
+class ToolCallRecord:
+    """One completed (or failed) tool call kept in the per-session history."""
+
+    tool_name: str
+    args_hash: str
+    result_hash: str | None
+    timestamp: float
+    has_error: bool = False
+
+
+@dataclass
+class _PingPongResult:
+    count: int = 0
+    paired_tool: str | None = None
+    no_progress: bool = False
+
+
+class ToolResultErrorDetector:
+    """Infer tool-call failure from structured result fields (fix branch)."""
+
+    _ERROR_STATUSES = frozenset({"error", "failed", "failure"})
+    _EXIT_KEYS = ("exit_code", "exitCode", "returncode", "return_code")
+    _REPR_SUCCESS_FALSE = re.compile(r"^success\s*=\s*False\b", re.IGNORECASE)
+    _REPR_SUCCESS_TRUE = re.compile(r"^success\s*=\s*True\b", re.IGNORECASE)
+
+    @staticmethod
+    def has_error(value: Any) -> bool:
+        payload = ToolResultErrorDetector._normalize(value)
+        if payload is None:
+            return False
+        return ToolResultErrorDetector._dict_has_error(payload)
+
+    @staticmethod
+    def has_explicit_success(value: Any) -> bool:
+        payload = ToolResultErrorDetector._normalize(value)
+        if payload is None or "success" not in payload:
+            return False
+        return ToolResultErrorDetector._boolish_true(payload.get("success"))
+
+    @staticmethod
+    def signal_has_error(signal: Signal) -> bool:
+        if signal.error is not None:
+            return True
+        if signal.tool_msg_content is not None:
+            return ToolResultErrorDetector.has_error(signal.tool_msg_content)
+        return False
+
+    @staticmethod
+    def infer_record_has_error(tool_result: Any, signal: Signal) -> bool:
+        if ToolResultErrorDetector.has_error(tool_result):
+            return True
+        if ToolResultErrorDetector.has_explicit_success(tool_result):
+            return False
+        return ToolResultErrorDetector.signal_has_error(signal)
+
+    @staticmethod
+    def _normalize(value: Any) -> dict | None:
+        if value is None:
+            return None
+        if isinstance(value, dict):
+            return value
+        model_dump = getattr(value, "model_dump", None)
+        if callable(model_dump):
+            try:
+                dumped = model_dump()
+                if isinstance(dumped, dict):
+                    return dumped
+            except Exception:
+                logger.debug(
+                    "ToolResultErrorDetector model_dump failed",
+                    exc_info=True,
+                )
+        if hasattr(value, "success"):
+            return {
+                "success": getattr(value, "success", None),
+                "data": getattr(value, "data", None),
+                "error": getattr(value, "error", None),
+            }
+        if isinstance(value, str):
+            text = value.strip()
+            if not text:
+                return None
+            if text.startswith("{"):
+                try:
+                    parsed = json.loads(text)
+                except (TypeError, ValueError):
+                    parsed = None
+                if isinstance(parsed, dict):
+                    return parsed
+            if ToolResultErrorDetector._REPR_SUCCESS_FALSE.match(text):
+                return {"success": False}
+            if ToolResultErrorDetector._REPR_SUCCESS_TRUE.match(text):
+                return {"success": True}
+        return None
+
+    @staticmethod
+    def _dict_has_error(payload: dict, *, check_data: bool = True) -> bool:
+        if "success" in payload:
+            if ToolResultErrorDetector._boolish_false(payload.get("success")):
+                return True
+            if ToolResultErrorDetector._boolish_true(payload.get("success")):
+                return False
+        if (
+            ToolResultErrorDetector._boolish_true(payload.get("is_error"))
+            or ToolResultErrorDetector._boolish_true(payload.get("isError"))
+        ):
+            return True
+        status = payload.get("status")
+        if isinstance(status, str) and status.strip().lower() in ToolResultErrorDetector._ERROR_STATUSES:
+            return True
+        result_type = payload.get("result_type")
+        if isinstance(result_type, str) and result_type.strip().lower() == "error":
+            return True
+        err = payload.get("error")
+        if err is not None:
+            if isinstance(err, str):
+                if err.strip() and err.strip().lower() != "none":
+                    return True
+            elif err:
+                return True
+        for key in ToolResultErrorDetector._EXIT_KEYS:
+            code = payload.get(key)
+            if isinstance(code, int) and code != 0:
+                return True
+        if check_data:
+            data = payload.get("data")
+            if isinstance(data, dict) and ToolResultErrorDetector._dict_has_error(data, check_data=False):
+                return True
+        return False
+
+    @staticmethod
+    def _boolish_false(value: Any) -> bool:
+        if value is False:
+            return True
+        return isinstance(value, str) and value.strip().lower() in {"false", "0", "no"}
+
+    @staticmethod
+    def _boolish_true(value: Any) -> bool:
+        if value is True:
+            return True
+        return isinstance(value, str) and value.strip().lower() in {"true", "1", "yes"}
+
+
+def format_tool_arguments(params: Any, max_len: int = _TOOL_ARGUMENTS_MAX_LEN) -> str:
+    text = json.dumps(params or {}, sort_keys=True, default=str)
+    if len(text) > max_len:
+        return text[: max_len - 3] + "..."
+    return text
+
+
+class RepeatToolCallDetector:
+    """Detect repeated / looping tool calls (fix/circuit_breaker_recovery)."""
+
+    def __init__(self, config: RepeatToolConfig | None = None) -> None:
+        self._config = config or RepeatToolConfig()
+        self._histories: dict[str, deque[ToolCallRecord]] = {}
+        self._locks: dict[str, asyncio.Lock] = {}
+        self._last_emissions: dict[str, tuple[str, str, str]] = {}
+
+    @property
+    def name(self) -> str:
+        return "repeat_tool_call"
+
+    def reset(self) -> None:
+        self._histories.clear()
+        self._locks.clear()
+        self._last_emissions.clear()
+
+    def _history(self, sid: str) -> deque[ToolCallRecord]:
+        h = self._histories.get(sid)
+        if h is None:
+            h = deque(maxlen=self._config.history_size)
+            self._histories[sid] = h
+        return h
+
+    def _lock(self, sid: str) -> asyncio.Lock:
+        lock = self._locks.get(sid)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[sid] = lock
+        return lock
+
+    @staticmethod
+    def _resolve_sid(signal: Signal) -> str:
+        if signal.member_name:
+            return signal.member_name
+        return "default"
+
+    async def observe(self, signal: Signal) -> Anomaly | None:
+        if signal.kind not in (SignalKind.AFTER_TOOL_CALL, SignalKind.TOOL_EXCEPTION):
+            return None
+        if not signal.tool_name:
+            return None
+
+        sid = self._resolve_sid(signal)
+        tool_args = signal.tool_args or {}
+        args_hash = self._hash_args(signal.tool_name, tool_args)
+        result_hash = self._hash_outcome(signal.tool_result)
+        has_error = ToolResultErrorDetector.infer_record_has_error(
+            signal.tool_result,
+            signal,
+        )
+
+        async with self._lock(sid):
+            history = self._history(sid)
+            history.append(
+                ToolCallRecord(
+                    tool_name=signal.tool_name,
+                    args_hash=args_hash,
+                    result_hash=result_hash,
+                    timestamp=time.time(),
+                    has_error=has_error,
+                )
+            )
+            anomaly = self._detect(
+                list(history),
+                signal.member_name,
+                signal.tool_name,
+                args_hash,
+                tool_args,
+            )
+            if anomaly is None:
+                self._last_emissions.pop(sid, None)
+                return None
+            signature = (
+                anomaly.kind.value,
+                anomaly.severity.value,
+                str(anomaly.evidence.get("detector_kind") or ""),
+            )
+            if self._last_emissions.get(sid) == signature:
+                return None
+            self._last_emissions[sid] = signature
+            return anomaly
+
+    @staticmethod
+    def _hash_args(tool_name: str, params: dict) -> str:
+        canonical = json.dumps(params or {}, sort_keys=True, default=str)
+        return hashlib.sha256(f"{tool_name}:{canonical}".encode()).hexdigest()
+
+    @staticmethod
+    def _normalize_result(result: Any) -> dict:
+        if isinstance(result, dict):
+            return {
+                "content": str(result.get("content", "")).strip(),
+                "output": str(result.get("output", "")).strip(),
+                "error": str(result.get("error", "")).strip(),
+                "status": str(result.get("status", "")),
+            }
+        return {"raw": str(result)}
+
+    @staticmethod
+    def _hash_outcome(result: Any) -> str | None:
+        if result is None:
+            return None
+        normalized = RepeatToolCallDetector._normalize_result(result)
+        return hashlib.sha256(
+            json.dumps(normalized, sort_keys=True, default=str).encode()
+        ).hexdigest()
+
+    def _detect(
+        self,
+        history: list[ToolCallRecord],
+        member_name: str,
+        tool_name: str,
+        args_hash: str,
+        tool_args: dict[str, Any],
+    ) -> Anomaly | None:
+        cfg = self._config
+        tool_arguments = format_tool_arguments(tool_args)
+
+        no_progress = self._get_no_progress_streak(history, tool_name, args_hash)
+        if no_progress >= cfg.global_breaker_threshold:
+            return self._build(
+                AnomalyKind.TOOL_CALL_LOOP,
+                Severity.CRITICAL,
+                member_name,
+                tool_name,
+                {
+                    "detector_kind": "global_circuit_breaker",
+                    "msg_key": "global_circuit_breaker",
+                    "count": no_progress,
+                    "tool_arguments": tool_arguments,
+                },
+            )
+
+        unknown_streak = self._get_unknown_tool_streak(history, tool_name)
+        unknown_critical = self._unknown_tool_critical_threshold(cfg)
+        unknown_warning = self._unknown_tool_warning_threshold(cfg)
+        if unknown_streak >= unknown_critical:
+            return self._build(
+                AnomalyKind.REPEAT_TOOL_CALL,
+                Severity.CRITICAL,
+                member_name,
+                tool_name,
+                {
+                    "detector_kind": "unknown_tool_repeat",
+                    "msg_key": "unknown_tool_repeat",
+                    "count": unknown_streak,
+                    "tool_arguments": tool_arguments,
+                },
+            )
+        if unknown_streak >= unknown_warning:
+            return self._build(
+                AnomalyKind.REPEAT_TOOL_CALL,
+                Severity.LOW,
+                member_name,
+                tool_name,
+                {
+                    "detector_kind": "unknown_tool_repeat",
+                    "msg_key": "unknown_tool_repeat_warning",
+                    "count": unknown_streak,
+                    "tool_arguments": tool_arguments,
+                },
+            )
+
+        ping_pong = self._get_ping_pong_streak(history, args_hash)
+        if ping_pong.count >= cfg.critical_threshold and ping_pong.no_progress:
+            return self._build(
+                AnomalyKind.TOOL_CALL_LOOP,
+                Severity.CRITICAL,
+                member_name,
+                tool_name,
+                {
+                    "detector_kind": "ping_pong",
+                    "msg_key": "ping_pong_critical",
+                    "count": ping_pong.count,
+                    "paired_tool": ping_pong.paired_tool,
+                    "tool_arguments": tool_arguments,
+                },
+            )
+        if ping_pong.count >= cfg.warning_threshold:
+            return self._build(
+                AnomalyKind.TOOL_CALL_LOOP,
+                Severity.LOW,
+                member_name,
+                tool_name,
+                {
+                    "detector_kind": "ping_pong",
+                    "msg_key": "ping_pong_warning",
+                    "count": ping_pong.count,
+                    "paired_tool": ping_pong.paired_tool,
+                    "tool_arguments": tool_arguments,
+                },
+            )
+
+        recent = self._count_recent_same(history, tool_name, args_hash)
+        if recent >= cfg.warning_threshold:
+            return self._build(
+                AnomalyKind.REPEAT_TOOL_CALL,
+                Severity.LOW,
+                member_name,
+                tool_name,
+                {
+                    "detector_kind": "generic_repeat",
+                    "msg_key": "generic_repeat",
+                    "count": recent,
+                    "tool_arguments": tool_arguments,
+                },
+            )
+
+        return None
+
+    @staticmethod
+    def _build(
+        kind: AnomalyKind,
+        severity: Severity,
+        member_name: str,
+        tool_name: str,
+        evidence: dict[str, Any],
+    ) -> Anomaly:
+        return Anomaly(
+            detector="repeat_tool_call",
+            kind=kind,
+            severity=severity,
+            member_name=member_name,
+            summary=f"{kind.value} on {tool_name}",
+            evidence=evidence,
+        )
+
+    @staticmethod
+    def _unknown_tool_warning_threshold(cfg: RepeatToolConfig) -> int:
+        return max(1, cfg.unknown_tool_threshold // 2)
+
+    @staticmethod
+    def _unknown_tool_critical_threshold(cfg: RepeatToolConfig) -> int:
+        if cfg.unknown_tool_threshold == cfg.warning_threshold:
+            return cfg.unknown_tool_threshold + 1
+        return cfg.unknown_tool_threshold
+
+    @staticmethod
+    def _get_no_progress_streak(
+        history: list[ToolCallRecord],
+        tool_name: str,
+        args_hash: str,
+    ) -> int:
+        streak = 0
+        latest_hash: str | None = None
+        for record in reversed(history):
+            if record.tool_name != tool_name or record.args_hash != args_hash:
+                break
+            if record.result_hash is None:
+                break
+            if latest_hash is None:
+                latest_hash = record.result_hash
+                streak = 1
+            elif record.result_hash == latest_hash:
+                streak += 1
+            else:
+                break
+        return streak
+
+    @staticmethod
+    def _side_outputs_stable(records: list[ToolCallRecord]) -> bool:
+        hashes = [r.result_hash for r in records if r.result_hash is not None]
+        if len(hashes) != len(records) or not hashes:
+            return False
+        return all(h == hashes[0] for h in hashes)
+
+    @staticmethod
+    def _collect_alternating_streak(
+        history: list[ToolCallRecord],
+    ) -> tuple[list[ToolCallRecord], str | None]:
+        if len(history) < 2:
+            return [], None
+        last_hash = history[-1].args_hash
+        other_hash: str | None = None
+        other_name: str | None = None
+        for record in reversed(history[:-1]):
+            if record.args_hash != last_hash:
+                other_hash = record.args_hash
+                other_name = record.tool_name
+                break
+        if other_hash is None:
+            return [], None
+
+        streak_rev = [history[-1]]
+        expect = other_hash
+        for record in reversed(history[:-1]):
+            if record.args_hash != expect:
+                break
+            streak_rev.append(record)
+            expect = last_hash if expect == other_hash else other_hash
+        streak_rev.reverse()
+        return streak_rev, other_name
+
+    def _get_ping_pong_streak(
+        self,
+        history: list[ToolCallRecord],
+        _current_args_hash: str,
+    ) -> _PingPongResult:
+        streak, paired_tool = self._collect_alternating_streak(history)
+        if len(streak) < 2:
+            return _PingPongResult()
+
+        count = len(streak) // 2
+        hash_last = streak[-1].args_hash
+        hash_other = next(r.args_hash for r in streak if r.args_hash != hash_last)
+
+        side_last = [r for r in streak if r.args_hash == hash_last]
+        side_other = [r for r in streak if r.args_hash == hash_other]
+
+        no_progress = (
+            len(side_last) >= 2
+            and len(side_other) >= 2
+            and self._side_outputs_stable(side_last)
+            and self._side_outputs_stable(side_other)
+        )
+
+        return _PingPongResult(
+            count=count,
+            paired_tool=paired_tool,
+            no_progress=no_progress,
+        )
+
+    @staticmethod
+    def _count_recent_same(
+        history: list[ToolCallRecord],
+        tool_name: str,
+        args_hash: str,
+    ) -> int:
+        count = 0
+        for record in reversed(history):
+            if record.tool_name != tool_name or record.args_hash != args_hash:
+                break
+            count += 1
+        return count
+
+    @staticmethod
+    def _get_unknown_tool_streak(
+        history: list[ToolCallRecord],
+        tool_name: str,
+    ) -> int:
+        streak = 0
+        for record in reversed(history):
+            if record.tool_name != tool_name:
+                break
+            if not record.has_error:
+                break
+            streak += 1
+        return streak

--- a/openjiuwen/harness/agent_ras/detectors/skill_verdicts.py
+++ b/openjiuwen/harness/agent_ras/detectors/skill_verdicts.py
@@ -1,0 +1,188 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Structured skill output schemas and parsers (detector layer)."""
+from __future__ import annotations
+
+import json
+import re
+from enum import Enum
+from typing import Any, Callable
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class ThinkingLoopFault(str, Enum):
+    """Primary fault types for llm-loop-detection."""
+
+    NONE = "none"
+    SEMANTIC_DEADLOCK = "semantic_deadlock"
+    TEXT_DEGRADATION = "text_degradation"
+    OVERTHINKING = "overthinking"
+
+
+class SkillVerdict(BaseModel):
+    """Base structured skill result."""
+
+    abnormal: bool = False
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+    rationale: str = ""
+    raw: dict[str, Any] = Field(default_factory=dict)
+    # Non-empty when parser rejected input and returned fail-open normal.
+    fail_open_reason: str = ""
+
+
+class LlmLoopDetectionVerdict(SkillVerdict):
+    """Verdict for llm-loop-detection skill."""
+
+    primary_fault: ThinkingLoopFault = ThinkingLoopFault.NONE
+
+    @field_validator("primary_fault", mode="before")
+    @classmethod
+    def _coerce_fault(cls, value: Any) -> ThinkingLoopFault:
+        if isinstance(value, ThinkingLoopFault):
+            return value
+        text = str(value or "").strip().lower()
+        try:
+            return ThinkingLoopFault(text)
+        except ValueError as e:
+            raise ValueError(f"unknown primary_fault: {value!r}") from e
+
+    def model_post_init(self, __context: Any) -> None:
+        if self.fail_open_reason:
+            return
+        abnormal = self.abnormal
+        fault_abnormal = self.primary_fault != ThinkingLoopFault.NONE
+        if abnormal != fault_abnormal:
+            raise ValueError(
+                f"abnormal ({abnormal}) inconsistent with primary_fault ({self.primary_fault})"
+            )
+
+
+def extract_json_object_from_text(raw: str) -> dict[str, Any] | None:
+    """Parse a JSON object from agent output (bare JSON or ```json fence)."""
+    text = str(raw or "").strip()
+    if not text:
+        return None
+    match = re.search(r"```json\s*(.*?)\s*```", text, re.DOTALL)
+    if match:
+        json_str = match.group(1)
+    elif text.startswith("{") and text.endswith("}"):
+        json_str = text
+    else:
+        obj_match = re.search(r"\{.*\}", text, re.DOTALL)
+        if not obj_match:
+            return None
+        json_str = obj_match.group(0)
+    try:
+        parsed = json.loads(json_str)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def extract_invoke_output_payload(result: Any) -> dict[str, Any] | None:
+    """Extract structured JSON from a DeepAgent invoke result (auto_harness style)."""
+    if isinstance(result, dict):
+        output = result.get("output")
+        if isinstance(output, str) and output.strip():
+            return extract_json_object_from_text(output)
+        return extract_report_payload(result)
+    if isinstance(result, str):
+        return extract_json_object_from_text(result) or extract_report_payload(result)
+    return None
+
+
+def extract_report_payload(raw: str | dict[str, Any]) -> dict[str, Any] | None:
+    """Extract a JSON object from skill_complete report or top-level payload."""
+    if isinstance(raw, dict):
+        data: dict[str, Any] = raw
+        for key in ("report", "response", "text", "content"):
+            val = data.get(key)
+            if isinstance(val, dict):
+                return val
+            if isinstance(val, str) and val.strip():
+                try:
+                    parsed = json.loads(val.strip())
+                    if isinstance(parsed, dict):
+                        return parsed
+                except (json.JSONDecodeError, TypeError):
+                    continue
+        return data if data else None
+
+    text = str(raw or "").strip()
+    if not text:
+        return None
+    fenced = extract_json_object_from_text(text)
+    if fenced is not None:
+        return fenced
+    try:
+        parsed = json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def fail_open_verdict(reason: str = "invalid_or_empty") -> LlmLoopDetectionVerdict:
+    return LlmLoopDetectionVerdict(
+        abnormal=False,
+        primary_fault=ThinkingLoopFault.NONE,
+        confidence=0.0,
+        rationale="",
+        raw={},
+        fail_open_reason=reason,
+    )
+
+
+def parse_llm_loop_verdict(raw: str | dict[str, Any]) -> LlmLoopDetectionVerdict:
+    """Parse llm-loop-detection output; invalid or legacy formats fail-open."""
+    payload = extract_report_payload(raw)
+    if payload is None:
+        return fail_open_verdict("unparseable_payload")
+
+    required = {"abnormal", "primary_fault"}
+    if not required.issubset(payload.keys()):
+        return fail_open_verdict("missing_required_fields")
+
+    try:
+        verdict = LlmLoopDetectionVerdict(
+            abnormal=bool(payload.get("abnormal")),
+            primary_fault=payload.get("primary_fault"),
+            confidence=float(payload.get("confidence") or 0.0),
+            rationale=str(payload.get("rationale") or ""),
+            raw=dict(payload),
+        )
+    except (ValueError, TypeError):
+        return fail_open_verdict("schema_validation_failed")
+
+    if verdict.primary_fault != ThinkingLoopFault.NONE and not verdict.abnormal:
+        return fail_open_verdict("abnormal_primary_fault_inconsistent")
+    return verdict
+
+
+SKILL_VERDICT_PARSERS: dict[str, Callable[[str | dict[str, Any]], SkillVerdict]] = {
+    "llm-loop-detection": parse_llm_loop_verdict,
+    "llm-loop-review": parse_llm_loop_verdict,
+}
+
+
+def parse_skill_verdict(skill_name: str, raw: str | dict[str, Any]) -> SkillVerdict:
+    parser = SKILL_VERDICT_PARSERS.get(skill_name)
+    if parser is None:
+        return fail_open_verdict("unknown_skill")
+    return parser(raw)
+
+
+def verdict_to_dict(verdict: SkillVerdict) -> dict[str, Any]:
+    """Serialize a verdict for adapter/detector consumption."""
+    data: dict[str, Any] = {
+        "abnormal": verdict.abnormal,
+        "confidence": verdict.confidence,
+        "rationale": verdict.rationale,
+    }
+    if verdict.fail_open_reason:
+        data["fail_open_reason"] = verdict.fail_open_reason
+    if isinstance(verdict, LlmLoopDetectionVerdict):
+        data["primary_fault"] = verdict.primary_fault.value
+    if verdict.raw:
+        data.update({k: v for k, v in verdict.raw.items() if k not in data})
+    return data

--- a/openjiuwen/harness/agent_ras/detectors/skills/llm-loop-detection/SKILL.md
+++ b/openjiuwen/harness/agent_ras/detectors/skills/llm-loop-detection/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: llm-loop-detection
+description: Plan-execution semantic judge for LLM thinking-loop faults (PR#3102 L3).
+---
+
+# LLM 思考循环语义判定（Plan-Execution Judge）
+
+你是思考循环检测器。以下片段来自助手的长推理流（增量截取）。
+请识别是否存在异常，并选出**唯一**的 `primary_fault` 类型。
+
+## 故障类型（primary_fault）
+
+### semantic_deadlock（语义死锁）
+
+- 对同一批对象/选项/来源/条件反复权衡，换说法但结论不前进
+- 「等一下」「再看看」「不对」后重新回到旧论点或旧分析路径
+- 同一段分析逻辑在片段内重复出现（即使措辞不同）
+- 长时间纠结却无法选定下一步或给出阶段性结论
+
+### text_degradation（文本崩坏）
+
+- 语句明显不连续：前后句断裂、半句话拼接、词组被截断后硬接另一段内容
+- 出现乱码或粘连：字符错位、无意义混排、URL/词语/数字被撕碎后交叉拼接
+- 同一位置反复出现残缺片段，或可读性与语法大面积崩坏
+- 逻辑跳跃严重，推理链条难以跟随
+
+### overthinking（过度思考）
+
+- 推理冗长、反复自我质疑，但仍有微弱推进迹象
+- 大量铺垫与重复论证，迟迟不收敛到下一步或结论
+- 审慎复核本身不算异常；只有「纠结占主导、推进极慢」才判 overthinking
+
+### none（正常）
+
+- 推理在引入新信息、缩小选项、或明确向答案推进
+- 偶发笔误或轻微口癖不算异常
+
+## 互斥与优先级
+
+若多种信号并存，**只选一个** `primary_fault`，按优先级：
+
+1. `text_degradation`（可读性/安全优先）
+2. `semantic_deadlock`
+3. `overthinking`
+4. 否则 `none`
+
+## 触发规则
+
+- `primary_fault != "none"` 时，必须设 `abnormal: true`
+- `primary_fault == "none"` 时，必须设 `abnormal: false`
+- `abnormal` 与 `primary_fault` 必须一致，否则视为无效输出
+
+## 输出格式（强制）
+
+加载本 Skill 并完成判定后，**最终 assistant 回复必须且只能是一个 JSON 对象**（可裸 JSON，或用 \`\`\`json 代码块包裹）。
+禁止在回复中加入解释性文字、Markdown 标题或其他非 JSON 内容。
+禁止 `excerpts[]`、`loop_detected`、`degeneration_detected`、`is_dead_loop` 等旧字段。
+
+**禁止**使用 `skill_complete` 的 `report` 参数传递判定结果（`report` 在本项目中是用户可见文案，不是 verdict 通道）。
+**禁止**调用 `skill_complete`（detection 为短任务成员，判定 JSON 必须是最后一轮 assistant 的纯文本回复，不得附带任何 tool_call）。
+
+字段说明：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `abnormal` | boolean | 是 | 是否异常 |
+| `primary_fault` | string | 是 | `none` / `semantic_deadlock` / `text_degradation` / `overthinking` |
+| `confidence` | number | 否 | 0.0–1.0 |
+| `rationale` | string | 否 | 简短判定理由 |
+
+示例（文本崩坏）：
+
+```json
+{
+  "abnormal": true,
+  "primary_fault": "text_degradation",
+  "confidence": 0.85,
+  "rationale": "URL/词语被撕碎交叉拼接，推理链不可读"
+}
+```
+
+示例（正常）：
+
+```json
+{
+  "abnormal": false,
+  "primary_fault": "none",
+  "confidence": 0.9,
+  "rationale": "在推进任务，偶发复核但结论在前进"
+}
+```
+
+思考片段：
+{excerpt}

--- a/openjiuwen/harness/agent_ras/factory.py
+++ b/openjiuwen/harness/agent_ras/factory.py
@@ -1,0 +1,185 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Agent RAS composition helpers for the single-Agent in-process path.
+
+``build_agent_ras_rail`` installs a ``monitor_factory`` so each invoke gets an
+``AgentRASMonitor`` keyed by session id (detectors + executor state). The rail
+drops that monitor in ``after_invoke``; HITL resume state stays on session.state.
+"""
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+from openjiuwen.core.foundation.llm.model import Model
+from openjiuwen.harness.agent_ras.agents.base import AgentAdapter, NoOpAgentAdapter
+from openjiuwen.harness.agent_ras.agents.deep_agent_adapter import (
+    DeepAgentAdapter,
+    adapter_config_from_agent_ras,
+)
+from openjiuwen.harness.agent_ras.agents.ras_agents import RASAgents
+from openjiuwen.harness.agent_ras.config import AgentRASConfig
+from openjiuwen.harness.agent_ras.detectors.base import Detector
+from openjiuwen.harness.agent_ras.detectors.llm_thinking_loop import LlmThinkingLoopDetector
+from openjiuwen.harness.agent_ras.detectors.repeat_tool import RepeatToolCallDetector
+from openjiuwen.harness.agent_ras.monitor import AgentRASMonitor
+from openjiuwen.harness.rails.agent_ras_rail import AgentRASRail
+from openjiuwen.harness.agent_ras.recovery.engine import (
+    LocalAutoRecovery,
+    RecoveryExecutor,
+    RecoveryPolicy,
+)
+from openjiuwen.harness.agent_ras.reporter import AnomalyReporter
+
+
+def build_agent_adapter(
+    config: AgentRASConfig,
+    invoke_fn: Optional[Any] = None,
+    model: Optional[Model] = None,
+) -> AgentAdapter:
+    """Build the default semantic AgentAdapter."""
+    adapter_cfg = adapter_config_from_agent_ras(config)
+    if invoke_fn is not None:
+        return DeepAgentAdapter(cfg=adapter_cfg, invoke_fn=invoke_fn)
+    if model is not None:
+        return DeepAgentAdapter(cfg=adapter_cfg, model=model)
+    return NoOpAgentAdapter()
+
+
+def _build_repeat_tool(
+    config: AgentRASConfig,
+    agents: RASAgents,
+) -> Detector | None:
+    if not config.detectors.repeat_tool.enabled:
+        return None
+    return RepeatToolCallDetector(config.detectors.repeat_tool)
+
+
+def _build_llm_thinking_loop(
+    config: AgentRASConfig,
+    agents: RASAgents,
+) -> Detector | None:
+    if not config.detectors.llm_thinking_loop.enabled:
+        return None
+    return LlmThinkingLoopDetector(
+        config.detectors.llm_thinking_loop,
+        agents=agents,
+    )
+
+
+DETECTOR_BUILDERS: list[
+    tuple[str, Callable[[AgentRASConfig, RASAgents], Detector | None]]
+] = [
+    ("repeat_tool", _build_repeat_tool),
+    ("llm_thinking_loop", _build_llm_thinking_loop),
+]
+
+
+def build_member_detectors(
+    config: AgentRASConfig,
+    agents: RASAgents | None = None,
+) -> list[Detector]:
+    """Build enabled detectors via the registry."""
+    agents = agents or RASAgents(NoOpAgentAdapter())
+    detectors: list[Detector] = []
+    for _name, build in DETECTOR_BUILDERS:
+        detector = build(config, agents)
+        if detector is not None:
+            detectors.append(detector)
+    return detectors
+
+
+def _build_policy(config: AgentRASConfig) -> RecoveryPolicy:
+    return RecoveryPolicy.from_config(config.policy)
+
+
+def build_agent_ras_components(
+    config: AgentRASConfig,
+    agents: RASAgents | None = None,
+    invoke_fn: Optional[Any] = None,
+    model: Optional[Model] = None,
+    *,
+    reporter: AnomalyReporter | None = None,
+) -> tuple[
+    list[Detector],
+    AnomalyReporter | None,
+    RecoveryPolicy,
+    LocalAutoRecovery,
+    RecoveryExecutor,
+]:
+    """Assemble detectors, policy, auto-recovery, and executor for one Monitor.
+
+    Single-Agent path leaves ``reporter`` as None unless a host injects a sink.
+    """
+    if agents is None:
+        adapter = build_agent_adapter(config, invoke_fn=invoke_fn, model=model)
+        agents = RASAgents(adapter)
+    policy = _build_policy(config)
+    detectors = build_member_detectors(config, agents=agents)
+    auto = LocalAutoRecovery(policy)
+    executor = RecoveryExecutor(
+        auto,
+        notify_user_on_warning=config.recovery.notify_user_on_warning,
+    )
+    return detectors, reporter, policy, auto, executor
+
+
+def build_agent_ras_rail(
+    config: AgentRASConfig,
+    member_name: str,
+    invoke_fn: Optional[Any] = None,
+    model: Optional[Model] = None,
+    *,
+    session_id: str = "",
+    agents: RASAgents | None = None,
+    reporter: AnomalyReporter | None = None,
+    reporter_factory: Callable[[str], AnomalyReporter | None] | None = None,
+) -> AgentRASRail:
+    """Build an ``AgentRASRail`` with an invoke-scoped Monitor factory.
+
+    Each active session id gets an isolated suppress/recovery executor for that
+    invoke; the rail drops the monitor in ``after_invoke``. The shared
+    ``RASAgents`` instance is injected into every Monitor so L3 detection and
+    the recovery Reviewer reuse the same skill members. Message language
+    follows DeepAgent at runtime (see ``AgentRASRail.init``).
+
+    Optional ``reporter`` / ``reporter_factory`` let hosts inject a per-session
+    anomaly sink without duplicating recovery wiring. ``reporter_factory`` wins
+    when provided; it receives the runtime session id.
+    Optional ``agents`` reuses a shared ``RASAgents`` instance across sessions.
+    """
+    if agents is None:
+        adapter = build_agent_adapter(config, invoke_fn=invoke_fn, model=model)
+        agents = RASAgents(adapter)
+
+    def monitor_factory(runtime_session_id: str) -> AgentRASMonitor:
+        """Construct detectors, policy, and executor for one session id."""
+        sink = (
+            reporter_factory(runtime_session_id or session_id)
+            if reporter_factory is not None
+            else reporter
+        )
+        detectors, bound_reporter, policy, _auto, executor = build_agent_ras_components(
+            config=config,
+            agents=agents,
+            invoke_fn=invoke_fn,
+            model=model,
+            reporter=sink,
+        )
+        return AgentRASMonitor(
+            detectors=detectors,
+            reporter=bound_reporter,
+            policy=policy,
+            agent_id=member_name,
+            session_id=runtime_session_id or session_id,
+            agents=agents,
+            config=config,
+            executor=executor,
+            member_name=member_name,
+        )
+
+    return AgentRASRail(
+        monitor_factory=monitor_factory,
+        member_name=member_name,
+        agents=agents,
+        config=config,
+    )

--- a/openjiuwen/harness/agent_ras/models.py
+++ b/openjiuwen/harness/agent_ras/models.py
@@ -1,0 +1,150 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Agent RAS data models: anomalies, signals, and monitor events."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class Severity(str, Enum):
+    """Anomaly severity, ordered low to high."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class AnomalyKind(str, Enum):
+    """The kind of unhealthy behavior a detector identified."""
+
+    REPEAT_TOOL_CALL = "repeat_tool_call"
+    TOOL_CALL_LOOP = "tool_call_loop"
+    LLM_THINKING_LOOP = "llm_thinking_loop"
+    LLM_THINKING_DEAD_LOOP = "llm_thinking_dead_loop"
+
+
+class Anomaly(BaseModel):
+    """A detected unhealthy condition awaiting remediation."""
+
+    detector: str = Field(..., description="Detector identifier")
+    kind: AnomalyKind = Field(..., description="Anomaly category")
+    severity: Severity = Field(..., description="Severity level")
+    member_name: str = Field(..., description="Affected member")
+    summary: str = Field(..., description="One-line description for human/LLM")
+    evidence: dict[str, Any] = Field(default_factory=dict)
+    timestamp: int = Field(default=0, description="Millisecond Unix epoch when emitted")
+
+
+class SignalKind(str, Enum):
+    """Lifecycle point a signal was captured at."""
+
+    BEFORE_TOOL_CALL = "before_tool_call"
+    AFTER_TOOL_CALL = "after_tool_call"
+    TOOL_EXCEPTION = "tool_exception"
+    MODEL_EXCEPTION = "model_exception"
+    AFTER_MODEL_CALL = "after_model_call"
+    BEFORE_MODEL_CALL = "before_model_call"
+    STREAM_CHUNK = "stream_chunk"
+    INVOKE_RESET = "invoke_reset"
+
+
+@dataclass(slots=True)
+class Signal:
+    """One observation captured at a lifecycle point."""
+
+    kind: SignalKind
+    member_name: str
+    tool_name: str | None = None
+    tool_args: Any | None = None
+    error: str | None = None
+    text_len: int | None = None
+    thinking_len: int | None = None
+    message_count: int | None = None
+    tool_result: Any | None = None
+    tool_msg_content: str | None = None
+    chunk_type: str | None = None
+    chunk_text: str | None = None
+
+    def to_dict(
+        self,
+        *,
+        tool_result_max_bytes: int = 512,
+    ) -> dict[str, Any]:
+        """Serialize the signal without changing framework-visible values."""
+        from openjiuwen.harness.agent_ras.window import stable_result_hash
+
+        payload: dict[str, Any] = {
+            "kind": self.kind.value,
+            "member_name": self.member_name,
+        }
+        optional_fields = (
+            "tool_name",
+            "tool_args",
+            "error",
+            "text_len",
+            "thinking_len",
+            "message_count",
+            "tool_msg_content",
+            "chunk_type",
+            "chunk_text",
+        )
+        for field in optional_fields:
+            value = getattr(self, field, None)
+            if value is not None:
+                payload[field] = value
+        if self.tool_result is not None:
+            payload["tool_result_hash"] = stable_result_hash(self.tool_result)
+            payload["result_preview"] = str(self.tool_result)[:tool_result_max_bytes]
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Signal":
+        """Deserialize a dict produced by ``to_dict``."""
+        kind_raw = data.get("kind")
+        if isinstance(kind_raw, SignalKind):
+            kind = kind_raw
+        else:
+            kind = SignalKind(str(kind_raw))
+        tool_result = data.get("tool_result")
+        if tool_result is None and data.get("tool_result_hash") is not None:
+            tool_result = data["tool_result_hash"]
+        return cls(
+            kind=kind,
+            member_name=str(data.get("member_name") or ""),
+            tool_name=data.get("tool_name"),
+            tool_args=data.get("tool_args"),
+            error=data.get("error"),
+            text_len=data.get("text_len"),
+            thinking_len=data.get("thinking_len"),
+            message_count=data.get("message_count"),
+            tool_result=tool_result,
+            tool_msg_content=data.get("tool_msg_content"),
+            chunk_type=data.get("chunk_type"),
+            chunk_text=data.get("chunk_text"),
+        )
+
+
+EventType = Literal[
+    "anomaly",
+    "recovery_action",
+    "metric_update",
+    "stream_chunk",
+    "stream_truncated",
+]
+
+
+class AgentRASMonitorEvent(BaseModel):
+    """One in-process Agent RAS event."""
+
+    event_type: EventType = Field(..., description="Event type literal")
+    timestamp: int = Field(..., description="Millisecond Unix epoch")
+    agent_id: str = Field(..., description="Owning agent")
+    session_id: str = Field(..., description="Owning session")
+    anomaly: Optional[Anomaly] = Field(default=None)
+    action: Optional[str] = Field(default=None)
+    payload: dict[str, Any] = Field(default_factory=dict)

--- a/openjiuwen/harness/agent_ras/monitor.py
+++ b/openjiuwen/harness/agent_ras/monitor.py
@@ -1,0 +1,1030 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Session-scoped Agent RAS monitor: detection and recovery orchestration.
+
+Called by :class:`AgentRASRail`. Owns detectors, optional anomaly reporter,
+recovery policy/executor, stream suppress state, and automatic stream recovery
+(L1/L2 immediate abort; L3 Reviewer second-opinion with fail-open). Atomic side
+effects live in ``recovery.operations``; kind→ops mapping in ``recovery.engine``.
+Monitor does not import ``robustness_prompt`` directly.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from collections import deque
+from typing import Any, AsyncIterator, Optional
+
+from openjiuwen.core.common.logging import logger
+from openjiuwen.core.single_agent.rail.base import AgentCallbackContext
+from openjiuwen.harness.agent_ras.config import AgentRASConfig
+from openjiuwen.harness.agent_ras.agents.base import (
+    ASYNC_RECOVERY_TIMEOUT_SECONDS,
+    FAULT_DOMAIN_LLM_THINKING_LOOP,
+    SKILL_TIMEOUT_SECONDS,
+    skill_for,
+)
+from openjiuwen.harness.agent_ras.detectors.base import (
+    AsyncRecoveryHandler,
+    is_async_recovery_detector,
+)
+from openjiuwen.harness.agent_ras.models import (
+    AgentRASMonitorEvent,
+    Anomaly,
+    Signal,
+    SignalKind,
+)
+from openjiuwen.harness.agent_ras.recovery.engine import (
+    RecoveryAction,
+    RecoveryExecutor,
+    RecoveryPolicy,
+    StreamRecoveryArgs,
+    needs_immediate_apply,
+)
+from openjiuwen.harness.agent_ras.detectors.skill_verdicts import parse_skill_verdict
+from openjiuwen.harness.agent_ras.recovery.operations import (
+    apply_recovery_abnormal,
+    apply_recovery_normal,
+    emit_user_notice,
+    suppress_and_buffer,
+)
+from openjiuwen.harness.agent_ras.recovery.state import PendingRecovery
+from openjiuwen.harness.agent_ras.reporter import AnomalyReporter
+
+
+def _async_recovery_still_in_flight(detector: Any) -> bool:
+    checker = getattr(detector, "has_async_recovery_in_flight", None)
+    if not callable(checker):
+        return False
+    try:
+        return bool(checker())
+    except Exception:
+        return False
+
+
+def _release_async_recovery_detectors(detectors: list[Any]) -> None:
+    """Call ``release_async_recovery`` on every async-capable detector."""
+    for detector in detectors:
+        if not is_async_recovery_detector(detector):
+            continue
+        try:
+            detector.release_async_recovery()
+        except Exception:
+            logger.warning(
+                "Agent RAS release_async_recovery failed detector=%s",
+                getattr(detector, "name", type(detector).__name__),
+                exc_info=True,
+            )
+
+
+def _wire_async_recovery_handlers(
+    detectors: list[Any],
+    handler: AsyncRecoveryHandler | None,
+) -> None:
+    """Set the Monitor completion handler on detectors that expose the setter."""
+    for detector in detectors:
+        setter = getattr(detector, "set_async_recovery_handler", None)
+        if callable(setter):
+            setter(handler)
+
+
+async def _await_async_recovery_detectors(
+    detectors: list[Any],
+    timeout: float,
+) -> bool:
+    """Wait for async detectors; return True if work remained after timeout."""
+    if timeout <= 0:
+        return False
+    deadline = time.monotonic() + timeout
+    timed_out = False
+    for detector in detectors:
+        if not is_async_recovery_detector(detector):
+            continue
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            timed_out = True
+            break
+        try:
+            await detector.await_async_recovery(remaining)
+        except Exception:
+            logger.warning(
+                "Agent RAS await_async_recovery failed detector=%s",
+                getattr(detector, "name", type(detector).__name__),
+                exc_info=True,
+            )
+        if _async_recovery_still_in_flight(detector):
+            timed_out = True
+            break
+
+    if timed_out or any(
+        _async_recovery_still_in_flight(detector)
+        for detector in detectors
+        if is_async_recovery_detector(detector)
+    ):
+        logger.warning(
+            "[async_recovery] timed out waiting for detectors; releasing in-flight state",
+        )
+        _release_async_recovery_detectors(detectors)
+        return True
+    return False
+
+
+class RingBuffer:
+    """In-process anomaly event history (newest-first via ``recent``).
+
+    Used for metrics/debug only — not part of suppress/recovery state.
+    """
+
+    def __init__(self, capacity: int = 10000) -> None:
+        if capacity <= 0:
+            raise ValueError(f"capacity must be > 0, got {capacity}")
+        self._capacity = capacity
+        self._events: deque[Any] = deque(maxlen=capacity)
+        self._lock = asyncio.Lock()
+
+    @property
+    def capacity(self) -> int:
+        return self._capacity
+
+    def size(self) -> int:
+        """Return the number of buffered events."""
+        return len(self._events)
+
+    async def append(self, event: Any) -> None:
+        """Append one event (drops oldest when full)."""
+        async with self._lock:
+            self._events.append(event)
+
+    async def recent(self, n: int) -> list[Any]:
+        """Return up to ``n`` newest events (newest first)."""
+        if n <= 0:
+            return []
+        async with self._lock:
+            count = min(n, len(self._events))
+            if count == 0:
+                return []
+            return list(reversed(list(self._events)[-count:]))
+
+    def clear(self) -> None:
+        """Drop all buffered events."""
+        self._events.clear()
+
+
+class AgentRASMonitor:
+    """Per-session detection + recovery orchestrator.
+
+    Typical rail path: ``handle`` = ``detection`` then immediate ``recovery``.
+    Stream path: ``on_stream_chunk`` may suppress output and arm automatic
+    recovery (L1/L2 abort immediately; L3 starts a Reviewer background task).
+    """
+
+    _EVENT_STREAM_END: Any = object()
+
+    def __init__(
+        self,
+        detectors: list[Any],
+        reporter: AnomalyReporter | None,
+        policy: RecoveryPolicy,
+        agent_id: str = "agent",
+        session_id: str = "session",
+        ring_buffer_capacity: int = 10000,
+        *,
+        agents: Any = None,
+        config: AgentRASConfig | None = None,
+        executor: RecoveryExecutor | None = None,
+        member_name: str | None = None,
+    ) -> None:
+        self._detectors = list(detectors)
+        self._reporter = reporter
+        self._policy = policy
+        self._agent_id = agent_id
+        self._session_id = session_id
+        self._agents = agents
+        self._config = config or AgentRASConfig()
+        self._executor = executor
+        self._member = member_name or agent_id
+        self._ring = RingBuffer(capacity=ring_buffer_capacity)
+        self._started = False
+        self._stopped = False
+        self._invoke_count = 0
+        self._anomaly_count = 0
+        self._recovery_count = 0
+        self._detect_durations_ms: deque[float] = deque(maxlen=2048)
+        self._subscribers: set[asyncio.Queue] = set()
+        self._active_ctx: AgentCallbackContext | None = None
+        self._review_task: asyncio.Task | None = None
+        self._abnormal_committed = False
+        self._notice_emitted_immediate: str | None = None
+        self._language = "cn"
+
+    @property
+    def started(self) -> bool:
+        return self._started
+
+    @property
+    def stopped(self) -> bool:
+        return self._stopped
+
+    @property
+    def agent_id(self) -> str:
+        return self._agent_id
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+    @property
+    def agents(self) -> Any:
+        return self._agents
+
+    @property
+    def config(self) -> AgentRASConfig:
+        return self._config
+
+    @property
+    def member_name(self) -> str:
+        return self._member
+
+    @property
+    def executor(self) -> RecoveryExecutor | None:
+        return self._executor
+
+    @property
+    def policy(self) -> RecoveryPolicy:
+        return self._policy
+
+    @property
+    def detectors(self) -> tuple[Any, ...]:
+        return tuple(self._detectors)
+
+    def bind_ctx(self, ctx: AgentCallbackContext | None) -> None:
+        """Bind the active callback context used by stream/async recovery."""
+        self._active_ctx = ctx
+        self.bind_reporter_ctx(ctx)
+
+    def bind_reporter_ctx(self, ctx: Any) -> None:
+        """Forward ctx to reporters that support ``bind_ctx``."""
+        if self._reporter is None:
+            return
+        binder = getattr(self._reporter, "bind_ctx", None)
+        if callable(binder):
+            binder(ctx)
+
+    def set_language(self, language: str) -> None:
+        """Sync recovery/steering locale from DeepAgent language (cn/en)."""
+        from openjiuwen.harness.agent_ras.config import coerce_message_locale
+
+        self._language = coerce_message_locale(language)
+        if self._executor is not None:
+            self._executor.set_locale(self._language)
+
+    def _locale(self) -> str:
+        return self._language
+
+    def ops_for(self, anomaly: Anomaly) -> set[RecoveryAction]:
+        """Resolve the atomic recovery op set for ``anomaly`` via policy."""
+        try:
+            return self._policy.ops_for(anomaly)
+        except Exception:
+            logger.error(
+                "Agent RAS recovery planning failed member=%s session=%s kind=%s",
+                self._member,
+                self._session_id,
+                anomaly.kind,
+                exc_info=True,
+            )
+            return set()
+
+    async def start(self, ctx: AgentCallbackContext | None = None) -> None:
+        """Invoke start: reset executor/detectors and wire async handlers."""
+        await self._cancel_review_task()
+        self._abnormal_committed = False
+        self._notice_emitted_immediate = None
+        if ctx is not None:
+            self.bind_ctx(ctx)
+        if self._executor is not None:
+            self._executor.reset()
+        self.reset_detectors()
+        self.wire_async_recovery()
+        if self._started:
+            return
+        self._started = True
+        self._stopped = False
+
+    async def stop(self) -> None:
+        """Invoke end: await async recovery, close detectors, end event streams."""
+        await self._cancel_review_task()
+        await self.await_async_recovery()
+        if self._stopped:
+            self.bind_ctx(None)
+            return
+        self._stopped = True
+        self._started = False
+        for detector in self._detectors:
+            close = getattr(detector, "aclose", None)
+            if callable(close):
+                try:
+                    await close()
+                except Exception as exc:
+                    logger.warning(
+                        "agent_ras detector close failed agent=%s session=%s "
+                        "detector=%s error_type=%s",
+                        self._agent_id,
+                        self._session_id,
+                        getattr(detector, "name", type(detector).__name__),
+                        type(exc).__name__,
+                        exc_info=True,
+                    )
+        for queue in tuple(self._subscribers):
+            queue.put_nowait(self._EVENT_STREAM_END)
+        # Clear per-round detector state (e.g. RepeatToolDetector._locks)
+        # so stop() does not leak session-scoped resources (CR-004).
+        self.reset_detectors()
+        self.bind_ctx(None)
+
+    async def detection(self, signal: Signal) -> list[Anomaly]:
+        """Fan-out ``signal`` to all detectors; report/record each anomaly."""
+        self._invoke_count += 1
+        detect_started = time.perf_counter()
+        produced: list[Anomaly] = []
+        for detector in self._detectors:
+            try:
+                anomaly = await self._call_detector(detector, signal)
+            except Exception as exc:
+                logger.error(
+                    "agent_ras detector failed agent=%s session=%s detector=%s "
+                    "error_type=%s",
+                    self._agent_id,
+                    self._session_id,
+                    getattr(detector, "name", repr(detector)),
+                    type(exc).__name__,
+                    exc_info=True,
+                )
+                continue
+            if anomaly is None:
+                continue
+            produced.append(anomaly)
+            await self._route(anomaly)
+            self._anomaly_count += 1
+            await self._record_event(anomaly)
+        self._detect_durations_ms.append(
+            (time.perf_counter() - detect_started) * 1000.0,
+        )
+        return produced
+
+    async def recovery(
+        self,
+        ctx: AgentCallbackContext | None,
+        anomalies: list[Anomaly],
+        *,
+        phase: str = "immediate",
+        chunk: Any = None,
+        chunk_type: str = "",
+        chunk_text: str = "",
+    ) -> None:
+        """Apply policy ops for each anomaly (immediate side effects or stream phase)."""
+        if not anomalies or self._executor is None:
+            return
+        target_ctx = ctx if ctx is not None else self._active_ctx
+        for anomaly in anomalies:
+            actions = self.ops_for(anomaly)
+            try:
+                if phase == "stream":
+                    await self._executor.run_stream_recovery(
+                        target_ctx,
+                        anomaly,
+                        StreamRecoveryArgs(
+                            chunk_result=chunk,
+                            chunk_type=chunk_type,
+                            chunk_text=chunk_text,
+                        ),
+                        actions,
+                    )
+                    self.record_recovery()
+                elif needs_immediate_apply(actions):
+                    if target_ctx is None:
+                        continue
+                    await self._executor.apply(target_ctx, anomaly, actions)
+                    self.record_recovery()
+            except Exception:
+                logger.error(
+                    "Agent RAS recovery failed member=%s session=%s kind=%s phase=%s",
+                    self._member,
+                    self._session_id,
+                    anomaly.kind,
+                    phase,
+                    exc_info=True,
+                )
+
+    async def handle(
+        self,
+        signal: Signal,
+        ctx: AgentCallbackContext | None = None,
+    ) -> list[Anomaly]:
+        """Run ``detection`` then immediate-phase ``recovery`` (main rail entry)."""
+        if ctx is not None:
+            self.bind_ctx(ctx)
+        anomalies = await self.detection(signal)
+        await self.recovery(ctx, anomalies, phase="immediate")
+        return anomalies
+
+    async def on_stream_chunk(
+        self,
+        chunk_type: str,
+        chunk_text: str,
+        chunk: Any,
+        ctx: AgentCallbackContext,
+    ) -> None:
+        """Stream-phase path: buffer if suppressing, else detect and auto-recover.
+
+        L1/L2 (``text_repetition``) abort immediately. L3 (``plan_execution``)
+        keeps suppressing while a Reviewer skill runs; confirmed abnormal then
+        aborts, otherwise fail-open flushes the buffer.
+        """
+        self.bind_ctx(ctx)
+        if self._executor is None:
+            return
+        if self._executor.should_suppress_stream(chunk_type):
+            suppress_and_buffer(
+                self._executor.suppress_state,
+                chunk_type,
+                chunk_text,
+                chunk,
+            )
+            return
+        anomalies = await self.detection(
+            Signal(
+                kind=SignalKind.STREAM_CHUNK,
+                member_name=self._member,
+                chunk_type=chunk_type,
+                chunk_text=chunk_text,
+            )
+        )
+        await self.recovery(
+            ctx,
+            anomalies,
+            phase="stream",
+            chunk=chunk,
+            chunk_type=chunk_type,
+            chunk_text=chunk_text,
+        )
+        await self._dispatch_automatic_recovery(ctx)
+
+    async def complete_async_stream_recovery(
+        self,
+        anomaly: Anomaly,
+        chunk_type: str,
+    ) -> None:
+        """Callback for async detectors (e.g. L3 thinking-loop) that finish after observe."""
+        try:
+            await self.record_anomaly(anomaly)
+            if self._executor is not None:
+                await self._executor.run_stream_recovery(
+                    self._active_ctx,
+                    anomaly,
+                    StreamRecoveryArgs(
+                        chunk_result=None,
+                        chunk_type=chunk_type,
+                        chunk_text="",
+                    ),
+                    self.ops_for(anomaly),
+                )
+                self.record_recovery()
+            if self._active_ctx is not None:
+                await self._dispatch_automatic_recovery(self._active_ctx)
+        finally:
+            self._release_async_recovery_for(anomaly.detector)
+
+    def _release_async_recovery_for(self, detector_name: str) -> None:
+        for detector in self._detectors:
+            if getattr(detector, "name", None) != detector_name:
+                continue
+            release = getattr(detector, "release_async_recovery", None)
+            if callable(release):
+                release()
+            return
+
+    def wire_async_recovery(self) -> None:
+        """Install ``complete_async_stream_recovery`` on async-capable detectors."""
+        _wire_async_recovery_handlers(
+            self._detectors,
+            self.complete_async_stream_recovery,
+        )
+
+    async def await_async_recovery(self) -> None:
+        """Block until async detectors finish or the configured timeout elapses."""
+        timeout = float(ASYNC_RECOVERY_TIMEOUT_SECONDS)
+        try:
+            timed_out = await _await_async_recovery_detectors(
+                self._detectors,
+                timeout,
+            )
+            if timed_out:
+                logger.warning(
+                    "Agent RAS async recovery timed out member=%s session=%s timeout=%.1f",
+                    self._member,
+                    self._session_id,
+                    timeout,
+                )
+        except Exception:
+            logger.warning(
+                "Agent RAS async recovery wait failed member=%s session=%s",
+                self._member,
+                self._session_id,
+                exc_info=True,
+            )
+
+    async def _cancel_review_task(self) -> None:
+        task = self._review_task
+        self._review_task = None
+        if task is None or task.done():
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.debug("Agent RAS review task cancel wait failed", exc_info=True)
+
+    async def _dispatch_automatic_recovery(self, ctx: AgentCallbackContext) -> None:
+        """Route armed suppress pending to L1/L2 abort or L3 Reviewer."""
+        if self._executor is None or self._abnormal_committed:
+            return
+        suppress = self._executor.suppress_state
+        pending = suppress.pending
+        if pending is None or suppress.resolved is not None:
+            return
+        if suppress.review_awaiting or (
+            self._review_task is not None and not self._review_task.done()
+        ):
+            return
+        if pending.is_plan_execution:
+            self._start_l3_review(ctx, pending)
+            return
+        await self._apply_abnormal_recovery(ctx, pending)
+
+    def _start_l3_review(
+        self,
+        ctx: AgentCallbackContext,
+        pending: PendingRecovery,
+    ) -> None:
+        """Kick off one background Reviewer skill without aborting the stream."""
+        if self._executor is None:
+            return
+        suppress = self._executor.suppress_state
+        suppress.review_awaiting = True
+        self._review_task = asyncio.create_task(
+            self._run_l3_review(ctx, pending),
+            name=f"agent_ras_l3_review:{self._session_id}",
+        )
+
+    async def _run_l3_review(
+        self,
+        ctx: AgentCallbackContext,
+        pending: PendingRecovery,
+    ) -> None:
+        try:
+            await self._run_l3_review_body(ctx, pending)
+        finally:
+            if self._review_task is asyncio.current_task():
+                self._review_task = None
+            if self._executor is not None:
+                self._executor.suppress_state.review_awaiting = False
+
+    async def _run_l3_review_body(
+        self,
+        ctx: AgentCallbackContext,
+        pending: PendingRecovery,
+    ) -> None:
+        """Reviewer confirm → abnormal; timeout/error/invalid/normal → fail-open."""
+        if self._executor is None or self._abnormal_committed:
+            return
+        suppress = self._executor.suppress_state
+        if suppress.pending is None or suppress.resolved is not None:
+            return
+        confirmed_abnormal = False
+        try:
+            confirmed_abnormal = await self._invoke_l3_recovery(pending)
+        except Exception:
+            logger.warning(
+                "Agent RAS L3 recovery failed member=%s session=%s",
+                self._member,
+                self._session_id,
+                exc_info=True,
+            )
+            confirmed_abnormal = False
+        if self._abnormal_committed:
+            return
+        # Pending may have been cleared by finalize_stream_recovery fail-open.
+        if suppress.pending is None or suppress.resolved is not None:
+            return
+        if confirmed_abnormal:
+            await self._apply_abnormal_recovery(ctx, pending)
+            return
+        await self._apply_normal_recovery(ctx, pending, release_plan_execution=True)
+
+    @staticmethod
+    def _fault_domain_for_pending(pending: PendingRecovery) -> str:
+        """Resolve fault domain for recovery skill lookup."""
+        domain = str(pending.extra.get("fault_domain") or "").strip()
+        if domain:
+            return domain
+        if pending.is_plan_execution or pending.is_text_repetition:
+            return FAULT_DOMAIN_LLM_THINKING_LOOP
+        return FAULT_DOMAIN_LLM_THINKING_LOOP
+
+    async def _invoke_l3_recovery(self, pending: PendingRecovery) -> bool:
+        """Return True only when recovery skill explicitly confirms abnormal."""
+        agents = self._agents
+        if agents is None:
+            logger.warning(
+                "Agent RAS L3 recovery fail-open member=%s session=%s "
+                "reason=no_agents",
+                self._member,
+                self._session_id,
+            )
+            return False
+        invoke = getattr(agents, "invoke_skill", None)
+        if not callable(invoke):
+            logger.warning(
+                "Agent RAS L3 recovery fail-open member=%s session=%s "
+                "reason=no_invoke_skill",
+                self._member,
+                self._session_id,
+            )
+            return False
+        payload = json.dumps(
+            {
+                "first_verdict": {
+                    "abnormal": True,
+                    "primary_fault": pending.extra.get("primary_fault")
+                    or "semantic_deadlock",
+                    "confidence": pending.extra.get("skill_confidence"),
+                    "rationale": pending.extra.get("skill_rationale") or "",
+                },
+                "thinking_excerpt": (
+                    pending.thinking_excerpt or pending.scanned_text or ""
+                ),
+            },
+            ensure_ascii=False,
+        )
+        fault_domain = self._fault_domain_for_pending(pending)
+        try:
+            skill_name = skill_for(fault_domain, "recovery")
+        except ValueError:
+            logger.warning(
+                "Agent RAS L3 recovery fail-open member=%s session=%s "
+                "fault_domain=%s reason=unknown_domain_or_role",
+                self._member,
+                self._session_id,
+                fault_domain,
+                exc_info=True,
+            )
+            return False
+        result = await invoke(
+            role="recovery",
+            skill_name=skill_name,
+            payload=payload,
+            timeout=float(SKILL_TIMEOUT_SECONDS),
+        )
+        if not isinstance(result, dict) or not result:
+            logger.warning(
+                "Agent RAS L3 recovery fail-open member=%s session=%s "
+                "skill=%s reason=empty_or_non_dict",
+                self._member,
+                self._session_id,
+                skill_name,
+            )
+            return False
+        # Re-parse so illegal / incomplete recovery payloads stay fail-open even
+        # when a test double returns a raw dict (adapter already parses).
+        verdict = parse_skill_verdict(skill_name, result)
+        if verdict.fail_open_reason:
+            logger.warning(
+                "Agent RAS L3 recovery fail-open member=%s session=%s "
+                "skill=%s reason=%s",
+                self._member,
+                self._session_id,
+                skill_name,
+                verdict.fail_open_reason,
+            )
+            return False
+        if not verdict.abnormal:
+            logger.info(
+                "Agent RAS L3 recovery normal member=%s session=%s skill=%s",
+                self._member,
+                self._session_id,
+                skill_name,
+            )
+            return False
+        return True
+
+    async def _apply_abnormal_recovery(
+        self,
+        ctx: AgentCallbackContext,
+        pending: PendingRecovery,
+    ) -> None:
+        if self._executor is None or self._abnormal_committed:
+            return
+        # Prefer the invoke-bound ctx so abort / steering / notice stay aligned
+        # (ZZP-001). Cancel before commit must leave pending intact for
+        # finalize_stream_recovery fail-open (ZZP-004).
+        ctx = self._active_ctx or ctx
+        suppress = self._executor.suppress_state
+        try:
+            request_abort = getattr(ctx, "request_abort_stream", None)
+            if callable(request_abort):
+                request_abort()
+            notice = await apply_recovery_abnormal(
+                ctx, pending, locale=self._locale(),
+            )
+            # Emit immediately so the user sees the interrupt reason even if the
+            # next model call does not run; also schedule for before_model_call
+            # with dedup via consume_notice_for_emit.
+            await emit_user_notice(ctx, notice)
+            self._notice_emitted_immediate = notice
+            self._executor.schedule_recovery_notice(notice)
+            primary_fault = pending.extra.get("primary_fault") or ""
+            logger.warning(
+                "Agent RAS thinking-loop abort member=%s session=%s source=%s "
+                "profile=%s primary_fault=%s notice=%s",
+                self._member,
+                self._session_id,
+                pending.source,
+                pending.recovery_profile,
+                primary_fault,
+                notice,
+            )
+            suppress.clear()
+            suppress.mark_resolved_abnormal()
+            self._abnormal_committed = True
+        except asyncio.CancelledError:
+            logger.warning(
+                "Agent RAS abnormal recovery cancelled before commit "
+                "member=%s session=%s source=%s committed=%s pending=%s",
+                self._member,
+                self._session_id,
+                pending.source,
+                self._abnormal_committed,
+                suppress.pending is not None,
+            )
+            raise
+
+    async def _apply_normal_recovery(
+        self,
+        ctx: AgentCallbackContext,
+        pending: PendingRecovery,
+        *,
+        release_plan_execution: bool = False,
+    ) -> None:
+        if self._executor is None or self._abnormal_committed:
+            return
+        suppress = self._executor.suppress_state
+        await apply_recovery_normal(
+            ctx, suppress, pending, locale=self._locale(),
+        )
+        if release_plan_execution:
+            self._release_plan_execution_latches()
+        # Drop any raced abnormal notice; normal path continues the stream.
+        self._executor.take_pending_recovery_notice()
+
+    def _release_plan_execution_latches(self) -> None:
+        """Allow L3 re-detection only after another full semantic_eval_chars window."""
+        for detector in self._detectors:
+            release = getattr(detector, "release_plan_execution_latch", None)
+            if not callable(release):
+                continue
+            try:
+                release()
+            except Exception:
+                logger.debug(
+                    "Agent RAS release_plan_execution_latch failed detector=%s",
+                    getattr(detector, "name", type(detector).__name__),
+                    exc_info=True,
+                )
+
+    def prepare_for_next_model_call(self) -> None:
+        """Reopen recovery gates after an abnormal turn, before the next model call.
+
+        Abnormal recovery sets ``_abnormal_committed`` for the aborted stream.
+        The same invoke may continue via steering into another model call; without
+        clearing that gate, a new detect would never re-run automatic recovery.
+        Does **not** consume pending recovery notice (caller emits it first).
+        """
+        if not self._abnormal_committed:
+            return
+        self._abnormal_committed = False
+        if self._executor is not None:
+            state = self._executor.suppress_state
+            if state.resolved == "abnormal":
+                state.resolved = None
+            state.review_awaiting = False
+
+    async def finalize_stream_recovery(self, ctx: AgentCallbackContext) -> None:
+        """After model call: await/cancel Reviewer and fail-open if still pending.
+
+        Preferred path resolves mid-stream. When the stream ends while Reviewer
+        is still running (or pending was never resolved), treat as **normal**:
+        flush buffers and release the L3 latch. Already-committed abnormal paths
+        are left untouched.
+        """
+        if self._abnormal_committed or self._executor is None:
+            return
+
+        suppress = self._executor.suppress_state
+        if suppress.resolved == "abnormal":
+            self._abnormal_committed = True
+            return
+        if suppress.resolved == "normal":
+            return
+
+        task = self._review_task
+        fail_open_reason = "still_pending"
+        if task is not None and not task.done():
+            timeout = float(SKILL_TIMEOUT_SECONDS)
+            try:
+                await asyncio.wait_for(task, timeout=timeout)
+            except asyncio.TimeoutError:
+                fail_open_reason = "timeout"
+                logger.warning(
+                    "Agent RAS L3 recovery wait timed out member=%s session=%s",
+                    self._member,
+                    self._session_id,
+                )
+                await self._cancel_review_task()
+            except asyncio.CancelledError:
+                fail_open_reason = "cancelled"
+                await self._cancel_review_task()
+            except Exception:
+                fail_open_reason = "wait_failed"
+                logger.warning(
+                    "Agent RAS L3 recovery wait failed member=%s session=%s",
+                    self._member,
+                    self._session_id,
+                    exc_info=True,
+                )
+                await self._cancel_review_task()
+
+        # After cancel/timeout: if abnormal recovery was interrupted mid-flight,
+        # pending may still be set and committed is False — fall through to
+        # fail-open below (ZZP-004).
+        if self._abnormal_committed or suppress.resolved is not None:
+            return
+
+        pending = suppress.pending
+        if pending is None:
+            return
+
+        logger.info(
+            "Agent RAS stream recovery fail-open member=%s session=%s "
+            "source=%s reason=%s",
+            self._member,
+            self._session_id,
+            pending.source,
+            fail_open_reason,
+        )
+        await self._apply_normal_recovery(
+            ctx,
+            pending,
+            release_plan_execution=pending.is_plan_execution,
+        )
+
+    def take_notice(self) -> str | None:
+        """Pop a deferred user-visible recovery notice (emitted before next model call)."""
+        if self._executor is None:
+            return None
+        return self._executor.take_pending_recovery_notice()
+
+    def consume_notice_for_emit(self) -> str | None:
+        """Pop deferred notice, skipping duplicate of an already-emitted immediate notice."""
+        notice = self.take_notice()
+        if notice is None:
+            return None
+        if notice == self._notice_emitted_immediate:
+            self._notice_emitted_immediate = None
+            return None
+        self._notice_emitted_immediate = None
+        return notice
+
+    async def _call_detector(self, detector: Any, signal: Signal) -> Optional[Anomaly]:
+        """Run one detector's ``observe``; await if it returns a coroutine."""
+        result = detector.observe(signal)
+        if asyncio.iscoroutine(result):
+            result = await result
+        return result
+
+    async def _route(self, anomaly: Anomaly) -> None:
+        """Optionally forward the anomaly to the configured reporter."""
+        if self._reporter is None:
+            return
+        actions = self._policy.actions_for(anomaly.severity, kind=anomaly.kind)
+        report_actions = {
+            RecoveryAction.REPORT_TO_USER,
+            RecoveryAction.ESCALATE_USER,
+        }
+        invoke_reporter = bool(set(actions) & report_actions)
+        if getattr(self._reporter, "handles_all_anomalies", False):
+            invoke_reporter = True
+        if not invoke_reporter:
+            return
+        try:
+            result = self._reporter.report(anomaly)
+            if asyncio.iscoroutine(result):
+                await result
+        except Exception as exc:
+            logger.error(
+                "agent_ras reporter failed agent=%s session=%s kind=%s error_type=%s",
+                self._agent_id,
+                self._session_id,
+                anomaly.kind,
+                type(exc).__name__,
+                exc_info=True,
+            )
+
+    async def record_anomaly(self, anomaly: Anomaly) -> None:
+        """Record an anomaly produced outside ``detection`` (async stream path)."""
+        await self._route(anomaly)
+        self._anomaly_count += 1
+        await self._record_event(anomaly)
+
+    def record_recovery(self) -> None:
+        """Bump the recovery counter after a successful apply/stream recovery."""
+        self._recovery_count += 1
+
+    async def _record_event(self, anomaly: Anomaly) -> None:
+        event = AgentRASMonitorEvent(
+            event_type="anomaly",
+            timestamp=_now_ms(),
+            agent_id=self._agent_id,
+            session_id=self._session_id,
+            anomaly=anomaly,
+        )
+        await self._ring.append(event)
+        for queue in tuple(self._subscribers):
+            if queue.full():
+                try:
+                    queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    pass
+            queue.put_nowait(event)
+
+    def reset_detectors(self) -> None:
+        """Reset every detector's per-round state."""
+        for detector in self._detectors:
+            try:
+                detector.reset()
+            except Exception as exc:
+                logger.warning(
+                    "agent_ras detector reset failed agent=%s session=%s "
+                    "detector=%s error_type=%s",
+                    self._agent_id,
+                    self._session_id,
+                    getattr(detector, "name", repr(detector)),
+                    type(exc).__name__,
+                    exc_info=True,
+                )
+
+    def reset(self) -> None:
+        """Alias for ``reset_detectors`` (historical API)."""
+        self.reset_detectors()
+
+    async def get_recent_events(self, n: int) -> list[AgentRASMonitorEvent]:
+        """Return the most recent ``n`` anomaly events (newest first)."""
+        return await self._ring.recent(n)
+
+    async def get_metrics(self) -> dict[str, Any]:
+        """Return basic observability counters for this session."""
+        ordered = sorted(self._detect_durations_ms)
+        p99_index = max(0, int(len(ordered) * 0.99) - 1)
+        return {
+            "invoke_count": self._invoke_count,
+            "anomaly_count": self._anomaly_count,
+            "recovery_count": self._recovery_count,
+            "detect_p99_ms": ordered[p99_index] if ordered else 0.0,
+            "buffer_size": self._ring.size(),
+        }
+
+    async def events(self) -> AsyncIterator[AgentRASMonitorEvent]:
+        """Live async iterator of anomaly events until ``stop`` sends a sentinel."""
+        if self._stopped:
+            return
+        queue: asyncio.Queue = asyncio.Queue(maxsize=256)
+        self._subscribers.add(queue)
+        try:
+            recent = await self._ring.recent(256)
+            for event in reversed(recent):
+                queue.put_nowait(event)
+            while True:
+                event = await queue.get()
+                if event is self._EVENT_STREAM_END:
+                    return
+                yield event
+        finally:
+            self._subscribers.discard(queue)
+
+
+def _now_ms() -> int:
+    """Current wall time in milliseconds (Unix epoch)."""
+    return int(time.time() * 1000)

--- a/openjiuwen/harness/agent_ras/recovery/__init__.py
+++ b/openjiuwen/harness/agent_ras/recovery/__init__.py
@@ -1,0 +1,35 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Recovery: policy mapping + atomic operations + robustness prompts."""
+
+from openjiuwen.harness.agent_ras.recovery.engine import (
+    DEFAULT_SEVERITY_ACTIONS,
+    LocalAutoRecovery,
+    RecoveryAction,
+    RecoveryExecutor,
+    RecoveryPlan,
+    RecoveryPolicy,
+    needs_immediate_apply,
+    plan_recovery,
+    should_emit_user_notice,
+)
+from openjiuwen.harness.agent_ras.recovery.robustness_prompt import load_message
+from openjiuwen.harness.agent_ras.recovery.state import (
+    PendingRecovery,
+    SuppressFlushState,
+)
+
+__all__ = [
+    "DEFAULT_SEVERITY_ACTIONS",
+    "LocalAutoRecovery",
+    "PendingRecovery",
+    "RecoveryPlan",
+    "RecoveryAction",
+    "RecoveryExecutor",
+    "RecoveryPolicy",
+    "SuppressFlushState",
+    "load_message",
+    "needs_immediate_apply",
+    "plan_recovery",
+    "should_emit_user_notice",
+]

--- a/openjiuwen/harness/agent_ras/recovery/engine.py
+++ b/openjiuwen/harness/agent_ras/recovery/engine.py
@@ -1,0 +1,442 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Recovery engine: kind→ops mapping, rate limiting, and effect dispatch.
+
+``RecoveryPolicy`` maps anomalies to atomic ``RecoveryAction`` sets.
+``RecoveryExecutor`` turns those ops into stream suppress / notices / steering
+/ terminate via ``operations``. User-facing copy comes from
+``robustness_prompt`` (steer/notice/critical text).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+from openjiuwen.core.common.logging import logger
+from openjiuwen.core.single_agent.rail.base import AgentCallbackContext
+from openjiuwen.harness.agent_ras.models import Anomaly, AnomalyKind, Severity
+from openjiuwen.harness.agent_ras.recovery.robustness_prompt import (
+    critical_text_for,
+    generic_steer_text_for,
+    recovery_user_notice_for_anomaly,
+    steer_text_for,
+    user_notice_text_for,
+)
+from openjiuwen.harness.agent_ras.recovery.state import SuppressFlushState
+from openjiuwen.harness.agent_ras.recovery.operations import (
+    emit_user_notice,
+    inject_steering,
+    pending_from_anomaly,
+    terminate,
+    truncate_chunk_on_hit,
+)
+
+# Per-invoke cap on rate-limited auto-recovery actions (not host-configurable).
+_MAX_AUTO_ACTIONS_PER_INVOKE = 5
+
+
+class RecoveryAction(str, Enum):
+    """Atomic recovery operations applied by ``RecoveryExecutor`` / Monitor.
+
+    - ``SUPPRESS_STREAM``: truncate/suppress thinking-loop stream chunks
+    - ``INJECT_STEERING`` / ``REPORT_TO_USER`` / ``TERMINATE``: immediate apply
+    """
+
+    OBSERVE_ONLY = "observe_only"
+    REPORT_TO_USER = "report_to_user"
+    INJECT_STEERING = "inject_steering"
+    ESCALATE_USER = "escalate_user"
+    SUPPRESS_STREAM = "suppress_stream"
+    TERMINATE = "terminate"
+
+
+# Severity fall-back when kind has no explicit override.
+DEFAULT_SEVERITY_ACTIONS: dict[Severity, list[RecoveryAction]] = {
+    Severity.LOW: [RecoveryAction.OBSERVE_ONLY, RecoveryAction.INJECT_STEERING],
+    Severity.MEDIUM: [RecoveryAction.REPORT_TO_USER],
+    Severity.HIGH: [RecoveryAction.REPORT_TO_USER, RecoveryAction.INJECT_STEERING],
+    Severity.CRITICAL: [RecoveryAction.INJECT_STEERING, RecoveryAction.ESCALATE_USER],
+}
+
+# Kind → set of atomic ops (primary mapping source).
+DEFAULT_KIND_OVERRIDES: dict[AnomalyKind, list[RecoveryAction]] = {
+    AnomalyKind.LLM_THINKING_LOOP: [
+        RecoveryAction.OBSERVE_ONLY,
+        RecoveryAction.SUPPRESS_STREAM,
+    ],
+    AnomalyKind.LLM_THINKING_DEAD_LOOP: [
+        RecoveryAction.OBSERVE_ONLY,
+        RecoveryAction.SUPPRESS_STREAM,
+    ],
+}
+
+_IMMEDIATE_OPS = frozenset({
+    RecoveryAction.INJECT_STEERING,
+    RecoveryAction.REPORT_TO_USER,
+    RecoveryAction.ESCALATE_USER,
+    RecoveryAction.TERMINATE,
+})
+
+
+def needs_immediate_apply(actions: set[RecoveryAction]) -> bool:
+    """True when anomaly should run non-stream side effects now."""
+    return bool(actions & _IMMEDIATE_OPS)
+
+
+class RecoveryPolicy:
+    """Map anomaly kind (preferred) or severity to atomic recovery ops."""
+
+    def __init__(
+        self,
+        severity_actions: dict[Severity, list[RecoveryAction]] | None = None,
+        kind_overrides: dict[AnomalyKind, list[RecoveryAction]] | None = None,
+    ) -> None:
+        self._map = dict(severity_actions) if severity_actions else dict(DEFAULT_SEVERITY_ACTIONS)
+        self._kind_overrides = dict(kind_overrides) if kind_overrides else {}
+
+    def actions_for(
+        self,
+        severity: Severity,
+        kind: AnomalyKind | None = None,
+    ) -> list[RecoveryAction]:
+        """Return configured ops for ``kind`` override, else severity defaults."""
+        if kind is not None and kind in self._kind_overrides:
+            return list(self._kind_overrides[kind])
+        return list(self._map.get(severity, []))
+
+    def ops_for(self, anomaly: Anomaly) -> set[RecoveryAction]:
+        """Resolve the atomic op set for one anomaly (kind preferred over severity)."""
+        return set(self.actions_for(anomaly.severity, kind=anomaly.kind))
+
+    @classmethod
+    def from_config(cls, config: Any) -> "RecoveryPolicy":
+        """Build policy with default kind overrides merged over config overrides."""
+        kind_overrides = dict(DEFAULT_KIND_OVERRIDES)
+        kind_overrides.update(getattr(config, "kind_overrides", {}) or {})
+        # Drop legacy DEFER_HITL if present in host overrides.
+        for kind, actions in list(kind_overrides.items()):
+            kind_overrides[kind] = [
+                action for action in actions
+                if getattr(action, "value", action) != "defer_hitl"
+            ]
+        return cls(
+            getattr(config, "severity_actions", None),
+            kind_overrides=kind_overrides,
+        )
+
+
+class LocalAutoRecovery:
+    """Per-invoke rate limit for steering (and related) auto-recovery actions."""
+
+    def __init__(
+        self,
+        policy: RecoveryPolicy,
+        *,
+        locale: str = "cn",
+    ) -> None:
+        self._policy = policy
+        self._counts: dict[RecoveryAction, int] = {}
+        self._locale = (locale or "cn").strip().lower()
+        if self._locale == "zh":
+            self._locale = "cn"
+
+    def set_locale(self, locale: str) -> None:
+        """Update message locale from DeepAgent language (cn/en)."""
+        loc = (locale or "cn").strip().lower()
+        self._locale = "cn" if loc == "zh" else loc
+
+    def steer_message(self, anomaly: Anomaly) -> str | None:
+        """Return a rate-limited steering text from ``robustness_prompt``, or None."""
+        if RecoveryAction.INJECT_STEERING not in self._policy.actions_for(
+            anomaly.severity, kind=anomaly.kind
+        ):
+            return None
+        if not self.allow(RecoveryAction.INJECT_STEERING):
+            return None
+        specific = steer_text_for(anomaly, locale=self._locale)
+        if specific:
+            return specific
+        return generic_steer_text_for(anomaly, locale=self._locale)
+
+    def allow(self, action: RecoveryAction) -> bool:
+        """Consume one per-invoke budget slot for ``action``; False when exhausted."""
+        used = self._counts.get(action, 0)
+        if used >= _MAX_AUTO_ACTIONS_PER_INVOKE:
+            return False
+        self._counts[action] = used + 1
+        return True
+
+    def reset(self) -> None:
+        """Clear per-invoke counters (call at invoke start)."""
+        self._counts.clear()
+
+
+@dataclass(slots=True)
+class StreamRecoveryArgs:
+    """Stream chunk view passed to ``RecoveryExecutor.run_stream_recovery``."""
+
+    chunk_result: Any
+    chunk_type: str
+    chunk_text: str
+
+
+@dataclass(slots=True)
+class RecoveryPlan:
+    """Resolved remediation effects for one anomaly."""
+
+    actions: set[RecoveryAction] = field(default_factory=set)
+    primary_action: RecoveryAction = RecoveryAction.OBSERVE_ONLY
+    steering_text: str | None = None
+    user_notice: str | None = None
+    recovery_notice: str | None = None
+    terminate_message: str | None = None
+    terminate_critical: bool = False
+
+    @property
+    def has_effect(self) -> bool:
+        return bool(
+            self.steering_text
+            or self.user_notice
+            or self.recovery_notice
+            or self.terminate_message
+            or self.primary_action != RecoveryAction.OBSERVE_ONLY
+        )
+
+
+def should_emit_user_notice(
+    anomaly: Anomaly,
+    policy_actions: set[RecoveryAction],
+    *,
+    notify_user_on_warning: bool,
+) -> bool:
+    """True when policy asks to surface a WARNING-level notice to the user."""
+    if not notify_user_on_warning:
+        return False
+    if RecoveryAction.REPORT_TO_USER in policy_actions:
+        return True
+    return (
+        anomaly.severity == Severity.LOW
+        and RecoveryAction.INJECT_STEERING in policy_actions
+    )
+
+
+def plan_recovery(
+    anomaly: Anomaly,
+    policy: RecoveryPolicy | None,
+    auto: LocalAutoRecovery | None,
+    *,
+    locale: str = "cn",
+    notify_user_on_warning: bool = True,
+    policy_actions: set[RecoveryAction] | None = None,
+) -> RecoveryPlan:
+    """Map policy actions + rate-limited steering into a ``RecoveryPlan``.
+
+    Called by ``Monitor.recovery`` / executor before applying side effects.
+    Text comes from ``robustness_prompt``.
+    """
+    loc = (locale or "cn").strip().lower()
+    if loc == "zh":
+        loc = "cn"
+    actions = (
+        set(policy_actions)
+        if policy_actions is not None
+        else set(policy.actions_for(anomaly.severity, kind=anomaly.kind))
+        if policy is not None
+        else set()
+    )
+    plan = RecoveryPlan(actions=actions, primary_action=RecoveryAction.OBSERVE_ONLY)
+
+    if should_emit_user_notice(anomaly, actions, notify_user_on_warning=notify_user_on_warning):
+        plan.user_notice = user_notice_text_for(anomaly, locale=loc)
+
+    if RecoveryAction.INJECT_STEERING in actions and auto is not None:
+        plan.steering_text = auto.steer_message(anomaly)
+        if plan.steering_text:
+            plan.primary_action = RecoveryAction.INJECT_STEERING
+
+    if RecoveryAction.REPORT_TO_USER in actions or RecoveryAction.ESCALATE_USER in actions:
+        if plan.primary_action == RecoveryAction.OBSERVE_ONLY:
+            plan.primary_action = RecoveryAction.REPORT_TO_USER
+
+    if (
+        not plan.user_notice
+        and plan.steering_text
+        and notify_user_on_warning
+    ):
+        plan.recovery_notice = recovery_user_notice_for_anomaly(anomaly, locale=loc)
+
+    if RecoveryAction.SUPPRESS_STREAM in actions:
+        if plan.primary_action == RecoveryAction.OBSERVE_ONLY:
+            plan.primary_action = RecoveryAction.SUPPRESS_STREAM
+
+    if RecoveryAction.TERMINATE in actions:
+        if (
+            anomaly.severity == Severity.CRITICAL
+            and anomaly.kind in (AnomalyKind.REPEAT_TOOL_CALL, AnomalyKind.TOOL_CALL_LOOP)
+        ):
+            plan.terminate_message = critical_text_for(anomaly, locale=loc) or (
+                f"[agent_ras] {anomaly.kind.value} detected: {anomaly.summary}"
+            )
+            plan.terminate_critical = True
+        else:
+            plan.terminate_message = (
+                f"[agent_ras] {anomaly.kind.value} detected: {anomaly.summary}"
+            )
+
+    return plan
+
+
+class RecoveryExecutor:
+    """Owns suppress/pending state and dispatches ops through ``operations``.
+
+    Stream-phase thinking-loop resolution (L1/L2 immediate abort, L3 recovery)
+    is orchestrated by ``AgentRASMonitor``; this class records deferred pending,
+    truncates stream chunks, and runs ``apply`` for steering / notices / terminate.
+    """
+
+    def __init__(
+        self,
+        auto_recovery: Optional[LocalAutoRecovery],
+        *,
+        locale: str = "cn",
+        notify_user_on_warning: bool = True,
+    ) -> None:
+        self._auto = auto_recovery
+        self._locale = (locale or "cn").strip().lower()
+        if self._locale == "zh":
+            self._locale = "cn"
+        self._notify_user_on_warning = notify_user_on_warning
+        self._suppress_flush = SuppressFlushState()
+        self._pending_recovery_notice: str | None = None
+
+    def set_locale(self, locale: str) -> None:
+        """Update message locale and push it to LocalAutoRecovery."""
+        loc = (locale or "cn").strip().lower()
+        self._locale = "cn" if loc == "zh" else loc
+        if self._auto is not None:
+            self._auto.set_locale(self._locale)
+
+    def schedule_recovery_notice(self, message: str) -> None:
+        """Queue a notice to emit before the next model call."""
+        self._pending_recovery_notice = message
+
+    def take_pending_recovery_notice(self) -> str | None:
+        """Pop and return any queued recovery notice, or None."""
+        notice = self._pending_recovery_notice
+        self._pending_recovery_notice = None
+        return notice
+
+    @property
+    def suppress_state(self) -> SuppressFlushState:
+        """Session-local suppress buffer and deferred recovery pending."""
+        return self._suppress_flush
+
+    def reset(self) -> None:
+        """Clear suppress/pending state and auto-recovery counters at invoke start."""
+        self._suppress_flush.clear()
+        self._pending_recovery_notice = None
+        if self._auto is not None:
+            self._auto.reset()
+
+    def should_suppress_stream(self, chunk_type: str) -> bool:
+        """True while deferred recovery is active for ``chunk_type``."""
+        return self._suppress_flush.should_suppress(chunk_type)
+
+    def record_suppressed_chunk(self, chunk_type: str, text: str) -> None:
+        """Append truncated stream text for a later flush."""
+        self._suppress_flush.record_suppressed(chunk_type, text)
+
+    def record_deferred_recovery(
+        self,
+        anomaly: Anomaly,
+        policy_actions: set[RecoveryAction] | None = None,
+    ) -> None:
+        """Arm suppress pending from anomaly evidence when stream suppress is allowed."""
+        actions = policy_actions or set()
+        if RecoveryAction.SUPPRESS_STREAM not in actions:
+            return
+        self._suppress_flush.record_pending(pending_from_anomaly(anomaly))
+
+    async def run_stream_recovery(
+        self,
+        ctx: AgentCallbackContext | None,
+        anomaly: Anomaly,
+        stream: StreamRecoveryArgs,
+        policy_actions: set[RecoveryAction],
+    ) -> None:
+        """Apply stream truncate/suppress and optional immediate ``apply``."""
+        if RecoveryAction.SUPPRESS_STREAM in policy_actions:
+            evidence = anomaly.evidence or {}
+            raw_keep = evidence.get("stream_chunk_keep_len")
+            keep_len = int(raw_keep) if raw_keep is not None else 0
+            truncate_chunk_on_hit(
+                stream.chunk_result,
+                stream.chunk_text,
+                keep_len=keep_len if keep_len > 0 else None,
+            )
+            suppressed_part = (
+                stream.chunk_text[keep_len:] if keep_len > 0 else stream.chunk_text
+            )
+            self.record_suppressed_chunk(stream.chunk_type, suppressed_part)
+            self.record_deferred_recovery(anomaly, policy_actions)
+
+        if ctx is not None and needs_immediate_apply(policy_actions):
+            await self.apply(ctx, anomaly, policy_actions)
+
+    async def apply(
+        self,
+        ctx: AgentCallbackContext,
+        anomaly: Anomaly,
+        policy_actions: set[RecoveryAction],
+    ) -> None:
+        """Emit notices / steering / terminate from ``plan_recovery`` (rate-limited)."""
+        plan = plan_recovery(
+            anomaly,
+            None,
+            self._auto,
+            locale=self._locale,
+            notify_user_on_warning=self._notify_user_on_warning,
+            policy_actions=policy_actions,
+        )
+
+        notice_emitted = False
+        if plan.user_notice and self._allowed(RecoveryAction.REPORT_TO_USER):
+            logger.warning(
+                "[RecoveryExecutor] user notice (%s/%s): %s",
+                anomaly.kind.value,
+                anomaly.severity.value,
+                plan.user_notice,
+            )
+            await emit_user_notice(ctx, plan.user_notice)
+            notice_emitted = True
+
+        if (
+            not notice_emitted
+            and plan.recovery_notice
+            and self._allowed(RecoveryAction.REPORT_TO_USER)
+        ):
+            logger.warning(
+                "[RecoveryExecutor] recovery notice (%s): %s",
+                anomaly.kind.value,
+                plan.recovery_notice,
+            )
+            await emit_user_notice(ctx, plan.recovery_notice)
+
+        if plan.steering_text:
+            logger.info(
+                "[RecoveryExecutor] steering pushed for %s (%s chars)",
+                anomaly.kind.value,
+                len(plan.steering_text),
+            )
+            await inject_steering(ctx, plan.steering_text)
+
+        if plan.terminate_message and self._allowed(RecoveryAction.TERMINATE):
+            await terminate(
+                ctx,
+                plan.terminate_message,
+                write_error_stream=plan.terminate_critical,
+            )
+
+    def _allowed(self, action: RecoveryAction) -> bool:
+        return self._auto is None or self._auto.allow(action)

--- a/openjiuwen/harness/agent_ras/recovery/operations.py
+++ b/openjiuwen/harness/agent_ras/recovery/operations.py
@@ -1,0 +1,221 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Atomic recovery side effects for stream suppress / flush / steering / terminate.
+
+Prompt text for thinking-loop recovery notices and steering comes from
+``robustness_prompt``.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from openjiuwen.core.common.logging import logger
+from openjiuwen.core.single_agent.rail.base import AgentCallbackContext
+from openjiuwen.harness.agent_ras.models import Anomaly
+from openjiuwen.harness.agent_ras.recovery.robustness_prompt import (
+    format_steering,
+    recovery_steering_on_abnormal,
+    recovery_user_notice_for,
+)
+from openjiuwen.harness.agent_ras.recovery.state import (
+    PendingRecovery,
+    SuppressFlushState,
+)
+
+LLM_STREAM_TYPES = frozenset({"llm_output", "llm_reasoning"})
+_USER_NOTICE_STREAM_TYPE = "retry_notification"
+
+
+def truncate_chunk_payload(chunk: Any, content: str) -> None:
+    """In-place truncate stream chunk payload content."""
+    if isinstance(chunk, dict):
+        payload = chunk.get("payload")
+        if isinstance(payload, dict):
+            payload["content"] = content
+        return
+    payload = getattr(chunk, "payload", None)
+    if payload is None:
+        return
+    if isinstance(payload, dict):
+        payload["content"] = content
+    else:
+        try:
+            setattr(payload, "content", content)
+        except Exception:
+            logger.debug(
+                "truncate_chunk_payload: could not set payload.content",
+                exc_info=True,
+            )
+
+
+def truncate_chunk_on_hit(
+    chunk: Any,
+    chunk_text: str,
+    *,
+    keep_len: int | None = None,
+) -> None:
+    """Truncate hitting chunk: keep prefix before repeat or clear entirely."""
+    if keep_len is not None and keep_len > 0:
+        truncate_chunk_payload(chunk, chunk_text[:keep_len])
+    else:
+        truncate_chunk_payload(chunk, "")
+
+
+def suppress_and_buffer(
+    state: SuppressFlushState,
+    chunk_type: str,
+    text: str,
+    chunk: Any,
+) -> None:
+    """Buffer suppressed text and truncate outgoing chunk payload."""
+    state.record_suppressed(chunk_type, text)
+    truncate_chunk_payload(chunk, "")
+
+
+async def flush_suppressed_stream(
+    ctx: AgentCallbackContext,
+    chunk_type: str,
+    content: str,
+) -> None:
+    """Write buffered suppressed text back to the session stream (normal path)."""
+    session = getattr(ctx, "session", None)
+    if session is None or not content:
+        return
+    try:
+        from openjiuwen.core.session.stream import OutputSchema
+
+        await session.write_stream(
+            OutputSchema(
+                type=chunk_type,
+                index=0,
+                payload={"content": content},
+            )
+        )
+    except Exception:
+        logger.warning("flush_suppressed_stream failed", exc_info=True)
+
+
+async def inject_steering(ctx: AgentCallbackContext, message: str) -> None:
+    """Push a self-correction steering message onto the agent context.
+
+    Applies the standard ``<system-reminder>`` envelope via ``format_steering``.
+    """
+    try:
+        text = format_steering(message or "")
+        queue = getattr(ctx, "steering_queue", None)
+        if queue is None:
+            logger.warning(
+                "inject_steering skipped: steering_queue is None "
+                "chars=%s prefix=%r",
+                len(text),
+                text[:80],
+            )
+            return
+        ctx.push_steering(text)
+        logger.info(
+            "inject_steering pushed chars=%s prefix=%r",
+            len(text),
+            text[:80],
+        )
+    except Exception:
+        logger.error("inject_steering failed", exc_info=True)
+
+
+async def emit_user_notice(ctx: AgentCallbackContext, message: str) -> None:
+    """Emit a user-visible recovery / warning notice on the session stream."""
+    session = getattr(ctx, "session", None)
+    if session is None:
+        return
+    try:
+        from openjiuwen.core.session.stream import OutputSchema
+
+        notice_text = f"\n\n⚠️ {message}\n\n"
+        await session.write_stream(
+            OutputSchema(
+                type=_USER_NOTICE_STREAM_TYPE,
+                index=-1,
+                payload={
+                    "output": {
+                        "output": notice_text,
+                        "result_type": "text",
+                    },
+                },
+            )
+        )
+    except Exception:
+        logger.warning("emit_user_notice failed", exc_info=True)
+
+
+async def emit_stream_error(ctx: AgentCallbackContext, message: str) -> None:
+    """Write an error-typed stream event (critical terminate path)."""
+    session = getattr(ctx, "session", None)
+    if session is None:
+        return
+    try:
+        from openjiuwen.core.session.stream import OutputSchema
+
+        await session.write_stream(
+            OutputSchema(
+                type="error",
+                index=0,
+                payload={"error": message, "message": message},
+            )
+        )
+    except Exception:
+        logger.warning("emit_stream_error failed", exc_info=True)
+
+
+async def terminate(
+    ctx: AgentCallbackContext,
+    message: str,
+    *,
+    write_error_stream: bool,
+) -> None:
+    """Force-finish the invoke; optionally emit an error stream event first."""
+    if write_error_stream:
+        await emit_stream_error(ctx, message)
+    try:
+        ctx.request_force_finish({"output": message, "result_type": "error"})
+    except Exception:
+        logger.error("terminate failed", exc_info=True)
+
+
+def pending_from_anomaly(anomaly: Anomaly) -> PendingRecovery:
+    """Alias for ``PendingRecovery.from_anomaly`` (executor / Monitor use)."""
+    return PendingRecovery.from_anomaly(anomaly)
+
+
+async def apply_recovery_normal(
+    ctx: AgentCallbackContext,
+    suppress: SuppressFlushState,
+    pending: PendingRecovery,
+    *,
+    locale: str = "cn",
+) -> None:
+    """Normal / fail-open: flush suppressed buffers and stop suppressing."""
+    _ = locale
+    chunk_type = pending.chunk_type
+    suppress.mark_resolved_normal()
+    flushed = suppress.flush_suppressed(chunk_type)
+    if flushed:
+        await flush_suppressed_stream(ctx, chunk_type, flushed)
+
+
+async def apply_recovery_abnormal(
+    ctx: AgentCallbackContext,
+    pending: PendingRecovery,
+    *,
+    locale: str = "cn",
+) -> str:
+    """Abnormal path: inject recovery steering and return notice text."""
+    steering = recovery_steering_on_abnormal(pending, locale=locale)
+    logger.info(
+        "apply_recovery_abnormal source=%s profile=%s primary_fault=%s "
+        "steering_chars=%s",
+        pending.source,
+        pending.recovery_profile,
+        pending.extra.get("primary_fault") or "",
+        len(steering),
+    )
+    await inject_steering(ctx, steering)
+    return recovery_user_notice_for(pending, locale=locale)

--- a/openjiuwen/harness/agent_ras/recovery/robustness_prompt.py
+++ b/openjiuwen/harness/agent_ras/recovery/robustness_prompt.py
@@ -1,0 +1,656 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Robustness prompt templates and recovery/steering message rendering."""
+from __future__ import annotations
+
+from typing import Any
+
+from openjiuwen.harness.agent_ras.models import Anomaly, AnomalyKind
+from openjiuwen.harness.agent_ras.recovery.state import PendingRecovery
+
+# --- robustness_prompts_cn ---
+
+robustness_prompts_cn: dict[str, str] = {
+    "llm_loop_literal_low": (
+        "检测到 LLM 输出末尾的严格周期重复 {repeats} 次。"
+    ),
+    "llm_loop_progressive_medium": (
+        "检测到 LLM 输出中出现 {repeats} 个高度相似的子句，疑似模板循环。"
+    ),
+    "llm_loop_literal_high": (
+        "检测到 LLM 输出长时间循环（{repeats} 次），"
+        "请立即更换策略或结束任务。"
+    ),
+    "llm_loop_global_critical": (
+        "全局 LLM 循环：增量输出已超过阈值且无进展，强制中断。"
+    ),
+    "llm_dead_loop_agent_high": (
+        "LLM 思考流可能陷入语义死循环（重复 {repeats} 次），请更换思路。"
+    ),
+    "llm_dead_loop_agent_critical": (
+        "LLM 思考流被判定为语义死循环，已自动中断并执行恢复。"
+    ),
+    "repeat_tool_generic_warning": (
+        "工具 {tool_name} 已重复调用 {count} 次，请检查是否有效。"
+    ),
+    "repeat_tool_generic_user": (
+        "[工具调用异常] 工具 {tool_name} 已重复调用 {count} 次。"
+    ),
+    "repeat_tool_generic_steering": (
+        "你已多次使用完全相同参数重复调用同一工具，且未取得进展。\n"
+        "重复工具调用检测结果：\n"
+        "- 工具：{tool_name}\n"
+        "- 重复次数：{count}\n"
+        "- 参数：{tool_arguments}\n"
+        "上述重复调用未产生有效进展。请勿再次使用完全相同的工具与参数进行调用。\n"
+        "请分析导致工具重复调用的原因，并采取应对方案：立刻停止工具重复调用，"
+        "调整参数、更换工具/策略，或在已有证据充分时结束任务。"
+    ),
+    "repeat_tool_pingpong_warning": (
+        "检测到 {tool_name} 与另一工具的交替循环（{count} 轮），"
+        "请合并步骤或更换策略。"
+    ),
+    "repeat_tool_pingpong_user": (
+        "[工具调用异常] Ping-Pong 交替调用已持续 {count} 轮。"
+    ),
+    "repeat_tool_pingpong_steering": (
+        "检测到 Ping-Pong 交替工具调用且未取得进展。\n"
+        "- 交替轮次：{count}\n"
+        "- 最新工具：{tool_name}\n"
+        "请停止 A↔B 工具循环。合并步骤、更换策略或换路径；"
+        "若已有证据充分，请结束任务。"
+    ),
+    "repeat_tool_unknown_tool_warning": (
+        "未知工具 {tool_name} 已连续失败 {count} 次，请停止重试。"
+    ),
+    "repeat_tool_unknown_user": (
+        "[工具调用异常] 工具 {tool_name} 已连续失败 {count} 次。"
+    ),
+    "repeat_tool_unknown_steering": (
+        "未知或失败的工具已被连续多次调用，且未取得进展。\n"
+        "重复工具调用检测结果：\n"
+        "- 工具：{tool_name}\n"
+        "- 重复次数：{count}\n"
+        "- 参数：{tool_arguments}\n"
+        "上述重复调用未产生有效进展。请勿再次使用完全相同的工具与参数进行调用。\n"
+        "请分析导致工具重复调用的原因，并采取应对方案：立刻停止工具重复调用，"
+        "调整参数、更换工具/策略，或在已有证据充分时结束任务。"
+    ),
+    "repeat_tool_global_breaker_critical": (
+        "全局断路器: {tool_name} 连续 {count} 次无进展"
+    ),
+    "repeat_tool_pingpong_critical": (
+        "Ping-Pong 循环: {count} 轮交替无进展，阻断"
+    ),
+    "repeat_tool_unknown_tool_critical": (
+        "未知工具 {tool_name} 连续调用 {count} 次，停止重试"
+    ),
+    "thinking_loop_lock_judge_intro": (
+        "检测到思考/输出陷入重复循环（检测模式={mode}，重复 **{count}** 次）。"
+        "请阅读下方重复片段并判断是否属于正常表达："
+    ),
+    "thinking_loop_lock_repeat_block_header": "问题输出原文（自重复起点起）",
+    "thinking_loop_lock_judge_question": "上述重复内容是否正常？",
+    "thinking_loop_lock_judge_yes": "是，正常继续",
+    "thinking_loop_lock_judge_yes_desc": "重复符合预期，按当前思路继续",
+    "thinking_loop_lock_judge_no": "否，需要恢复",
+    "thinking_loop_lock_judge_no_desc": "重复异常，触发恢复策略",
+    "thinking_loop_lock_steering_recovery": (
+        "[思考循环锁定] 系统判定重复内容异常（模式={mode}，重复{count}次）。\n"
+        "请严格按以下顺序执行：\n"
+        "1. 立刻停止：停止复读与沿旧路径继续生成，勿沿用刚才导致卡住的措辞与思路。\n"
+        "2. 执行策略：更换全新切入点，或基于已有信息直接给出最简下一步/结论；"
+        "禁止再铺垫与中间空转。\n"
+        "3. 再评估是否继续任务：若请求实质是测试/压测/故意诱导循环，立刻停止且勿继续生成；"
+        "否则按新策略推进。"
+    ),
+    "thinking_loop_lock_steering_continue_normal": (
+        "[思考循环锁定-继续] 用户确认刚才的输出属于正常表达。"
+        "请从中断处继续原任务，不要再次询问用户是否正常，也不要复述上述判定过程。"
+    ),
+    "thinking_loop_lock_no_user_input": "思考循环锁定：请选择「是」或「否」。",
+    "thinking_loop_lock_ask_failed": "思考循环锁定：无法获取用户判断（{detail}）。",
+    "plan_exec_judge_intro": (
+        "检测到思考过程可能陷入混乱或重复循环（LLM 语义判定异常）。"
+        "请阅读下方思考片段并判断是否属于正常表达："
+    ),
+    "plan_exec_thinking_block_header": "思考过程片段（待判定）",
+    "plan_exec_judge_question": "上述思考内容是否正常？",
+    "plan_exec_steering_recovery": (
+        "[思考循环锁定] 系统判定思考内容异常。\n"
+        "请严格按以下顺序执行：\n"
+        "1. 立刻停止：停止沿当前路径继续生成，勿沿用刚才导致卡住的措辞与思路。\n"
+        "2. 执行策略：更换全新切入点，或基于已有信息直接给出最简下一步/结论；"
+        "禁止再铺垫与中间空转。\n"
+        "3. 再评估是否继续任务：若请求实质是测试/压测/故意诱导循环，立刻停止且勿继续生成；"
+        "否则按新策略推进。"
+    ),
+    "plan_exec_semantic_deadlock_judge_intro": (
+        "检测到思考过程可能在同一组条件/对象上反复权衡、结论无法前进（**语义死锁**）。"
+        "请阅读下方思考片段并判断是否属于正常表达："
+    ),
+    "plan_exec_semantic_deadlock_steering_recovery": (
+        "[思考循环锁定] 系统判定思考内容异常（语义死锁）。\n"
+        "请严格按以下顺序执行：\n"
+        "1. 立刻停止：停止在同一前提下反复比较与空转权衡。\n"
+        "2. 执行策略：明确做出取舍或临时假设并标注；已多次无法得出结论的方向视为死路，"
+        "直接给出最简下一步行动或结论。\n"
+        "3. 再评估是否继续任务：若请求实质是测试/压测/故意诱导循环，立刻停止且勿继续生成；"
+        "否则按新策略推进。"
+    ),
+    "plan_exec_semantic_deadlock_recovery_user_notice": (
+        "检测到思考语义死锁异常，已执行恢复操作"
+    ),
+    "plan_exec_text_degradation_judge_intro": (
+        "检测到思考/输出出现断裂、粘连、乱码或词语/URL 被撕碎拼接（**文本崩坏**）。"
+        "请阅读下方片段并判断是否属于正常表达："
+    ),
+    "plan_exec_text_degradation_steering_recovery": (
+        "[思考循环锁定] 系统判定思考内容异常（文本崩坏）。\n"
+        "请严格按以下顺序执行：\n"
+        "1. 立刻停止：停止继续生成混乱、断裂或碎片化内容。\n"
+        "2. 执行策略：用完整、可读句子重写当前要点；信息不足时直接说明缺口，勿拼接碎片。\n"
+        "3. 再评估是否继续任务：若请求实质是测试/压测/故意诱导循环，立刻停止且勿继续生成；"
+        "否则按新策略推进。"
+    ),
+    "plan_exec_text_degradation_recovery_user_notice": (
+        "检测到思考文本崩坏异常，已执行恢复操作"
+    ),
+    "plan_exec_overthinking_judge_intro": (
+        "检测到思考过程冗长纠结、迟迟不收敛（**过度思考**）。"
+        "请阅读下方片段并判断是否属于正常表达："
+    ),
+    "plan_exec_overthinking_steering_recovery": (
+        "[思考循环锁定] 系统判定思考内容异常（过度思考）。\n"
+        "请严格按以下顺序执行：\n"
+        "1. 立刻停止：停止冗长纠结与重复论证。\n"
+        "2. 执行策略：已确认事实与待验证假设各不超过 3 条；跳过铺垫，"
+        "直接输出最简下一步或阶段性结论。\n"
+        "3. 再评估是否继续任务：若请求实质是测试/压测/故意诱导循环，立刻停止且勿继续生成；"
+        "否则按新策略推进。"
+    ),
+    "plan_exec_overthinking_recovery_user_notice": (
+        "检测到过度思考异常，已执行恢复操作"
+    ),
+    "thinking_loop_recovery_user_notice": (
+        "检测到思考循环异常，已执行恢复操作"
+    ),
+    "plan_exec_loop_recovery_user_notice": (
+        "检测到计划执行循环异常，已执行恢复操作"
+    ),
+    "generic_recovery_user_notice": (
+        "检测到 {kind_label} 异常，已执行恢复操作"
+    ),
+}
+
+# --- robustness_prompts_en ---
+
+robustness_prompts_en: dict[str, str] = {
+    "llm_loop_literal_low": (
+        "Detected a strict suffix cycle of {repeats} repeats in the LLM output."
+    ),
+    "llm_loop_progressive_medium": (
+        "Detected {repeats} highly similar clauses in the LLM output; possible template loop."
+    ),
+    "llm_loop_literal_high": (
+        "Detected a sustained literal loop in the LLM output "
+        "({repeats} repeats). Change strategy or end the task."
+    ),
+    "llm_loop_global_critical": (
+        "Global LLM loop: incremental output exceeded the threshold with no progress; terminating."
+    ),
+    "llm_dead_loop_agent_high": (
+        "The LLM reasoning stream may be in a semantic dead loop "
+        "({repeats} repeats). Try a new angle."
+    ),
+    "llm_dead_loop_agent_critical": (
+        "The LLM reasoning stream was judged a semantic dead loop; "
+        "stream aborted and automatic recovery applied."
+    ),
+    "repeat_tool_generic_warning": (
+        "Tool {tool_name} has been repeated {count} times; please verify it is effective."
+    ),
+    "repeat_tool_generic_user": (
+        "[Tool Call Anomaly] Tool {tool_name} has been repeated {count} times."
+    ),
+    "repeat_tool_generic_steering": (
+        "You have repeatedly called the same tool with identical parameters many times.\n"
+        "Repeated tool call detected:\n"
+        "- tool: {tool_name}\n"
+        "- repeated_times: {count}\n"
+        "- arguments: {tool_arguments}\n"
+        "The previous repeated calls did not make progress. "
+        "Do not call this exact same tool with the exact same arguments again.\n"
+        "Analyze why the tool is being called repeatedly and take corrective action: "
+        "stop repeating the same tool call immediately, adjust parameters, switch tools/strategy, "
+        "or finish the task if enough evidence has been gathered."
+    ),
+    "repeat_tool_pingpong_warning": (
+        "Detected ping-pong alternation between {tool_name} and another tool "
+        "({count} rounds). Merge steps or change strategy."
+    ),
+    "repeat_tool_pingpong_user": (
+        "[Tool Call Anomaly] Ping-pong alternating calls have continued for {count} rounds."
+    ),
+    "repeat_tool_pingpong_steering": (
+        "Ping-pong alternating tool calls detected with no progress.\n"
+        "- rounds: {count}\n"
+        "- latest tool: {tool_name}\n"
+        "Stop the A↔B tool loop. Merge steps, change approach, "
+        "or finish the task if enough evidence has been gathered."
+    ),
+    "repeat_tool_unknown_tool_warning": (
+        "Unknown tool {tool_name} has failed {count} times in a row; please stop retrying."
+    ),
+    "repeat_tool_unknown_user": (
+        "[Tool Call Anomaly] Tool {tool_name} has failed {count} times in a row."
+    ),
+    "repeat_tool_unknown_steering": (
+        "An unknown or failing tool has been called repeatedly with no progress.\n"
+        "Repeated tool call detected:\n"
+        "- tool: {tool_name}\n"
+        "- repeated_times: {count}\n"
+        "- arguments: {tool_arguments}\n"
+        "The previous repeated calls did not make progress. "
+        "Do not call this exact same tool with the exact same arguments again.\n"
+        "Analyze why the tool is being called repeatedly and take corrective action: "
+        "stop repeating the same tool call immediately, adjust parameters, switch tools/strategy, "
+        "or finish the task if enough evidence has been gathered."
+    ),
+    "repeat_tool_global_breaker_critical": (
+        "Circuit breaker: {tool_name} made no progress for {count} consecutive calls"
+    ),
+    "repeat_tool_pingpong_critical": (
+        "Ping-pong loop: {count} alternating calls with no progress, blocked"
+    ),
+    "repeat_tool_unknown_tool_critical": (
+        "Unknown tool {tool_name} called {count} times in a row, stopping retries"
+    ),
+    "thinking_loop_lock_judge_intro": (
+        "Thinking/output stuck in a repeat loop (mode={mode}, **{count}** repeats). "
+        "Review the repeated excerpt below and judge whether it is expected:"
+    ),
+    "thinking_loop_lock_repeat_block_header": "Original output (from repeat start)",
+    "thinking_loop_lock_judge_question": "Is this repetition normal?",
+    "thinking_loop_lock_judge_yes": "Yes, continue",
+    "thinking_loop_lock_judge_yes_desc": "Expected repetition; continue as-is",
+    "thinking_loop_lock_judge_no": "No, recover",
+    "thinking_loop_lock_judge_no_desc": "Abnormal repetition; apply recovery",
+    "thinking_loop_lock_steering_recovery": (
+        "[Thinking Loop Lock] System judged repetition abnormal "
+        "(mode={mode}, count={count}).\n"
+        "Follow these steps in order:\n"
+        "1. Stop immediately: stop repeating and stop continuing along the old path; "
+        "do not reuse the wording or reasoning that just caused you to get stuck.\n"
+        "2. Execute strategy: switch to a fresh angle, or give the most concise next "
+        "step/conclusion from what you already know; no more setup or idle churn.\n"
+        "3. Re-evaluate whether to continue: if the request is essentially a "
+        "test/stress/adversarial loop-inducing task, stop and do not continue "
+        "generating; otherwise proceed with the new strategy."
+    ),
+    "thinking_loop_lock_steering_continue_normal": (
+        "[Thinking Loop Lock Continue] The user confirmed the recent output "
+        "is expected/normal. Resume the original task from the interruption "
+        "point. Do not ask again whether it is normal, and do not restate "
+        "this confirmation."
+    ),
+    "thinking_loop_lock_no_user_input": (
+        "Thinking loop lock: please choose Yes or No."
+    ),
+    "thinking_loop_lock_ask_failed": (
+        "Thinking loop lock: could not obtain user judgment ({detail})."
+    ),
+    "plan_exec_judge_intro": (
+        "Thinking may be confused or stuck in a loop (LLM semantic judge: abnormal). "
+        "Review the excerpt below and judge whether it is expected:"
+    ),
+    "plan_exec_thinking_block_header": "Reasoning excerpt (for review)",
+    "plan_exec_judge_question": "Is this reasoning normal?",
+    "plan_exec_steering_recovery": (
+        "[Thinking Loop Lock] System judged reasoning abnormal.\n"
+        "Follow these steps in order:\n"
+        "1. Stop immediately: stop continuing along the current path; do not reuse "
+        "the wording or reasoning that just caused you to get stuck.\n"
+        "2. Execute strategy: switch to a fresh angle, or give the most concise next "
+        "step/conclusion from what you already know; no more setup or idle churn.\n"
+        "3. Re-evaluate whether to continue: if the request is essentially a "
+        "test/stress/adversarial loop-inducing task, stop and do not continue "
+        "generating; otherwise proceed with the new strategy."
+    ),
+    "plan_exec_semantic_deadlock_judge_intro": (
+        "Thinking may be stuck weighing the same objects/conditions without "
+        "progress (**semantic deadlock**). Review the excerpt below and judge "
+        "whether it is expected:"
+    ),
+    "plan_exec_semantic_deadlock_steering_recovery": (
+        "[Thinking Loop Lock] System judged reasoning abnormal (semantic deadlock).\n"
+        "Follow these steps in order:\n"
+        "1. Stop immediately: stop comparing under the same premises and idle "
+        "weighing loops.\n"
+        "2. Execute strategy: make a clear trade-off or state a temporary "
+        "assumption; treat repeatedly dead-end directions as closed, and output "
+        "only the most concise next action or conclusion.\n"
+        "3. Re-evaluate whether to continue: if the request is essentially a "
+        "test/stress/adversarial loop-inducing task, stop and do not continue "
+        "generating; otherwise proceed with the new strategy."
+    ),
+    "plan_exec_semantic_deadlock_recovery_user_notice": (
+        "Detected a semantic deadlock anomaly; recovery has been applied"
+    ),
+    "plan_exec_text_degradation_judge_intro": (
+        "Thinking/output may show breaks, garbling, or shredded URL/word "
+        "fragments (**text degradation**). Review the excerpt below and judge "
+        "whether it is expected:"
+    ),
+    "plan_exec_text_degradation_steering_recovery": (
+        "[Thinking Loop Lock] System judged reasoning abnormal (text degradation).\n"
+        "Follow these steps in order:\n"
+        "1. Stop immediately: stop generating garbled, broken, or fragmented text.\n"
+        "2. Execute strategy: rewrite the current point in complete, readable "
+        "sentences; if information is missing, state the gap—do not stitch "
+        "fragments together.\n"
+        "3. Re-evaluate whether to continue: if the request is essentially a "
+        "test/stress/adversarial loop-inducing task, stop and do not continue "
+        "generating; otherwise proceed with the new strategy."
+    ),
+    "plan_exec_text_degradation_recovery_user_notice": (
+        "Detected a text degradation anomaly; recovery has been applied"
+    ),
+    "plan_exec_overthinking_judge_intro": (
+        "Thinking may be verbose and indecisive without converging "
+        "(**overthinking**). Review the excerpt below and judge whether it is "
+        "expected:"
+    ),
+    "plan_exec_overthinking_steering_recovery": (
+        "[Thinking Loop Lock] System judged reasoning abnormal (overthinking).\n"
+        "Follow these steps in order:\n"
+        "1. Stop immediately: stop verbose indecision and repeated argumentation.\n"
+        "2. Execute strategy: at most 3 confirmed facts and 3 open hypotheses; "
+        "skip setup and output the most concise next step or interim conclusion.\n"
+        "3. Re-evaluate whether to continue: if the request is essentially a "
+        "test/stress/adversarial loop-inducing task, stop and do not continue "
+        "generating; otherwise proceed with the new strategy."
+    ),
+    "plan_exec_overthinking_recovery_user_notice": (
+        "Detected an overthinking anomaly; recovery has been applied"
+    ),
+    "thinking_loop_recovery_user_notice": (
+        "Detected a thinking loop anomaly; recovery has been applied"
+    ),
+    "plan_exec_loop_recovery_user_notice": (
+        "Detected a plan-execution loop anomaly; recovery has been applied"
+    ),
+    "generic_recovery_user_notice": (
+        "Detected a {kind_label} anomaly; recovery has been applied"
+    ),
+}
+
+# --- message_catalog ---
+
+
+# Backward-compatible aliases (deprecated: use robustness_prompts_*).
+cn_messages = robustness_prompts_cn
+en_messages = robustness_prompts_en
+
+_LOCALES: dict[str, dict[str, str]] = {
+    "cn": robustness_prompts_cn,
+    "zh": robustness_prompts_cn,
+    "en": robustness_prompts_en,
+}
+_DEFAULT_LOCALE = "cn"
+
+_STEERING_BY_EVIDENCE: dict[str, str] = {
+    "generic_repeat": "repeat_tool_generic_steering",
+    "ping_pong_warning": "repeat_tool_pingpong_steering",
+    "unknown_tool_repeat_warning": "repeat_tool_unknown_steering",
+}
+
+_USER_WARNING_BY_EVIDENCE: dict[str, str] = {
+    "generic_repeat": "repeat_tool_generic_user",
+    "ping_pong_warning": "repeat_tool_pingpong_user",
+    "unknown_tool_repeat_warning": "repeat_tool_unknown_user",
+}
+
+_CRITICAL_BY_EVIDENCE: dict[str, str] = {
+    "global_circuit_breaker": "repeat_tool_global_breaker_critical",
+    "unknown_tool_repeat": "repeat_tool_unknown_tool_critical",
+    "ping_pong_critical": "repeat_tool_pingpong_critical",
+}
+
+_GENERIC_STEER_CN = (
+    "检测到 {kind} 异常（{summary}），"
+    "请尝试调整参数、更换工具/策略，"
+    "或在已有证据充分时结束任务。"
+)
+_GENERIC_STEER_EN = (
+    "Detected {kind} anomaly ({summary}). "
+    "Please adjust parameters, switch tools/strategy, "
+    "or finish the task if enough evidence has been gathered."
+)
+
+_PLAN_EXEC_FAULT_KEYS: dict[str, tuple[str, str, str]] = {
+    "semantic_deadlock": (
+        "plan_exec_semantic_deadlock_judge_intro",
+        "plan_exec_semantic_deadlock_steering_recovery",
+        "plan_exec_semantic_deadlock_recovery_user_notice",
+    ),
+    "text_degradation": (
+        "plan_exec_text_degradation_judge_intro",
+        "plan_exec_text_degradation_steering_recovery",
+        "plan_exec_text_degradation_recovery_user_notice",
+    ),
+    "overthinking": (
+        "plan_exec_overthinking_judge_intro",
+        "plan_exec_overthinking_steering_recovery",
+        "plan_exec_overthinking_recovery_user_notice",
+    ),
+}
+
+_PLAN_EXEC_DEFAULT_KEYS = (
+    "plan_exec_judge_intro",
+    "plan_exec_steering_recovery",
+    "plan_exec_loop_recovery_user_notice",
+)
+
+
+def _plan_exec_fault(pending: PendingRecovery) -> str | None:
+    fault = str(pending.extra.get("primary_fault") or "").strip()
+    return fault if fault in _PLAN_EXEC_FAULT_KEYS else None
+
+
+def _plan_exec_message_keys(pending: PendingRecovery) -> tuple[str, str, str]:
+    fault = _plan_exec_fault(pending)
+    if fault is not None:
+        return _PLAN_EXEC_FAULT_KEYS[fault]
+    return _PLAN_EXEC_DEFAULT_KEYS
+
+
+def _table(locale: str) -> dict[str, str]:
+    loc = (locale or "cn").strip().lower()
+    if loc == "zh":
+        loc = "cn"
+    return _LOCALES.get(loc) or _LOCALES[_DEFAULT_LOCALE]
+
+
+def load_message(locale: str, key: str, **kwargs: Any) -> str:
+    """Render a robustness prompt template (public API)."""
+    table = _table(locale)
+    template = table.get(key)
+    if template is None:
+        template = _LOCALES[_DEFAULT_LOCALE].get(key)
+    if template is None:
+        raise KeyError(
+            f"prompt key {key!r} not found in locale {locale!r} "
+            f"or fallback {_DEFAULT_LOCALE!r}"
+        )
+    try:
+        return template.format(**kwargs)
+    except (KeyError, IndexError):
+        return template
+
+
+def render(template_key: str, locale: str = "cn", **kwargs: Any) -> str:
+    template = _table(locale).get(template_key) or template_key
+    try:
+        return template.format(**kwargs)
+    except (KeyError, IndexError):
+        return template
+
+
+_STEERING_OPEN = "<system-reminder>"
+_STEERING_CLOSE = "</system-reminder>"
+
+
+def format_steering(body: str) -> str:
+    """Wrap steering body in the standard ``<system-reminder>`` envelope.
+
+    Idempotent: already-wrapped text is returned unchanged (aside from strip).
+    Templates should store body only; callers should prefer this helper (or
+    ``inject_steering``, which applies it by default).
+    """
+    text = (body or "").strip()
+    if not text:
+        return text
+    if text.startswith(_STEERING_OPEN) and text.endswith(_STEERING_CLOSE):
+        return text
+    inner = text
+    if inner.startswith(_STEERING_OPEN):
+        inner = inner[len(_STEERING_OPEN):].lstrip("\n")
+    if inner.endswith(_STEERING_CLOSE):
+        inner = inner[: -len(_STEERING_CLOSE)].rstrip()
+    return f"{_STEERING_OPEN}\n{inner}\n{_STEERING_CLOSE}"
+
+
+def _repeat_tool_fields(anomaly: Anomaly) -> dict[str, Any]:
+    evidence = anomaly.evidence or {}
+    return {
+        "tool_name": anomaly.member_name,
+        "count": int(evidence.get("count") or 0),
+        "tool_arguments": str(evidence.get("tool_arguments") or ""),
+    }
+
+
+def steer_text_for(anomaly: Anomaly, locale: str = "cn") -> str | None:
+    evidence = anomaly.evidence or {}
+    msg_key = evidence.get("msg_key") or ""
+    template_key = _STEERING_BY_EVIDENCE.get(msg_key)
+    if not template_key:
+        return None
+    return format_steering(
+        render(template_key, locale, **_repeat_tool_fields(anomaly))
+    )
+
+
+def user_warning_text_for(anomaly: Anomaly, locale: str = "cn") -> str | None:
+    evidence = anomaly.evidence or {}
+    msg_key = evidence.get("msg_key") or ""
+    template_key = _USER_WARNING_BY_EVIDENCE.get(msg_key)
+    if not template_key:
+        return None
+    fields = _repeat_tool_fields(anomaly)
+    fields.pop("tool_arguments", None)
+    return render(template_key, locale, **fields)
+
+
+def user_notice_text_for(anomaly: Anomaly, locale: str = "cn") -> str | None:
+    """Short user-facing notice for any anomaly (detector-specific when available)."""
+    specific = user_warning_text_for(anomaly, locale=locale)
+    if specific:
+        return specific
+    return None
+
+
+_KIND_LABELS: dict[str, dict[AnomalyKind, str]] = {
+    "cn": {
+        AnomalyKind.LLM_THINKING_LOOP: "思考循环",
+        AnomalyKind.LLM_THINKING_DEAD_LOOP: "思考死循环",
+        AnomalyKind.REPEAT_TOOL_CALL: "工具重复调用",
+        AnomalyKind.TOOL_CALL_LOOP: "工具调用循环",
+    },
+    "en": {
+        AnomalyKind.LLM_THINKING_LOOP: "thinking loop",
+        AnomalyKind.LLM_THINKING_DEAD_LOOP: "thinking dead loop",
+        AnomalyKind.REPEAT_TOOL_CALL: "repeat tool call",
+        AnomalyKind.TOOL_CALL_LOOP: "tool call loop",
+    },
+}
+
+
+def _kind_label_for(anomaly: Anomaly, locale: str) -> str:
+    loc = (locale or "cn").strip().lower()
+    if loc == "zh":
+        loc = "cn"
+    labels = _KIND_LABELS.get(loc) or _KIND_LABELS["cn"]
+    return labels.get(anomaly.kind, anomaly.kind.value)
+
+
+def recovery_user_notice_for(pending: PendingRecovery, locale: str = "cn") -> str:
+    """User-facing notice after automatic recovery is applied."""
+    profile = pending.recovery_profile
+    if profile == "thinking_loop_plan_exec" or pending.source == "plan_execution_loop_lock":
+        _, _, notice_key = _plan_exec_message_keys(pending)
+        return render(notice_key, locale)
+    if profile == "thinking_loop_text_rep" or pending.source == "text_repetition":
+        return render("thinking_loop_recovery_user_notice", locale)
+    return render("thinking_loop_recovery_user_notice", locale)
+
+
+def recovery_user_notice_for_anomaly(anomaly: Anomaly, locale: str = "cn") -> str:
+    """Recovery notice from an anomaly (immediate apply path)."""
+    pending = PendingRecovery.from_anomaly(anomaly)
+    if pending.recovery_profile or pending.source in (
+        "plan_execution_loop_lock",
+        "text_repetition",
+    ):
+        return recovery_user_notice_for(pending, locale=locale)
+    return render(
+        "generic_recovery_user_notice",
+        locale,
+        kind_label=_kind_label_for(anomaly, locale),
+    )
+
+
+def critical_text_for(anomaly: Anomaly, locale: str = "cn") -> str:
+    evidence = anomaly.evidence or {}
+    msg_key = evidence.get("msg_key") or ""
+    template_key = _CRITICAL_BY_EVIDENCE.get(msg_key, msg_key)
+    return render(template_key, locale, **_repeat_tool_fields(anomaly))
+
+
+def generic_steer_text_for(anomaly: Anomaly, locale: str = "cn") -> str:
+    template = _GENERIC_STEER_EN if locale == "en" else _GENERIC_STEER_CN
+    try:
+        body = template.format(kind=anomaly.kind.value, summary=anomaly.summary)
+    except (KeyError, IndexError):
+        body = template
+    return format_steering(body)
+
+
+def recovery_steering_on_abnormal(pending: PendingRecovery, locale: str = "cn") -> str:
+    """Steering injected after automatic recovery confirms an abnormal thinking loop."""
+    profile = pending.recovery_profile
+    if profile == "thinking_loop_plan_exec" or pending.source == "plan_execution_loop_lock":
+        _, steering_key, _ = _plan_exec_message_keys(pending)
+        return format_steering(render(steering_key, locale))
+    return format_steering(
+        render(
+            "thinking_loop_lock_steering_recovery",
+            locale,
+            mode=pending.mode,
+            count=pending.count,
+        )
+    )
+
+
+def format_repeat_display(scanned_text: str, start_pos: int, max_len: int = 1200) -> str:
+    if not scanned_text:
+        return ""
+    text = scanned_text[start_pos:] if start_pos > 0 else scanned_text
+    if len(text) > max_len:
+        return text[:max_len] + "…"
+    return text
+
+
+def extract_repeat_unit(scanned_text: str, start_pos: int, max_unit: int = 200) -> str:
+    unit = format_repeat_display(scanned_text, start_pos, max_len=max_unit)
+    return unit or "(无法提取重复片段)"

--- a/openjiuwen/harness/agent_ras/recovery/skills/llm-loop-review/SKILL.md
+++ b/openjiuwen/harness/agent_ras/recovery/skills/llm-loop-review/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: llm-loop-review
+description: Recovery-side second opinion for LLM thinking-loop L3 first verdicts.
+---
+
+# LLM 思考循环二次复核（Recovery Reviewer）
+
+你是恢复侧二次复核审查员。输入包含**首次 L3 检测结果**与对应思考片段。
+请独立复核该结论是否成立，并选出**唯一**的 `primary_fault`。
+
+## 输入说明
+
+调用方会提供：
+
+- `first_verdict`：首次检测的 `abnormal` / `primary_fault` / `confidence` / `rationale`
+- `thinking_excerpt`：触发检测的增量思考/输出片段
+
+你应基于片段本身复核，而不是盲目复述首次结论。
+
+## 故障类型（primary_fault）
+
+### semantic_deadlock（语义死锁）
+
+- 对同一批对象/选项/来源/条件反复权衡，换说法但结论不前进
+- 「等一下」「再看看」「不对」后重新回到旧论点或旧分析路径
+- 同一段分析逻辑在片段内重复出现（即使措辞不同）
+
+### text_degradation（文本崩坏）
+
+- 语句明显不连续：前后句断裂、半句话拼接、词组被截断后硬接另一段内容
+- 出现乱码或粘连：字符错位、无意义混排、URL/词语/数字被撕碎后交叉拼接
+
+### overthinking（过度思考）
+
+- 推理冗长、反复自我质疑，但仍有微弱推进迹象
+- 大量铺垫与重复论证，迟迟不收敛到下一步或结论
+
+### none（正常）
+
+- 推理在引入新信息、缩小选项、或明确向答案推进
+- 首次检测可能误报：长推理、合理复核、可理解的重复强调
+
+## 互斥与优先级
+
+若多种信号并存，**只选一个** `primary_fault`，按优先级：
+
+1. `text_degradation`
+2. `semantic_deadlock`
+3. `overthinking`
+4. 否则 `none`
+
+## 触发规则
+
+- `primary_fault != "none"` 时，必须设 `abnormal: true`
+- `primary_fault == "none"` 时，必须设 `abnormal: false`
+- `abnormal` 与 `primary_fault` 必须一致，否则视为无效输出
+
+## 输出格式（强制）
+
+加载本 Skill 并完成判定后，**最终 assistant 回复必须且只能是一个 JSON 对象**（可裸 JSON，或用 ```json 代码块包裹）。
+禁止在回复中加入解释性文字、Markdown 标题或其他非 JSON 内容。
+禁止调用 `skill_complete`。
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `abnormal` | boolean | 是 | 是否确认异常 |
+| `primary_fault` | string | 是 | `none` / `semantic_deadlock` / `text_degradation` / `overthinking` |
+| `confidence` | number | 否 | 0.0–1.0 |
+| `rationale` | string | 否 | 简短复核理由 |
+
+示例（确认异常）：
+
+```json
+{
+  "abnormal": true,
+  "primary_fault": "semantic_deadlock",
+  "confidence": 0.8,
+  "rationale": "复核确认：反复权衡同一批来源且无新结论"
+}
+```
+
+示例（推翻误报，按正常）：
+
+```json
+{
+  "abnormal": false,
+  "primary_fault": "none",
+  "confidence": 0.75,
+  "rationale": "长推理在缩小选项，首次检测偏严"
+}
+```
+
+复核材料：
+{payload}

--- a/openjiuwen/harness/agent_ras/recovery/state.py
+++ b/openjiuwen/harness/agent_ras/recovery/state.py
@@ -1,0 +1,138 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Session-local deferred recovery and stream-buffer state.
+
+``PendingRecovery`` carries recovery context derived from an anomaly's evidence.
+``SuppressFlushState`` buffers suppressed stream text until automatic recovery
+resolves (flush on normal/fail-open, clear on abnormal). Held by
+``RecoveryExecutor.suppress_state``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from openjiuwen.harness.agent_ras.models import Anomaly
+
+RecoveryResolved = Literal["normal", "abnormal"]
+
+
+@dataclass
+class PendingRecovery:
+    """Deferred recovery payload for a thinking-loop (or similar) anomaly."""
+
+    source: str
+    recovery_profile: str = ""
+    chunk_type: str = "llm_output"
+    mode: str = ""
+    count: int = 0
+    start_pos: int = 0
+    scanned_text: str = ""
+    thinking_excerpt: str = ""
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_anomaly(cls, anomaly: Anomaly) -> PendingRecovery:
+        """Build pending state from ``anomaly.evidence`` (profile / channel / excerpt)."""
+        evidence = dict(anomaly.evidence or {})
+        channel = str(evidence.pop("channel", "") or "")
+        mode = str(evidence.get("mode") or "")
+        profile = str(evidence.get("recovery_profile") or "")
+        if not profile:
+            if mode == "plan_execution_loop_lock" or channel == "plan_execution":
+                profile = "thinking_loop_plan_exec"
+            elif channel == "text_repetition":
+                profile = "thinking_loop_text_rep"
+        if mode == "plan_execution_loop_lock" or channel == "plan_execution":
+            source = "plan_execution_loop_lock"
+        elif channel == "text_repetition":
+            source = "text_repetition"
+        else:
+            source = mode or channel or anomaly.kind.value
+        return cls(
+            source=source,
+            recovery_profile=profile,
+            chunk_type=str(evidence.get("chunk_type") or "llm_output"),
+            mode=mode,
+            count=int(evidence.get("count") or 0),
+            start_pos=int(evidence.get("start_pos") or 0),
+            scanned_text=str(evidence.get("scanned_text") or ""),
+            thinking_excerpt=str(evidence.get("thinking_excerpt") or ""),
+            extra=evidence,
+        )
+
+    @property
+    def is_plan_execution(self) -> bool:
+        return (
+            self.source == "plan_execution_loop_lock"
+            or self.recovery_profile == "thinking_loop_plan_exec"
+            or self.mode == "plan_execution_loop_lock"
+        )
+
+    @property
+    def is_text_repetition(self) -> bool:
+        return (
+            self.source == "text_repetition"
+            or self.recovery_profile == "thinking_loop_text_rep"
+        )
+
+
+@dataclass
+class SuppressFlushState:
+    """Stream suppress buffer plus optional pending recovery for one session.
+
+    Lifecycle fields:
+
+    - ``review_awaiting``: L3 recovery background task is in flight
+    - ``resolved``: ``\"normal\"`` / ``\"abnormal\"`` once recovery decided
+    """
+
+    pending: PendingRecovery | None = None
+    cleared_normal: bool = False
+    suppressed: dict[str, list[str]] = field(default_factory=dict)
+    review_awaiting: bool = False
+    resolved: RecoveryResolved | None = None
+
+    def record_pending(self, pending: PendingRecovery) -> None:
+        """Arm deferred recovery; subsequent matching chunks are suppressed."""
+        self.pending = pending
+        self.cleared_normal = False
+        self.review_awaiting = False
+        self.resolved = None
+
+    def should_suppress(self, chunk_type: str) -> bool:
+        """True while pending recovery is active for this chunk type."""
+        return (
+            self.pending is not None
+            and not self.cleared_normal
+            and chunk_type == self.pending.chunk_type
+        )
+
+    def record_suppressed(self, chunk_type: str, text: str) -> None:
+        """Append suppressed stream text for a later flush."""
+        if text:
+            self.suppressed.setdefault(chunk_type, []).append(text)
+
+    def flush_suppressed(self, chunk_type: str) -> str:
+        """Join and clear buffered text for ``chunk_type`` (normal path)."""
+        return "".join(self.suppressed.pop(chunk_type, []))
+
+    def clear(self) -> None:
+        """Drop pending and all buffers (abnormal / reset)."""
+        self.pending = None
+        self.cleared_normal = False
+        self.suppressed.clear()
+        self.review_awaiting = False
+        self.resolved = None
+
+    def mark_resolved_normal(self) -> None:
+        """Normal / fail-open: stop suppressing but keep buffers for flush."""
+        self.cleared_normal = True
+        self.pending = None
+        self.review_awaiting = False
+        self.resolved = "normal"
+
+    def mark_resolved_abnormal(self) -> None:
+        """Abnormal: decision recorded; caller clears buffers."""
+        self.review_awaiting = False
+        self.resolved = "abnormal"

--- a/openjiuwen/harness/agent_ras/reporter.py
+++ b/openjiuwen/harness/agent_ras/reporter.py
@@ -1,0 +1,24 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Optional anomaly sink protocol between Monitor and external reporters.
+
+This module defines only the typing contract. A single-Agent Monitor may pass
+``reporter=None`` and skip external reporting.
+"""
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from openjiuwen.harness.agent_ras.models import Anomaly
+
+
+@runtime_checkable
+class AnomalyReporter(Protocol):
+    """Structural protocol: ``async report(anomaly)`` for optional sinks.
+
+    Implementations may also expose ``bind_ctx`` and ``handles_all_anomalies``.
+    """
+
+    async def report(self, anomaly: Anomaly) -> None:
+        """Forward one detected anomaly to the configured sink."""
+        ...

--- a/openjiuwen/harness/agent_ras/signal_builder.py
+++ b/openjiuwen/harness/agent_ras/signal_builder.py
@@ -1,0 +1,127 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Shared Signal construction helpers for Agent RAS rails."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from openjiuwen.harness.agent_ras.models import Signal, SignalKind
+
+
+def tool_args_as_dict(args: Any) -> dict[str, Any] | None:
+    if isinstance(args, dict):
+        return args
+    dump = getattr(args, "model_dump", None)
+    if callable(dump):
+        try:
+            value = dump()
+            return value if isinstance(value, dict) else {"value": value}
+        except (TypeError, ValueError):
+            return {"raw": str(args)}
+    if isinstance(args, str):
+        try:
+            value = json.loads(args)
+        except (TypeError, ValueError):
+            return {"raw": args}
+        return value if isinstance(value, dict) else {"value": value}
+    if args is None:
+        return None
+    return {"raw": str(args)}
+
+
+def tool_msg_content_from_inputs(inputs: Any) -> str | None:
+    tool_msg = getattr(inputs, "tool_msg", None)
+    if tool_msg is None:
+        return None
+    content = getattr(tool_msg, "content", None)
+    if isinstance(content, str):
+        return content
+    if isinstance(tool_msg, str):
+        return tool_msg
+    return str(tool_msg)
+
+
+def measure_text(response: Any) -> tuple[int | None, int | None]:
+    if response is None:
+        return None, None
+    content = getattr(response, "content", None)
+    text_len = len(content) if isinstance(content, str) else None
+    reasoning = (
+        getattr(response, "reasoning_content", None)
+        or getattr(response, "thinking", None)
+    )
+    thinking_len = len(reasoning) if isinstance(reasoning, str) else None
+    return text_len, thinking_len
+
+
+def error_text(exc: Exception | None) -> str:
+    return str(exc) if exc is not None else "error"
+
+
+def build_before_tool_call_signal(member_name: str, inputs: Any) -> Signal:
+    return Signal(
+        kind=SignalKind.BEFORE_TOOL_CALL,
+        member_name=member_name,
+        tool_name=getattr(inputs, "tool_name", "") or "",
+        tool_args=tool_args_as_dict(getattr(inputs, "tool_args", None)),
+    )
+
+
+def build_after_tool_call_signal(member_name: str, inputs: Any) -> Signal:
+    return Signal(
+        kind=SignalKind.AFTER_TOOL_CALL,
+        member_name=member_name,
+        tool_name=getattr(inputs, "tool_name", "") or "",
+        tool_args=tool_args_as_dict(getattr(inputs, "tool_args", None)),
+        tool_result=getattr(inputs, "tool_result", None),
+        tool_msg_content=tool_msg_content_from_inputs(inputs),
+    )
+
+
+def build_tool_exception_signal(member_name: str, inputs: Any, exc: Exception | None) -> Signal:
+    return Signal(
+        kind=SignalKind.TOOL_EXCEPTION,
+        member_name=member_name,
+        tool_name=getattr(inputs, "tool_name", "") or "",
+        error=error_text(exc),
+        tool_msg_content=tool_msg_content_from_inputs(inputs),
+    )
+
+
+def build_model_exception_signal(member_name: str, exc: Exception | None) -> Signal:
+    return Signal(
+        kind=SignalKind.MODEL_EXCEPTION,
+        member_name=member_name,
+        error=error_text(exc),
+    )
+
+
+def build_before_model_call_signal(member_name: str, inputs: Any) -> Signal:
+    messages = getattr(inputs, "messages", None)
+    count = len(messages) if isinstance(messages, list) else None
+    return Signal(
+        kind=SignalKind.BEFORE_MODEL_CALL,
+        member_name=member_name,
+        message_count=count,
+    )
+
+
+def build_after_model_call_signal(member_name: str, inputs: Any) -> Signal:
+    text_len, thinking_len = measure_text(getattr(inputs, "response", None))
+    return Signal(
+        kind=SignalKind.AFTER_MODEL_CALL,
+        member_name=member_name,
+        text_len=text_len,
+        thinking_len=thinking_len,
+    )
+
+
+def build_stream_chunk_signal(member_name: str, inputs: Any) -> Signal:
+    return Signal(
+        kind=SignalKind.STREAM_CHUNK,
+        member_name=member_name,
+        chunk_type=getattr(inputs, "chunk_type", None) or "llm_output",
+        chunk_text=getattr(inputs, "chunk_text", None) or "",
+    )

--- a/openjiuwen/harness/agent_ras/stream_observer.py
+++ b/openjiuwen/harness/agent_ras/stream_observer.py
@@ -1,0 +1,166 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Session write_stream observer for Agent RAS stream detection.
+
+Registers on ``{session_id}write_stream`` (fired by ``Session.write_stream``
+*before* the payload is written to the stream writer). Truncation by
+``Monitor.on_stream_chunk`` therefore still affects what the frontend sees.
+
+Same-session sequential rebinding is allowed (``before_invoke`` →
+``before_model_call`` may use different ctx objects). Cross-session rebind
+while attached is rejected.
+"""
+from __future__ import annotations
+
+from typing import Any, Callable, Awaitable
+
+from openjiuwen.core.common.logging import logger
+from openjiuwen.core.single_agent.rail.base import AgentCallbackContext
+
+# Visible assistant token streams scanned by thinking-loop detectors.
+_LLM_STREAM_TYPES = frozenset({"llm_output", "llm_reasoning"})
+
+OnChunk = Callable[
+    [str, str, Any, AgentCallbackContext],
+    Awaitable[None],
+]
+
+
+def _session_id_from_ctx(ctx: AgentCallbackContext) -> str | None:
+    """Best-effort session id from callback ctx (session or inputs)."""
+    session = getattr(ctx, "session", None)
+    getter = getattr(session, "get_session_id", None)
+    if callable(getter):
+        try:
+            sid = str(getter() or "").strip()
+            if sid:
+                return sid
+        except Exception:
+            logger.debug(
+                "StreamObserver session id lookup failed",
+                exc_info=True,
+            )
+    inputs = getattr(ctx, "inputs", None)
+    cid = getattr(inputs, "conversation_id", None)
+    if cid is not None:
+        sid = str(cid).strip()
+        if sid:
+            return sid
+    return None
+
+
+class StreamObserver:
+    """Bind one session's write_stream events to an on_chunk coroutine."""
+
+    def __init__(self, on_chunk: OnChunk) -> None:
+        self._on_chunk = on_chunk
+        self._ctx: AgentCallbackContext | None = None
+        self._event: str | None = None
+        self._session_id: str | None = None
+        self._attached = False
+
+    def bind_ctx(self, ctx: AgentCallbackContext | None) -> bool:
+        """Bind the invoke callback context forwarded to Monitor.
+
+        Same-session rebinding is allowed so ``before_invoke`` and
+        ``before_model_call`` may use different ctx objects. While attached,
+        a ctx whose session_id differs from this observer's session is
+        rejected.
+
+        Returns:
+            ``True`` if the binding was applied, ``False`` if rejected.
+        """
+        if ctx is None:
+            self._ctx = None
+            return True
+        if self._attached and self._session_id is not None:
+            ctx_sid = _session_id_from_ctx(ctx)
+            if ctx_sid is not None and ctx_sid != self._session_id:
+                logger.warning(
+                    "StreamObserver reject bind_ctx: ctx session=%s != "
+                    "observer session=%s",
+                    ctx_sid,
+                    self._session_id,
+                )
+                return False
+        self._ctx = ctx
+        return True
+
+    @property
+    def attached(self) -> bool:
+        return self._attached
+
+    async def attach(self, session_id: str) -> None:
+        """Register the write_stream callback for ``session_id``."""
+        if self._attached:
+            return
+        sid = str(session_id or "").strip() or "default"
+        event = f"{sid}write_stream"
+        from openjiuwen.core.runner import Runner
+
+        await Runner.callback_framework.register(
+            event,
+            self._on_write_stream,
+            priority=100,
+            namespace="agent_ras",
+            tags={"agent_ras_stream"},
+        )
+        self._event = event
+        self._session_id = sid
+        self._attached = True
+
+    async def detach(self) -> None:
+        """Unregister the write_stream callback if attached."""
+        if not self._attached or not self._event:
+            self._ctx = None
+            self._session_id = None
+            return
+        from openjiuwen.core.runner import Runner
+
+        try:
+            await Runner.callback_framework.unregister(
+                self._event, self._on_write_stream,
+            )
+        except Exception:
+            logger.debug(
+                "StreamObserver detach failed event=%s",
+                self._event,
+                exc_info=True,
+            )
+        self._event = None
+        self._attached = False
+        self._session_id = None
+        self._ctx = None
+
+    async def _on_write_stream(self, *, data: Any = None, **_: Any) -> None:
+        """Callback Framework entry: inspect/truncate llm_* payloads."""
+        ctx = self._ctx
+        if ctx is None or data is None:
+            return
+        chunk_type, chunk_text = _extract_chunk(data)
+        if chunk_type not in _LLM_STREAM_TYPES:
+            return
+        try:
+            await self._on_chunk(chunk_type, chunk_text, data, ctx)
+        except Exception:
+            logger.warning(
+                "StreamObserver on_chunk failed type=%s",
+                chunk_type,
+                exc_info=True,
+            )
+
+
+def _extract_chunk(data: Any) -> tuple[str, str]:
+    """Return (type, content text) from an OutputSchema or dict."""
+    if isinstance(data, dict):
+        chunk_type = str(data.get("type") or "")
+        payload = data.get("payload")
+    else:
+        chunk_type = str(getattr(data, "type", "") or "")
+        payload = getattr(data, "payload", None)
+    text = ""
+    if isinstance(payload, dict):
+        text = str(payload.get("content") or "")
+    elif payload is not None:
+        text = str(getattr(payload, "content", "") or "")
+    return chunk_type, text

--- a/openjiuwen/harness/agent_ras/window.py
+++ b/openjiuwen/harness/agent_ras/window.py
@@ -1,0 +1,115 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Sliding-window counters and stable call hashing for detectors (single-Agent).
+
+Shared algorithm utilities (100% reused from develop branch):
+  - ``SlidingWindowCounter``: time-bucketed event counting for error-rate /
+    frequency sampling. Avoids the boundary spikes of fixed windows.
+  - ``stable_call_hash``: order-independent hash of a tool call so that
+    ``{"a": 1, "b": 2}`` and ``{"b": 2, "a": 1}`` collide, preventing repeat
+    detection from missing reordered-argument calls.
+  - ``stable_result_hash``: order-independent hash of a tool result.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import deque
+from typing import Any
+
+
+class SlidingWindowCounter:
+    """Count events within a trailing time window.
+
+    Keeps event timestamps in a deque and evicts those older than
+    ``window_seconds`` before the reference time on every operation. Callers
+    pass the current timestamp explicitly so the counter stays deterministic
+    and testable (no internal clock).
+    """
+
+    def __init__(self, window_seconds: float) -> None:
+        """Initialize the counter.
+
+        Args:
+            window_seconds: Trailing window width in seconds.
+        """
+        self._window = window_seconds
+        self._events: deque[float] = deque()
+
+    def add(self, ts: float) -> int:
+        """Record an event at ``ts`` and return the in-window count.
+
+        Args:
+            ts: Event timestamp in seconds.
+
+        Returns:
+            Number of events within the trailing window, including this one.
+        """
+        self._events.append(ts)
+        self._evict(ts)
+        return len(self._events)
+
+    def reset(self) -> None:
+        """Drop all recorded events."""
+        self._events.clear()
+
+    def _evict(self, ts: float) -> None:
+        """Evict events older than the trailing window relative to ``ts``."""
+        cutoff = ts - self._window
+        while self._events and self._events[0] < cutoff:
+            self._events.popleft()
+
+
+def stable_call_hash(tool_name: str, tool_args: dict[str, Any] | None) -> str:
+    """Hash a tool call so argument order never affects the result.
+
+    ``json.dumps(sort_keys=True)`` sorts keys recursively, so nested dicts are
+    order-independent too. ``default=str`` tolerates non-serializable argument
+    values without raising.
+
+    Args:
+        tool_name: The tool identifier.
+        tool_args: The tool arguments, or None.
+
+    Returns:
+        A hex digest of the tool name plus its recursively key-sorted args.
+    """
+    payload = json.dumps(
+        {"tool": tool_name, "args": tool_args or {}},
+        sort_keys=True,
+        ensure_ascii=False,
+        default=str,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def stable_result_hash(result: Any) -> str:
+    """Hash a tool result into a stable digest for loop detection.
+
+    Lets repeat detection distinguish "same call, same result" (a real loop)
+    from "same call, different result" (legitimate iteration). Prefers a
+    Pydantic ``model_dump`` (e.g. ToolOutput), then JSON with sorted keys, and
+    falls back to ``str`` so unusual objects never raise. ``default=str``
+    tolerates non-serializable values.
+
+    Args:
+        result: The tool execution result, or None.
+
+    Returns:
+        A hex digest, or "none" when result is None.
+    """
+    if result is None:
+        return "none"
+    if isinstance(result, str):
+        payload = result
+    elif hasattr(result, "model_dump"):
+        try:
+            payload = json.dumps(result.model_dump(), sort_keys=True, ensure_ascii=False, default=str)
+        except Exception:
+            payload = str(result)
+    else:
+        try:
+            payload = json.dumps(result, sort_keys=True, ensure_ascii=False, default=str)
+        except Exception:
+            payload = str(result)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/openjiuwen/harness/factory.py
+++ b/openjiuwen/harness/factory.py
@@ -23,6 +23,9 @@ from openjiuwen.harness.rails import (
     SubagentRail,
     TaskPlanningRail,
 )
+from openjiuwen.harness.agent_ras import AgentRASConfig
+from openjiuwen.harness.agent_ras.factory import build_agent_ras_rail
+from openjiuwen.harness.rails.agent_ras_rail import AgentRASRail
 from openjiuwen.harness.schema.agent_mode import AgentMode
 from openjiuwen.harness.schema.config import (
     AudioModelConfig,
@@ -34,6 +37,33 @@ from openjiuwen.harness.workspace.workspace import Workspace
 from openjiuwen.harness.prompts import resolve_language
 from openjiuwen.harness.prompts.sections.tools.task_tool import GENERAL_PURPOSE_AGENT_DESC
 from openjiuwen.harness.tools.web_tools import is_free_search_enabled
+
+
+def _normalize_agent_ras_config(
+    agent_ras: AgentRASConfig | dict[str, Any] | bool | None,
+) -> AgentRASConfig | None:
+    """Normalize create_deep_agent ``agent_ras`` into a typed config or None.
+
+    - ``None`` / ``True``: default enabled Agent RAS
+    - ``False``: disable
+    - ``dict``: advanced YAML/SDK overrides via ``AgentRASConfig.model_validate``
+    - ``AgentRASConfig``: use as-is
+    """
+    if agent_ras is False:
+        return None
+    if agent_ras is None or agent_ras is True:
+        return AgentRASConfig(enabled=True)
+    if isinstance(agent_ras, AgentRASConfig):
+        return agent_ras if agent_ras.enabled else None
+    if isinstance(agent_ras, dict):
+        raw = dict(agent_ras)
+        raw.setdefault("enabled", True)
+        config = AgentRASConfig.model_validate(raw)
+        return config if config.enabled else None
+    raise TypeError(
+        "agent_ras must be AgentRASConfig, dict, bool, or None, "
+        f"got {type(agent_ras).__name__}"
+    )
 
 
 def _is_disabled_free_search_tool(tool: Tool | ToolCard) -> bool:
@@ -156,6 +186,7 @@ def create_deep_agent(
     audio_model_config: Optional[AudioModelConfig] = None,
     enable_read_image_multimodal: bool = True,
     enable_task_planning: bool = False,
+    agent_ras: AgentRASConfig | dict[str, Any] | bool | None = None,
     restrict_to_work_dir: bool = True,
     allowed_paths: Optional[List[str]] = None,
     default_mode: AgentMode = AgentMode.AUTO,
@@ -199,6 +230,11 @@ def create_deep_agent(
             as native multimodal input. When False, read_file returns image
             metadata only and suggests using vision tools if available.
         enable_task_planning: Enable task_planning_rail.
+        agent_ras: Agent RAS configuration. ``None``/``True`` enables defaults;
+            ``False`` disables; ``dict`` / ``AgentRASConfig`` provide advanced
+            overrides. When enabled, AgentRASRail mounts automatically unless
+            the caller already provided it in ``rails``. HITL uses the host
+            ``ask_user_question`` tool when registered.
         restrict_to_work_dir: If True, restrict file access to workspace directory.
             If False, allow access to any path including system root.
         allowed_paths: Optional list of directory paths allowed by the
@@ -337,12 +373,17 @@ def create_deep_agent(
             enabled_skills=skills,
         )
 
+    def _make_agent_ras_rail() -> Any:
+        return build_agent_ras_rail(normalized_agent_ras, card.name, model=model)
+
+    normalized_agent_ras = _normalize_agent_ras_config(agent_ras)
     default_rails = [
         (SecurityRail, True, lambda: SecurityRail()),
         (TaskPlanningRail, enable_task_planning, lambda: TaskPlanningRail()),
         (SkillUseRail, bool(skills), _make_skill_rail),
         (SessionRail, bool(subagents) and enable_async_subagent, lambda: SessionRail()),
         (SubagentRail, bool(subagents) and not enable_async_subagent, lambda: SubagentRail()),
+        (AgentRASRail, normalized_agent_ras is not None, _make_agent_ras_rail),
     ]
     for rail_cls, should_add, make_rail in default_rails:
         if should_add and not _already_provided(rail_cls):

--- a/openjiuwen/harness/rails/agent_ras_rail.py
+++ b/openjiuwen/harness/rails/agent_ras_rail.py
@@ -1,0 +1,364 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Agent RAS signal-collection rail.
+
+Builds ``Signal`` objects from DeepAgent lifecycle hooks and forwards them to
+an invoke-scoped :class:`AgentRASMonitor`. Runtime state lives in a per-session
+monitor cache that ``after_invoke`` clears; only HITL resume data is persisted
+on ``session.state``. The rail does not read recovery policy or apply side
+effects itself (except flushing a deferred user notice before the next model
+call).
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import OrderedDict
+from collections.abc import Callable
+from typing import Any
+
+from openjiuwen.core.common.logging import logger
+from openjiuwen.core.single_agent.rail.base import AgentCallbackContext
+from openjiuwen.harness.rails.base import DeepAgentRail
+
+from openjiuwen.harness.agent_ras.agents.base import AGENT_RAS_SKILL_ROLES
+from openjiuwen.harness.agent_ras.config import AgentRASConfig, coerce_message_locale
+from openjiuwen.harness.agent_ras.monitor import AgentRASMonitor
+from openjiuwen.harness.agent_ras.recovery.operations import emit_user_notice
+from openjiuwen.harness.agent_ras.signal_builder import (
+    build_after_model_call_signal,
+    build_after_tool_call_signal,
+    build_before_model_call_signal,
+    build_before_tool_call_signal,
+    build_model_exception_signal,
+    build_tool_exception_signal,
+)
+from openjiuwen.harness.agent_ras.stream_observer import StreamObserver
+
+
+class AgentRASRail(DeepAgentRail):
+    """Thin collection layer: hooks -> Signal -> Monitor.handle / stream / HITL.
+
+    Runtime isolation: ``monitor_factory(session_id)`` builds one Monitor
+    (detectors + executor) for the active invoke. ``after_invoke`` stops and
+    drops that monitor. The in-flight monitor cache may exceed a soft high-water
+    mark; entries are never LRU-evicted while active (CR-003).
+
+    Hook duties:
+
+    - tool/model hooks -> ``monitor.handle(signal, ctx)``
+    - ``before_invoke`` attaches a ``StreamObserver`` on
+      ``{session_id}write_stream`` -> ``monitor.on_stream_chunk``
+    - ``after_model_call`` also -> ``monitor.finalize_stream_recovery``
+      (await/cancel L3 Reviewer; fail-open flush if still pending)
+
+    Message language follows ``system_prompt_builder.language`` / DeepAgent
+    config (same pattern as ``SecurityRail``), not a separate RAS config field.
+    """
+
+    priority: int = 5
+
+    def __init__(
+        self,
+        *,
+        monitor: AgentRASMonitor | None = None,
+        monitor_factory: Callable[[str], AgentRASMonitor] | None = None,
+        member_name: str = "",
+        config: AgentRASConfig | None = None,
+        agents: Any = None,
+    ) -> None:
+        super().__init__()
+        self._monitor = monitor
+        self._monitor_factory = monitor_factory
+        self._monitors: OrderedDict[str, AgentRASMonitor] = OrderedDict()
+        self._observers: dict[str, StreamObserver] = {}
+        # Soft high-water: log when in-flight monitor count exceeds this; never
+        # LRU-evict active monitors (CR-003).
+        self._monitor_soft_limit = 32
+        self._member = (
+            member_name
+            or getattr(monitor, "member_name", "")
+            or "agent"
+        )
+        self._config = config or getattr(monitor, "config", None) or AgentRASConfig()
+        self._agents = agents if agents is not None else getattr(monitor, "agents", None)
+        self.system_prompt_builder = None
+        self._host_agent: Any = None
+
+    @property
+    def member_name(self) -> str:
+        return self._member
+
+    def init(self, agent) -> None:
+        """Bind prompt builder so recovery / steering text follow DeepAgent language."""
+        self._host_agent = agent
+        self.system_prompt_builder = getattr(agent, "system_prompt_builder", None)
+
+    def uninit(self, agent) -> None:
+        _ = agent
+        self._host_agent = None
+        self.system_prompt_builder = None
+
+    def _ensure_steering_queue(self, ctx: AgentCallbackContext) -> None:
+        """Bind a steering queue before model call so recovery can push_steering.
+
+        Prefer the task-loop ``LoopQueues.steering`` when available so EventHandler
+        and Agent RAS share one queue; otherwise create a per-invoke default queue.
+        Does not touch ReActAgent / DeepAgent call sites.
+        """
+        bind = getattr(ctx, "bind_steering_queue", None)
+        if not callable(bind):
+            return
+        if getattr(ctx, "steering_queue", None) is not None:
+            return
+        queue = None
+        host = self._host_agent
+        handler = getattr(host, "event_handler", None) if host is not None else None
+        queues = getattr(handler, "interaction_queues", None) if handler is not None else None
+        if queues is not None:
+            queue = getattr(queues, "steering", None)
+        if queue is None:
+            queue = asyncio.Queue()
+        bind(queue)
+
+    def _resolve_language(self, agent: Any = None) -> str:
+        """Return cn/en from prompt builder or DeepAgent language."""
+        builder = self.system_prompt_builder
+        if builder is not None:
+            lang = getattr(builder, "language", None)
+            if isinstance(lang, str) and lang.strip():
+                return coerce_message_locale(lang)
+        if agent is not None:
+            deep_config = getattr(agent, "deep_config", None)
+            lang = getattr(deep_config, "language", None)
+            if isinstance(lang, str) and lang.strip():
+                return coerce_message_locale(lang)
+        return "cn"
+
+    @staticmethod
+    def _session_id(ctx: AgentCallbackContext) -> str:
+        """Resolve the session key used for monitor isolation."""
+        session = getattr(ctx, "session", None)
+        getter = getattr(session, "get_session_id", None)
+        if callable(getter):
+            try:
+                return str(getter() or "")
+            except Exception:
+                logger.warning("AgentRASRail session id lookup failed", exc_info=True)
+        inputs = getattr(ctx, "inputs", None)
+        return str(getattr(inputs, "conversation_id", None) or "default")
+
+    def _monitor_for(self, ctx: AgentCallbackContext) -> AgentRASMonitor:
+        """Return (or create) the Monitor bound to ``ctx``'s session.
+
+        The cache holds in-flight invoke monitors only; ``after_invoke`` pops
+        each entry. When the count exceeds ``_monitor_soft_limit``, a warning is
+        logged but no active monitor is evicted (CR-003).
+        """
+        session_id = self._session_id(ctx)
+        monitor = self._monitors.get(session_id)
+        if monitor is None:
+            if self._monitor_factory is not None:
+                monitor = self._monitor_factory(session_id)
+            elif self._monitor is not None:
+                monitor = self._monitor
+            else:
+                raise RuntimeError("AgentRASRail requires a monitor factory")
+            self._monitors[session_id] = monitor
+            if len(self._monitors) > self._monitor_soft_limit:
+                logger.warning(
+                    "AgentRASRail in-flight monitor count=%s exceeds soft "
+                    "limit=%s (session_id=%s); active monitors are not evicted",
+                    len(self._monitors),
+                    self._monitor_soft_limit,
+                    session_id,
+                )
+        else:
+            self._monitors.move_to_end(session_id)
+        agent = getattr(ctx, "agent", None)
+        monitor.set_language(self._resolve_language(agent))
+        return monitor
+
+    async def before_invoke(self, ctx: AgentCallbackContext) -> None:
+        """Start the session monitor and attach write_stream observer."""
+        monitor = None
+        try:
+            monitor = self._monitor_for(ctx)
+            await monitor.start(ctx)
+        except Exception:
+            logger.warning("AgentRASRail monitor start failed", exc_info=True)
+        if monitor is not None:
+            await self._attach_stream_observer(ctx, monitor)
+        await self._warmup_agent_team()
+
+    async def after_invoke(self, ctx: AgentCallbackContext) -> None:
+        """Detach stream observer; stop and drop the session monitor."""
+        session_id = self._session_id(ctx)
+        await self._detach_stream_observer(session_id)
+        monitor = self._monitors.pop(session_id, None)
+        if monitor is None:
+            return
+        try:
+            await monitor.stop()
+        except Exception:
+            logger.warning("AgentRASRail monitor stop failed", exc_info=True)
+
+    async def _attach_stream_observer(
+        self,
+        ctx: AgentCallbackContext,
+        monitor: AgentRASMonitor,
+    ) -> None:
+        """Register write_stream callback for this invoke's session.
+
+        If an observer is already attached for this session, rebind ctx
+        (same-session sequential hooks may use different ctx objects).
+        Cross-session rebind is rejected by ``StreamObserver.bind_ctx``.
+        """
+        session_id = self._session_id(ctx)
+        existing = self._observers.get(session_id)
+        if existing is not None and existing.attached:
+            if not existing.bind_ctx(ctx):
+                logger.warning(
+                    "AgentRASRail skip stream observer rebind session=%s: "
+                    "observer bound to a different session",
+                    session_id,
+                )
+            return
+        observer = StreamObserver(monitor.on_stream_chunk)
+        observer.bind_ctx(ctx)
+        try:
+            await observer.attach(session_id)
+            self._observers[session_id] = observer
+        except Exception:
+            logger.warning(
+                "AgentRASRail stream observer attach failed session=%s",
+                session_id,
+                exc_info=True,
+            )
+
+    async def _detach_stream_observer(self, session_id: str) -> None:
+        observer = self._observers.pop(session_id, None)
+        if observer is None:
+            return
+        try:
+            await observer.detach()
+        except Exception:
+            logger.warning(
+                "AgentRASRail stream observer detach failed session=%s",
+                session_id,
+                exc_info=True,
+            )
+
+    async def _warmup_agent_team(self) -> None:
+        """Pre-create detection/recovery members on each invoke (internal)."""
+        if self._agents is None:
+            return
+        started = time.monotonic()
+        try:
+            await self._agents.warmup_members(AGENT_RAS_SKILL_ROLES)
+            logger.info(
+                "[AgentRASRail] agent_team warmup done roles=%s elapsed_ms=%.1f",
+                AGENT_RAS_SKILL_ROLES,
+                (time.monotonic() - started) * 1000.0,
+            )
+        except Exception:
+            logger.warning(
+                "[AgentRASRail] agent_team warmup failed",
+                exc_info=True,
+            )
+
+    async def before_tool_call(self, ctx: AgentCallbackContext) -> None:
+        """Forward BEFORE_TOOL_CALL to ``Monitor.handle``."""
+        await self._monitor_for(ctx).handle(
+            build_before_tool_call_signal(self._member, ctx.inputs), ctx,
+        )
+
+    async def after_tool_call(self, ctx: AgentCallbackContext) -> None:
+        """Forward AFTER_TOOL_CALL to ``Monitor.handle``."""
+        await self._monitor_for(ctx).handle(
+            build_after_tool_call_signal(self._member, ctx.inputs), ctx,
+        )
+
+    async def on_tool_exception(self, ctx: AgentCallbackContext) -> None:
+        """Forward tool exceptions to ``Monitor.handle``."""
+        await self._monitor_for(ctx).handle(
+            build_tool_exception_signal(self._member, ctx.inputs, ctx.exception),
+            ctx,
+        )
+
+    async def on_model_exception(self, ctx: AgentCallbackContext) -> None:
+        """Forward model exceptions to ``Monitor.handle``."""
+        await self._monitor_for(ctx).handle(
+            build_model_exception_signal(self._member, ctx.exception), ctx,
+        )
+
+    async def before_model_call(self, ctx: AgentCallbackContext) -> None:
+        """Emit deferred recovery notice (if any), reopen recovery gates, then detect."""
+        self._ensure_steering_queue(ctx)
+        monitor = self._monitor_for(ctx)
+        monitor.bind_ctx(ctx)
+        observer = self._observers.get(self._session_id(ctx))
+        if observer is not None and not observer.bind_ctx(ctx):
+            logger.warning(
+                "AgentRASRail before_model_call: stream observer ctx rebind "
+                "rejected session=%s (cross-session mismatch)",
+                self._session_id(ctx),
+            )
+        notice = monitor.consume_notice_for_emit()
+        if notice:
+            await emit_user_notice(ctx, notice)
+        # After abnormal recovery + steering, clear gates so the next model
+        # turn can re-detect instead of silently suppressing forever.
+        monitor.prepare_for_next_model_call()
+        await monitor.handle(
+            build_before_model_call_signal(self._member, ctx.inputs), ctx,
+        )
+
+    async def after_model_call(self, ctx: AgentCallbackContext) -> None:
+        """Run detection/recovery, then finalize stream recovery (L3 fail-open)."""
+        monitor = self._monitor_for(ctx)
+        await monitor.handle(
+            build_after_model_call_signal(self._member, ctx.inputs), ctx,
+        )
+        try:
+            await monitor.finalize_stream_recovery(ctx)
+        except Exception:
+            logger.warning(
+                "AgentRASRail.finalize_stream_recovery failed", exc_info=True,
+            )
+
+    async def get_metrics(self, session_id: str | None = None) -> dict[str, Any]:
+        """Aggregate monitor counters for one session or all active sessions."""
+        if session_id is not None:
+            monitor = self._monitors.get(session_id)
+            return await monitor.get_metrics() if monitor else {}
+        metrics = [await m.get_metrics() for m in self._monitors.values()]
+        return {
+            "session_count": len(metrics),
+            "invoke_count": sum(m.get("invoke_count", 0) for m in metrics),
+            "anomaly_count": sum(m.get("anomaly_count", 0) for m in metrics),
+            "recovery_count": sum(m.get("recovery_count", 0) for m in metrics),
+        }
+
+    async def get_recent_events(
+        self,
+        n: int = 50,
+        session_id: str | None = None,
+    ) -> list[Any]:
+        """Return recent anomaly events from one or all session monitors."""
+        if session_id is not None:
+            monitor = self._monitors.get(session_id)
+            return await monitor.get_recent_events(n) if monitor else []
+        events: list[Any] = []
+        for monitor in self._monitors.values():
+            events.extend(await monitor.get_recent_events(n))
+        return events
+
+    async def aclose(self) -> None:
+        """Stop every cached session monitor (agent teardown fallback)."""
+        for session_id in list(self._observers.keys()):
+            await self._detach_stream_observer(session_id)
+        monitors = list(self._monitors.values())
+        self._monitors.clear()
+        for monitor in monitors:
+            await monitor.stop()


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/community/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openjiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
选择下面一种标签替换下方 `/kind <label>`，可选标签类型有：
- /kind bug 
- /kind task
- /kind feature
- /kind refactor
- /kind clean_code
如PR描述不符合规范，修改PR描述后需要/check-pr重新检查PR规范。
-->
/kind feature


**Self-checklist**:（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

+ - [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
+ - [ ] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
+ - [ ] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
+ - [ ] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
+ - [ ] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] 是否导致无法前向兼容 -->
<!-- + - [ ] 是否涉及依赖的三方库变更 -->

## Summary

在 agent-core 落地 **Agent RAS（Reliability Assurance System）**，使单 Agent 的可靠性监控、异常检测与本地恢复由 harness 统一提供，core 仅保留最小协作契约；enterprise DeepAgent 通过 `create_deep_agent(agent_ras=...)` 透传配置启用。

## 主要变更

### 新增 Agent RAS 运行时

- `openjiuwen/harness/agent_ras/`：Monitor、Detector（`repeat_tool`、`llm_thinking_loop`）、Recovery Engine、Config、Factory、StreamObserver
- `openjiuwen/harness/rails/agent_ras_rail.py`：会话级 Rail，接入 invoke / model / tool 生命周期

### 接入路径

- `create_deep_agent` 新增 `agent_ras` 参数（`None`/`True` 默认启用，`False` 关闭，支持 dict / `AgentRASConfig`）
- DeepAgent 单轮 `_steering_queue` 经 kwargs 传给 ReActAgent（不污染 inputs dict）
- 流式观测：`StreamObserver` 监听 `Session.write_stream` → `Monitor.on_stream_chunk`（不扩展 core Rail 事件）

### Core 最小改动

- `openjiuwen/core/single_agent/rail/base.py`：`request_abort_stream` / `consume_abort_stream` / `has_abort_stream_request`
- `openjiuwen/core/single_agent/agents/react_agent.py`：流循环 chunk 边界响应 abort；kwargs steering 绑定；`stream()` 转发 kwargs

### 检测与恢复（稳定范围）

- **repeat_tool**：重复 / 乒乓 / 未知工具调用检测
- **llm_thinking_loop**：文本重复、plan-exec 语义停滞、超时（含 streaming tool-call args 扫描）
- 本地 Recovery（steer / notice / suppress）+ 流中 HITL（宿主 `ask_user_question`）；确认异常后协作打断 `llm.stream`

## 依赖 / 配套说明

- 企业侧配置键 **`agent_ras`**（替代旧 `execution_guard`）
- jiuwenswarm `enterprise_dev` 需同步 YAML → `AgentRASConfig` 透传

## 测试效果
![image.png](https://raw.gitcode.com/user-images/assets/8766961/96c809fd-fb85-4f53-b612-e0d3fb993d0d/image.png 'image.png')