### PR TITLE
fix(todo): 修复任务列表重复显示问题并增加写入顺序校验

### DIFF
--- a/openjiuwen/harness/prompts/sections/todo.py
+++ b/openjiuwen/harness/prompts/sections/todo.py
@@ -33,7 +33,7 @@ Identify the planning need and call todo_create BEFORE starting execution.
 **Task management rules:**
 - Update status in real-time: call todo_modify the moment a task status changes
 - Only one task can be in_progress at a time; complete it before starting the next
-- **Follow list order**: do not skip pending earlier tasks; the tool rejects out-of-order updates
+- **Follow list order**: do not skip pending earlier tasks; the tool rejects out-of-order status changes and task additions
 - Batch updates: consolidate status changes in one todo_modify when order is valid (e.g. complete current, then in_progress next)
 - When marking the current step completed, include the next pending item as in_progress in the same todo_modify batch whenever more work remains
 - Mark unneeded tasks as cancelled via todo_modify (explicit skip)
@@ -43,16 +43,18 @@ Identify the planning need and call todo_create BEFORE starting execution.
 **Before marking a task completed:**
 - Verify the work is fully done (e.g., run tests to confirm)
 - Never mark completed if: partially implemented, tests failing, unresolved errors
-- After completing, check if new follow-up tasks were discovered and append them via todo_modify
+- After completing, check whether new follow-up tasks were discovered. Before append or insert, call todo_list and follow the list-order rules.
 - skill_complete does not update todos — use todo_modify to modify todos
 
-**Interrupt resume and todo tool choice (same for main and sub agents: each checks its own session's todo.json)**
-| This session's todo status | Action |
-| Has pending / in_progress | todo_list → todo_modify to resume; **do not** todo_create |
-| No pending / in_progress, or user asks to restart | todo_create (force=true) |
+**Todo tool choice (same for main and sub agents: each checks its own session's todo.json)**
+| User intent / todo status | Action |
+| Continue or retry while pending / in_progress items exist | todo_list → todo_modify; **do not** todo_create |
+| Independent new request and no active items remain | todo_create a complete new plan |
+| User explicitly asks to restart or replan while active items exist | todo_create(force=true) |
 
 - When the user says "continue" / "retry" / "try again", resume from the in_progress item;
   do not restart from Stage 1
+- Do not rename or reuse an old todo as the first step of an independent new plan
 - Sub-agents have separate sessions; the main agent must **not** block a sub-agent from
   todo_create in its own session because the main session already has todos
 """
@@ -74,7 +76,7 @@ TODO_SYSTEM_PROMPT_CN = """
 **任务管理规则：**
 - 实时更新状态：任务状态变化时立即调用 todo_modify
 - 同一时间只能有一个任务处于 in_progress，完成后再开始下一个
-- **按列表顺序推进**：不得跳过 pending 的前序任务；工具会拒绝跨档 update
+- **按列表顺序推进**：不得跳过 pending 的前序任务；工具会拒绝跨档状态更新和新增任务
 - 批量更新：将多个状态变更合并为一次 todo_modify 调用（须满足顺序：例如先 completed 当前项，再 in_progress 下一项）
 - 将当前步骤标为 completed 时，若仍有后续待办，须在同一批 todo_modify 中把下一项 pending 标为 in_progress
 - 不再需要的任务用 todo_modify 标记为 cancelled（明确跳过）
@@ -84,15 +86,17 @@ TODO_SYSTEM_PROMPT_CN = """
 **将任务标记为已完成前：**
 - 必须仔细验证工作已全部完成（如运行测试用例）
 - 以下情况绝对不能标记为已完成：部分实现、测试失败、存在未解决的错误等
-- 标记完成后，检查实现过程中是否发现新的后续任务，及时通过 todo_modify 追加
+- 标记完成后，检查实现过程中是否发现新的后续任务；append 或 insert 前先 todo_list，并遵守列表顺序规则
 - skill_complete 不更新 todo，修改 todo 请用 todo_modify
 
-**中断续跑与todo工具选择（主 Agent、子 Agent 相同：各看本 session 的 todo.json）**
-| 本 session todo 状态 | 做法 |
-| 有 pending / in_progress | todo_list → todo_modify 续跑；**不要** todo_create |
-| 无 pending / in_progress，或用户要求重来 | todo_create（force=true） |
+**todo 工具选择（主 Agent、子 Agent 相同：各看本 session 的 todo.json）**
+| 用户意图 / 本 session todo 状态 | 做法 |
+| 用户要求继续/重试，且有 pending / in_progress | todo_list → todo_modify 续跑；**不要** todo_create |
+| 独立新请求，且已无活跃项 | todo_create 建立完整新计划 |
+| 用户明确要求重来/重规划，且有活跃项 | todo_create（force=true） |
 
 - 用户说「继续/重试/再试一次」时，从 in_progress 项续跑，勿从 Stage 1 重来
+- 独立新计划不得改名或复用旧 todo 作为首项
 - 子 Agent 拥有独立 session；主 Agent **不得**因主会话已有 todo 而阻止子 Agent 在其自身 session 内正常 todo_create
 """
 

--- a/openjiuwen/harness/prompts/sections/tools/todo.py
+++ b/openjiuwen/harness/prompts/sections/tools/todo.py
@@ -202,13 +202,16 @@ insert_before：在指定任务之前插入新任务（目标任务状态须为 
 - insert_after：目标任务状态必须为 in_progress 或 pending
 - insert_before：目标任务状态必须为 pending
 
-## 顺序（强制，update 时由工具校验）
+## 顺序（强制，所有新增任务或状态变更操作均由工具校验）
 
 任务列表有固定顺序（与 todo_create 创建顺序一致）。
 
 1. **按序更新**：不得跳过仍为 pending 的前序任务将后项标为 in_progress/completed；in_progress 只能落在第一个非终态任务上；若当前项为 in_progress，须在同批先标 completed 再开下一项；跳过步骤须同批将前序标为 cancelled。
 2. **批量更新前**：跨多个 Stage/步骤变更状态时，或不确定 UUID 时，先 todo_list 再 modify。
 3. **仅改当前 in_progress 的 content/activeForm**（不改 status）时，可直接 update；其余跨任务状态变更适用上述规则。
+4. **新增任务前**：append、insert_after、insert_before 前先调用 todo_list；仅当插入点之后没有 in_progress 或 completed 任务时才可使用插入操作。
+5. **计划选择**：用户要求继续/重试时，使用 todo_list 后 todo_modify，勿 todo_create。独立新请求在无活跃任务后使用 todo_create 建立完整新计划；用户明确要求重来/重规划时才使用 todo_create(force=true)。
+6. **错误重试**：顺序校验失败后，重新调用 todo_list 并按顺序重试。严禁取消同义任务后用新 ID append/insert 作为绕过方式。
 
 ID 精确性要求（极其重要）：
 - 任务 ID 是 UUID 格式，必须从 todo_create 返回值或 todo_list 结果中原样复制
@@ -290,13 +293,16 @@ Core rules:
 - insert_after: target task status must be in_progress or pending
 - insert_before: target task status must be pending
 
-## Sequential order (enforced on update)
+## Sequential order (enforced for every task addition or status change)
 
 The todo list has a fixed order (same as todo_create).
 
 1. **Update in order**: Do not skip pending earlier tasks when setting later tasks to in_progress/completed; in_progress may only be on the first non-terminal task; if the current task is in_progress, complete it in the same batch before starting the next; to skip a step, cancel the earlier task in the same batch.
 2. **Before batch status changes** across stages or when UUIDs are uncertain, call todo_list first.
 3. **Content-only updates** to the current in_progress task (no status change) may use update directly; cross-task status changes follow the rules above.
+4. **Before adding tasks**: Call todo_list before append, insert_after, or insert_before. Use an insert operation only when no later task is in_progress or completed.
+5. **Choose the plan operation**: For continue/retry, call todo_list then todo_modify; do not call todo_create. For an independent request with no active tasks, use todo_create to create a complete plan. Use todo_create(force=true) only when the user explicitly asks to restart or replan.
+6. **Retry after an order error**: Call todo_list again and retry in order. Never cancel equivalent tasks and append/insert the same work with new IDs to bypass validation.
 
 ID Accuracy Requirement (Critical):
 - Task IDs are UUID format and MUST be copied exactly from todo_create results or todo_list output

--- a/openjiuwen/harness/tools/todo.py
+++ b/openjiuwen/harness/tools/todo.py
@@ -1131,22 +1131,27 @@ class TodoModifyTool(TodoTool):
         Raises:
             ToolError: If duplicate IDs found or validation fails
         """
-        todo_ids = [todo.id for todo in current_todos]
+        current_todo_ids = {todo.id for todo in current_todos}
+        todo_ids = set(current_todo_ids)
+        updated_todos = list(current_todos)
         for todo_data in todos_data:
             self._validate_single_todo_item(todo_data)
             todo_id = todo_data.get("id")
 
             if todo_id in todo_ids:
+                duplicate_source = "current todo list" if todo_id in current_todo_ids else "batch input"
                 raise build_error(
                     StatusCode.TOOL_TODOS_VALIDATION_INVALID,
-                    reason=f"Batch append failed: Task with ID '{todo_id}' is duplicated in current todo list"
+                    reason=f"Batch append failed: Task with ID '{todo_id}' is duplicated in {duplicate_source}"
                 )
 
-            current_todos.append(self._convert_to_todo_item(todo_data))
+            updated_todos.append(self._convert_to_todo_item(todo_data))
+            todo_ids.add(todo_id)
 
         # Validate single IN_PROGRESS constraint after updates
-        self._validate_single_in_progress(current_todos)
-        await self.save_todos(current_todos, file_path)
+        self._validate_single_in_progress(updated_todos)
+        self._validate_sequential_update(updated_todos)
+        await self.save_todos(updated_todos, file_path)
 
         result_msg = f"Successfully append {len(todos_data)} task(s)"
         tool_logger.info(
@@ -1203,6 +1208,7 @@ class TodoModifyTool(TodoTool):
 
         # Validate single IN_PROGRESS constraint
         self._validate_single_in_progress(updated_todos)
+        self._validate_sequential_update(updated_todos)
 
         await self.save_todos(updated_todos, file_path)
 
@@ -1261,6 +1267,7 @@ class TodoModifyTool(TodoTool):
 
         # Validate single IN_PROGRESS constraint
         self._validate_single_in_progress(updated_todos)
+        self._validate_sequential_update(updated_todos)
 
         await self.save_todos(updated_todos, file_path)
 

--- a/tests/unit_tests/harness/test_task_planning_rail.py
+++ b/tests/unit_tests/harness/test_task_planning_rail.py
@@ -1053,6 +1053,17 @@ def test_todo_prompt_contains_no_use_guidance() -> None:
     assert "何时不使用" in cn_prompt
 
 
+def test_todo_prompt_contains_plan_selection_and_addition_rules() -> None:
+    """System prompt aligns task additions and plan selection with todo tools."""
+    en_prompt = build_todo_system_prompt(language="en")
+    cn_prompt = build_todo_system_prompt(language="cn")
+
+    assert "task additions" in en_prompt
+    assert "Independent new request" in en_prompt
+    assert "新增任务" in cn_prompt
+    assert "独立新请求" in cn_prompt
+
+
 def test_build_progress_reminder_user_prompt_chinese() -> None:
     """build_progress_reminder_user_prompt returns Chinese prompt."""
     prompt = build_progress_reminder_user_prompt(language="cn")

--- a/tests/unit_tests/harness/tools/test_todo.py
+++ b/tests/unit_tests/harness/tools/test_todo.py
@@ -531,6 +531,83 @@ class TestTodoModifyTool(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(saved_todos), 4)
         self.assertEqual(saved_todos[-1].id, new_todo_id)
 
+    async def test_invoke_append_reports_duplicate_id_in_current_todo_list(self):
+        """Report when an appended task duplicates an existing task ID."""
+        append_data = [{
+            "id": self.test_todo_ids[0],
+            "content": "Duplicate Task",
+            "activeForm": "Executing Duplicate Task",
+            "status": TodoStatus.PENDING.value,
+        }]
+
+        with self.assertRaises(FrameworkError) as cm:
+            await self.tool.invoke(
+                {"action": "append", "todos": append_data},
+                session=self.mock_session,
+            )
+
+        self.assertIn(
+            f"Task with ID '{self.test_todo_ids[0]}' is duplicated in current todo list",
+            str(cm.exception),
+        )
+        self.tool.save_todos.assert_not_awaited()
+
+    async def test_invoke_append_reports_duplicate_id_in_batch_input(self):
+        """Report when two appended tasks share the same ID."""
+        duplicate_id = str(uuid.uuid4())
+        append_data = [
+            {
+                "id": duplicate_id,
+                "content": "New Task 4",
+                "activeForm": "Executing New Task 4",
+                "status": TodoStatus.PENDING.value,
+            },
+            {
+                "id": duplicate_id,
+                "content": "New Task 5",
+                "activeForm": "Executing New Task 5",
+                "status": TodoStatus.PENDING.value,
+            },
+        ]
+
+        with self.assertRaises(FrameworkError) as cm:
+            await self.tool.invoke(
+                {"action": "append", "todos": append_data},
+                session=self.mock_session,
+            )
+
+        self.assertIn(
+            f"Task with ID '{duplicate_id}' is duplicated in batch input",
+            str(cm.exception),
+        )
+        self.tool.save_todos.assert_not_awaited()
+
+    async def test_invoke_append_rejects_invalid_sequence_without_mutation(self):
+        """Reject append that advances past a pending item without mutating input."""
+        current_todos = [
+            TodoItem.create(content="Pending Task", status=TodoStatus.PENDING),
+        ]
+        self.tool.load_todos = AsyncMock(return_value=current_todos)
+        new_todo_id = str(uuid.uuid4())
+
+        with self.assertRaises(FrameworkError):
+            await self.tool.invoke(
+                {
+                    "action": "append",
+                    "todos": [{
+                        "id": new_todo_id,
+                        "content": "Completed Task",
+                        "activeForm": "Completed Task",
+                        "status": TodoStatus.COMPLETED.value,
+                    }],
+                },
+                session=self.mock_session,
+            )
+
+        self.tool.save_todos.assert_not_awaited()
+        self.assertEqual(len(current_todos), 1)
+        self.assertEqual(current_todos[0].status, TodoStatus.PENDING)
+
     async def test_invoke_insert_after_success(self):
         """Test successful insertion after target task"""
         # Construct insert data
@@ -580,6 +657,125 @@ class TestTodoModifyTool(unittest.IsolatedAsyncioTestCase):
         saved_todos = self.tool.save_todos.call_args[0][0]
         self.assertEqual(len(saved_todos), 4)
         self.assertEqual(saved_todos[1].id, new_todo_id)  # Verify insertion position
+
+    async def test_invoke_insert_after_rejects_invalid_sequence_without_save(self):
+        """Reject insertion before an existing completed item."""
+        current_todos = [
+            TodoItem.create(content="Active Task", status=TodoStatus.IN_PROGRESS),
+            TodoItem.create(content="Completed Task", status=TodoStatus.COMPLETED),
+        ]
+        self.tool.load_todos = AsyncMock(return_value=current_todos)
+        new_todo_id = str(uuid.uuid4())
+
+        with self.assertRaises(FrameworkError):
+            await self.tool.invoke(
+                {
+                    "action": "insert_after",
+                    "todo_data": {
+                        "target_id": current_todos[0].id,
+                        "items": [{
+                            "id": new_todo_id,
+                            "content": "Inserted Task",
+                            "activeForm": "Executing inserted task",
+                            "status": TodoStatus.PENDING.value,
+                        }],
+                    },
+                },
+                session=self.mock_session,
+            )
+
+        self.tool.save_todos.assert_not_awaited()
+        self.assertNotIn(new_todo_id, [todo.id for todo in current_todos])
+
+    async def test_invoke_insert_before_rejects_invalid_sequence_without_save(self):
+        """Reject insertion that leaves a pending item before a completed item."""
+        current_todos = [
+            TodoItem.create(content="Pending Task", status=TodoStatus.PENDING),
+            TodoItem.create(content="Completed Task", status=TodoStatus.COMPLETED),
+        ]
+        self.tool.load_todos = AsyncMock(return_value=current_todos)
+        new_todo_id = str(uuid.uuid4())
+
+        with self.assertRaises(FrameworkError):
+            await self.tool.invoke(
+                {
+                    "action": "insert_before",
+                    "todo_data": {
+                        "target_id": current_todos[0].id,
+                        "items": [{
+                            "id": new_todo_id,
+                            "content": "Inserted Task",
+                            "activeForm": "Executing inserted task",
+                            "status": TodoStatus.PENDING.value,
+                        }],
+                    },
+                },
+                session=self.mock_session,
+            )
+
+        self.tool.save_todos.assert_not_awaited()
+        self.assertNotIn(new_todo_id, [todo.id for todo in current_todos])
+
+    async def test_invoke_insert_after_rejects_second_in_progress_without_save(self):
+        """Reject an inserted in-progress item without persisting any new task."""
+        current_todos = [
+            TodoItem.create(content="Active Task", status=TodoStatus.IN_PROGRESS),
+        ]
+        self.tool.load_todos = AsyncMock(return_value=current_todos)
+        new_todo_id = str(uuid.uuid4())
+
+        with self.assertRaises(FrameworkError):
+            await self.tool.invoke(
+                {
+                    "action": "insert_after",
+                    "todo_data": {
+                        "target_id": current_todos[0].id,
+                        "items": [{
+                            "id": new_todo_id,
+                            "content": "Second Active Task",
+                            "activeForm": "Executing second active task",
+                            "status": TodoStatus.IN_PROGRESS.value,
+                        }],
+                    },
+                },
+                session=self.mock_session,
+            )
+
+        self.tool.save_todos.assert_not_awaited()
+        self.assertNotIn(new_todo_id, [todo.id for todo in current_todos])
+
+    async def test_invoke_insert_after_allows_cancelled_suffix(self):
+        """Allow insertion when only cancelled tasks follow the insertion point."""
+        current_todos = [
+            TodoItem.create(content="Active Task", status=TodoStatus.IN_PROGRESS),
+            TodoItem.create(content="Cancelled Task", status=TodoStatus.CANCELLED),
+        ]
+        self.tool.load_todos = AsyncMock(return_value=current_todos)
+        new_todo_id = str(uuid.uuid4())
+
+        result = await self.tool.invoke(
+            {
+                "action": "insert_after",
+                "todo_data": {
+                    "target_id": current_todos[0].id,
+                    "items": [{
+                        "id": new_todo_id,
+                        "content": "Inserted Task",
+                        "activeForm": "Executing inserted task",
+                        "status": TodoStatus.PENDING.value,
+                    }],
+                },
+            },
+            session=self.mock_session,
+        )
+
+        self.assertIn("Successfully inserted 1 task(s)", result["message"])
+        saved_todos = self.tool.save_todos.call_args[0][0]
+        self.assertEqual([todo.id for todo in saved_todos], [
+            current_todos[0].id,
+            new_todo_id,
+            current_todos[1].id,
+        ])
 
     async def test_invoke_cancel_success(self):
         """Test successful cancellation of todo items"""


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/community/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openjiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
选择下面一种标签替换下方 `/kind <label>`，可选标签类型有：
- /kind bug 
- /kind task
- /kind feature
- /kind refactor
- /kind clean_code
如PR描述不符合规范，修改PR描述后需要/check-pr重新检查PR规范。
-->
/kind bug


**Self-checklist**:（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

+ - [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
+ - [ ] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
+ - [ ] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
+ - [ ] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
+ - [ ] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] 是否导致无法前向兼容 -->
<!-- + - [ ] 是否涉及依赖的三方库变更 -->

## 目标

保证任何写入 `todo.json` 的任务列表都满足既有 R1/R2 顺序约束，避免模型因更新失败而取消原任务、再以新 ID 创建同义任务。续跑时保留已有列表；独立新请求沿用现有`todo_create` 的整表重建语义。

## 修改范围

| 仓库 | 文件 | 修改 |
| --- | --- | --- |
| agent-core | `openjiuwen/harness/tools/todo.py` | 为 `append`、`insert_after`、`insert_before` 增加候选列表顺序校验。 |
| agent-core | `openjiuwen/harness/prompts/sections/todo.py` | 同步通用系统提示词的顺序、新增任务与计划选择规则。 |
| agent-core | `openjiuwen/harness/prompts/sections/tools/todo.py` | 补充模型在已有活动计划时创建/扩展计划的约束。 |
| agent-core | `tests/unit_tests/harness/tools/test_todo.py` | 增加顺序拒绝、无落盘和合法路径测试。 |
| agent-core | `tests/unit_tests/harness/test_task_planning_rail.py` | 覆盖通用系统提示词的新增任务与计划选择规则。 |
| jiuwenswarm | 无 | 不修改。其后端仅下发 `todo.json` 当前列表；前端 `cancelled` 展示另行处理。 |

## 运行时代码

`append`、`insert_after`、`insert_before` 采用“候选列表、校验、保存”流程：

1. 构造 `updated_todos`，不修改 `current_todos`；
2. 执行 `_validate_single_in_progress(updated_todos)`；
3. 执行既有 `_validate_sequential_update(updated_todos)`；
4. 仅在全部通过后执行 `save_todos(updated_todos, file_path)`。

具体调整：

- `update` 已先通过模拟列表执行 R1/R2，本次不改其既有更新流程。
- `append` 改为在候选列表上追加并校验；保留现有 ID 校验、字段校验、返回消息和保存格式。
- `insert_after`、`insert_before` 在现有 `updated_todos` 构造完成后、保存前增加顺序校验。
- `cancel`、`delete` 和 `todo_create` 不改。

校验失败时不得调用 `save_todos`。因此，错误插入不留下首项或部分插入项；重试始终从插入前的原列表开始。

## 模型操作约束

同步更新通用系统提示词 `TODO_SYSTEM_PROMPT_CN/EN` 与工具说明 `TODO_MODIFY_DESCRIPTION_CN/EN`：

1. `append`、`insert_after`、`insert_before` 与 `update` 一样受顺序校验约束；操作前先调用 `todo_list`。
2. 仅当插入点之后不存在 `in_progress` 或 `completed` 任务时，使用 `insert_after` / `insert_before` 扩展当前计划。
3. 先区分用户意图：
   - “继续 / 重试”当前任务：调用 `todo_list → todo_modify`，不得 `todo_create`。
   - 当前计划内新增或拆分步骤：使用 `append` / `insert_*`，并遵守顺序校验。
   - 独立的新请求：在无活跃任务后使用 `todo_create` 建立完整新计划，不复用、改名或追加到旧计划。
   - 用户明确“重来 / 重规划”：使用 `todo_create(force=true)` 重建完整新计划。
4. `jiuwenswarm` 对非续跑的新消息会清理上一轮未完成 todo；清理完成后，模型调用 `todo_create` 写入新计划（首项 `in_progress`，其余 `pending`）。
5. 若活动任务仍存在而 `todo_create` 被拒绝，模型不得以取消同义任务加新 ID 追加的方式绕过； 应依据用户意图续跑，或在用户明确重规划后使用 `todo_create(force=true)`。
6. 顺序校验失败后，重新调用 `todo_list`，选择满足上述规则的操作；不得以取消加新 ID 追加作为重试方式。

该约束保持续跑计划的连续性，也使独立请求通过重建完整列表获得连续的新计划。

## 测试

在 `tests/unit_tests/harness/tools/test_todo.py` 覆盖：

1. `insert_after` / `insert_before` 在候选列表形成 `pending -> completed` 时拒绝，且不保存。
2. `append` 在已有 `pending` 后追加 `in_progress` 或 `completed` 时拒绝，且原列表不变。
3. 合法的末尾 `append` 与插入位置之后仅含 `pending` / `cancelled` 的插入仍成功。
4. 校验失败的插入批次包含首项 `in_progress` 时，确认无新 ID 被保存。
5. 通用系统提示词包含“新增任务受顺序约束”和“独立新请求仅在无活跃任务后创建新计划”的规则。

验证命令：

```powershell
make test TESTFLAGS="tests/unit_tests/harness/tools/test_todo.py"
```

## 兼容性

本修改只拒绝此前可写入的非法顺序，不改变合法任务、任务格式或前端事件。