### PR TITLE
fix(evolving): stabilize skill evolution runtime flow

### DIFF
--- a/openjiuwen/harness/deep_agent.py
+++ b/openjiuwen/harness/deep_agent.py
@@ -2846,10 +2846,6 @@ class DeepAgent(BaseAgent):
 
         async with self._interaction_control_lock:
             if is_resume_input:
-                if request.mode is not None:
-                    raise ValueError(
-                        "InteractiveInput does not support an input dispatch mode"
-                    )
                 self._event_manager.push_user(
                     RoundWorkItem.user(
                         request_id=request.request_id,

--- a/openjiuwen/harness/deep_agent.py
+++ b/openjiuwen/harness/deep_agent.py
@@ -2574,6 +2574,7 @@ class DeepAgent(BaseAgent):
                     "context": copy.deepcopy(work.context),
                 }
             invoke_inputs = self._normalize_inputs(inputs)
+            is_resume_input = self._is_resume_input(invoke_inputs)
             ctx = AgentCallbackContext(
                 agent=self, inputs=invoke_inputs, session=session
             )
@@ -2581,28 +2582,35 @@ class DeepAgent(BaseAgent):
                 AgentCallbackEvent.BEFORE_INVOKE,
                 AgentCallbackEvent.AFTER_INVOKE,
             ):
-                await controller.submit_round(
-                    session,
-                    str(work.query),
-                    is_follow_up=work.is_follow_up,
-                    run_kind=invoke_inputs.run_kind,
-                    run_context=invoke_inputs.run_context,
-                    task_id=task_id,
-                )
-                timeout = (
-                    self._deep_config.completion_timeout
-                    if self._deep_config
-                    else 600.0
-                )
-                result = await controller.wait_round_completion(timeout=timeout)
+                if is_resume_input:
+                    result = await self._run_single_round_invoke(ctx, session)
+                else:
+                    await controller.submit_round(
+                        session,
+                        str(work.query),
+                        is_follow_up=work.is_follow_up,
+                        run_kind=invoke_inputs.run_kind,
+                        run_context=invoke_inputs.run_context,
+                        task_id=task_id,
+                    )
+                    timeout = (
+                        self._deep_config.completion_timeout
+                        if self._deep_config
+                        else 600.0
+                    )
+                    result = await controller.wait_round_completion(timeout=timeout)
                 await self._write_round_result_to_stream(result, session)
                 invoke_inputs.result = result
-                next_work = self._build_interaction_next_work(
-                    work=work,
-                    result=result,
-                    session=session,
-                    coordinator=coordinator,
-                    controller=controller,
+                next_work = (
+                    None
+                    if is_resume_input
+                    else self._build_interaction_next_work(
+                        work=work,
+                        result=result,
+                        session=session,
+                        coordinator=coordinator,
+                        controller=controller,
+                    )
                 )
 
             self.save_state(session)
@@ -2806,11 +2814,12 @@ class DeepAgent(BaseAgent):
                 return stream
 
     async def send_input(self, request: SendInputRequest) -> None:
-        """Dispatch user text only; does not attach or return an output stream.
+        """Dispatch user text or interrupt-resume input.
 
         Hosts that need to read output must call ``attach_output`` first (or
         already hold a stream).  Steer / follow-up requests typically skip
-        attach and let the existing consumer receive output.
+        attach and let the existing consumer receive output.  Dispatch modes
+        do not apply to ``InteractiveInput`` recovery requests.
         """
         if not self._interaction_started or self._interaction_phase is InteractionPhase.TERMINATED:
             raise RuntimeError("interaction_terminated")
@@ -2820,14 +2829,37 @@ class DeepAgent(BaseAgent):
 
     async def _send_user(self, request: SendInputRequest) -> None:
         inputs = request.inputs
-        if (
-            not isinstance(inputs, dict)
-            or not isinstance(inputs.get("query"), str)
-            or not inputs["query"].strip()
+        if not isinstance(inputs, dict):
+            raise ValueError(
+                "send_input requires inputs['query'] to be a non-empty string "
+                "or InteractiveInput"
+            )
+        query = inputs.get("query")
+        is_resume_input = isinstance(query, InteractiveInput)
+        if not is_resume_input and (
+            not isinstance(query, str) or not query.strip()
         ):
-            raise ValueError("send_input requires a non-empty inputs['query']")
+            raise ValueError(
+                "send_input requires inputs['query'] to be a non-empty string "
+                "or InteractiveInput"
+            )
 
         async with self._interaction_control_lock:
+            if is_resume_input:
+                if request.mode is not None:
+                    raise ValueError(
+                        "InteractiveInput does not support an input dispatch mode"
+                    )
+                self._event_manager.push_user(
+                    RoundWorkItem.user(
+                        request_id=request.request_id,
+                        inputs=inputs,
+                        reset_loop=False,
+                    )
+                )
+                self._notify_work()
+                return
+
             loop = self.loop_controller
             try:
                 mode = (

--- a/openjiuwen/harness/rails/evolution/review/subagent.py
+++ b/openjiuwen/harness/rails/evolution/review/subagent.py
@@ -126,7 +126,7 @@ def build_evolution_review_agent_config(
     *,
     runtime: EvolutionReviewRuntime,
     model: Model | None,
-    max_iterations: int = 10,
+    max_iterations: int = 25,
     query_service: Any | None = None,
     store: Any | None = None,
     language: str = "cn",

--- a/openjiuwen/harness/rails/evolution/skill_evolution_rail.py
+++ b/openjiuwen/harness/rails/evolution/skill_evolution_rail.py
@@ -176,7 +176,7 @@ class SkillEvolutionRail(SkillEvolutionSharingMixin, EvolutionRail):
         evaluate_llm_policy: LLMInvokePolicy = EVALUATE_LLM_POLICY,
         simplify_llm_policy: LLMInvokePolicy = SIMPLIFY_LLM_POLICY,
         two_stage: bool = False,
-        review_agent_max_iterations: int = 10,
+        review_agent_max_iterations: int = 25,
         sharing_config: Optional[Dict[str, Any]] = None,
         disabled_skills: Optional[Union[str, List[str]]] = None,
         evolution_trigger: EvolutionTriggerPoint = EvolutionTriggerPoint.AFTER_INVOKE,

--- a/openjiuwen/harness/rails/evolution/team_skill_evolution_rail.py
+++ b/openjiuwen/harness/rails/evolution/team_skill_evolution_rail.py
@@ -174,7 +174,7 @@ class TeamSkillEvolutionRail(SkillEvolutionRail):
         fuzzy_review_interval: int = 5,
         completion_followup_enabled: Optional[bool] = None,
         review_trigger: Optional[bool] = None,
-        review_agent_max_iterations: int = 20,
+        review_agent_max_iterations: int = 40,
     ) -> None:
         if eval_interval < 1:
             raise ValueError("eval_interval must be >= 1")

--- a/openjiuwen/harness/schema/interaction.py
+++ b/openjiuwen/harness/schema/interaction.py
@@ -42,11 +42,13 @@ class InputDispatchMode(str, Enum):
 
 @dataclass(frozen=True)
 class SendInputRequest:
-    """A host request to dispatch user text through the interaction loop.
+    """A host request to dispatch input through the interaction loop.
 
     ``inputs[\"query\"]`` is the only source of user text.  The complete
     mapping is retained so existing DeepAgent invocation metadata (for example
     conversation id and trusted directories) travels with the work item.
+    The query may also be an ``InteractiveInput`` for interrupt recovery;
+    ``mode`` applies only to user text.
     """
 
     request_id: str

--- a/tests/unit_tests/harness/rails/evolution/test_evolution_review_subagent.py
+++ b/tests/unit_tests/harness/rails/evolution/test_evolution_review_subagent.py
@@ -33,7 +33,7 @@ def test_build_evolution_review_agent_config_is_stable_and_restricted():
     assert config.mcps == []
     assert config.skills is None
     assert config.rails == []
-    assert config.max_iterations == 10
+    assert config.max_iterations == 25
     tool_names = [tool.card.name for tool in config.tools]
     assert tool_names == [
         "list_skill_experiences",

--- a/tests/unit_tests/harness/rails/evolution/test_skill_evolution_rail.py
+++ b/tests/unit_tests/harness/rails/evolution/test_skill_evolution_rail.py
@@ -74,7 +74,7 @@ def _make_rail(
     auto_save: bool = True,
     disabled_skills=None,
     language: str = "cn",
-    review_agent_max_iterations: int = 10,
+    review_agent_max_iterations: int = 25,
     fuzzy_review: bool = True,
     fuzzy_review_interval: int = 5,
 ) -> SkillEvolutionRail:
@@ -681,7 +681,7 @@ def test_skill_rail_init_registers_review_agent_with_default_max_iterations(tmp_
         for config in agent.deep_config.subagents
         if getattr(config.agent_card, "name", None) == "evolution_reviewer"
     )
-    assert getattr(configured, "max_iterations", None) == 10
+    assert getattr(configured, "max_iterations", None) == 25
 
 
 def test_skill_rail_init_registers_review_agent_with_custom_max_iterations(tmp_path):

--- a/tests/unit_tests/harness/rails/evolution/test_team_skill_rail.py
+++ b/tests/unit_tests/harness/rails/evolution/test_team_skill_rail.py
@@ -551,7 +551,7 @@ def test_team_rail_init_registers_review_agent_with_default_max_iterations(tmp_p
         for config in agent.deep_config.subagents
         if getattr(config.agent_card, "name", None) == "evolution_reviewer"
     )
-    assert getattr(configured, "max_iterations", None) == 20
+    assert getattr(configured, "max_iterations", None) == 40
 
 
 def test_team_rail_init_registers_review_agent_with_custom_max_iterations(tmp_path):

--- a/tests/unit_tests/harness/test_deep_agent_interaction.py
+++ b/tests/unit_tests/harness/test_deep_agent_interaction.py
@@ -63,24 +63,29 @@ async def test_send_input_preserves_text_validation_and_queueing(
     assert work.reset_loop is True
 
 
+@pytest.mark.parametrize("mode", list(InputDispatchMode))
 @pytest.mark.asyncio
-async def test_send_input_rejects_dispatch_mode_for_interrupt_resume() -> None:
+async def test_send_input_ignores_dispatch_mode_for_interrupt_resume(
+    mode: InputDispatchMode,
+) -> None:
     agent = DeepAgent(AgentCard(name="deep", description="test"))
     agent._interaction_started = True
     interactive_input = InteractiveInput()
     interactive_input.update("call_123", {"action": "allow_once"})
 
-    with pytest.raises(
-        ValueError,
-        match="InteractiveInput does not support an input dispatch mode",
-    ):
-        await agent.send_input(
-            SendInputRequest(
-                request_id="resume-1",
-                inputs={"query": interactive_input},
-                mode=InputDispatchMode.FOLLOW_UP,
-            )
+    await agent.send_input(
+        SendInputRequest(
+            request_id="resume-1",
+            inputs={"query": interactive_input},
+            mode=mode,
         )
+    )
+
+    work = agent._event_manager.next_work()
+    assert work is not None
+    assert isinstance(work.query, InteractiveInput)
+    assert work.query.user_inputs == interactive_input.user_inputs
+    assert work.reset_loop is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/harness/test_deep_agent_interaction.py
+++ b/tests/unit_tests/harness/test_deep_agent_interaction.py
@@ -1,0 +1,128 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Tests for the session-scoped DeepAgent interaction entrypoint."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from openjiuwen.core.session import InteractiveInput
+from openjiuwen.core.single_agent.schema.agent_card import AgentCard
+from openjiuwen.harness.deep_agent import DeepAgent
+from openjiuwen.harness.schema.interaction import (
+    InputDispatchMode,
+    RoundWorkItem,
+    SendInputRequest,
+)
+
+
+@pytest.mark.asyncio
+async def test_send_input_queues_interactive_input_as_interrupt_resume(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = DeepAgent(AgentCard(name="deep", description="test"))
+    agent._interaction_started = True
+    monkeypatch.setattr(agent, "_notify_work", MagicMock())
+    interactive_input = InteractiveInput()
+    interactive_input.update("call_123", {"action": "allow_once"})
+
+    await agent.send_input(
+        SendInputRequest(
+            request_id="resume-1",
+            inputs={"query": interactive_input},
+        )
+    )
+
+    work = agent._event_manager.next_work()
+    assert work is not None
+    assert isinstance(work.query, InteractiveInput)
+    assert work.query.user_inputs == {
+        "call_123": {"action": "allow_once"},
+    }
+    assert work.reset_loop is False
+
+
+@pytest.mark.asyncio
+async def test_send_input_preserves_text_validation_and_queueing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = DeepAgent(AgentCard(name="deep", description="test"))
+    agent._interaction_started = True
+    monkeypatch.setattr(agent, "_notify_work", MagicMock())
+
+    with pytest.raises(ValueError, match="non-empty string or InteractiveInput"):
+        await agent.send_input(SendInputRequest(request_id="empty-1", inputs={"query": ""}))
+
+    await agent.send_input(SendInputRequest(request_id="text-1", inputs={"query": "continue"}))
+
+    work = agent._event_manager.next_work()
+    assert work is not None
+    assert work.query == "continue"
+    assert work.reset_loop is True
+
+
+@pytest.mark.asyncio
+async def test_send_input_rejects_dispatch_mode_for_interrupt_resume() -> None:
+    agent = DeepAgent(AgentCard(name="deep", description="test"))
+    agent._interaction_started = True
+    interactive_input = InteractiveInput()
+    interactive_input.update("call_123", {"action": "allow_once"})
+
+    with pytest.raises(
+        ValueError,
+        match="InteractiveInput does not support an input dispatch mode",
+    ):
+        await agent.send_input(
+            SendInputRequest(
+                request_id="resume-1",
+                inputs={"query": interactive_input},
+                mode=InputDispatchMode.FOLLOW_UP,
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_one_round_uses_single_round_path_for_interrupt_resume(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = DeepAgent(AgentCard(name="deep", description="test"))
+    interactive_input = InteractiveInput()
+    interactive_input.update("call_123", {"action": "allow_once"})
+    work = RoundWorkItem.user(
+        request_id="resume-1",
+        inputs={"query": interactive_input},
+        reset_loop=False,
+    )
+    session = MagicMock()
+    coordinator = MagicMock()
+    controller = MagicMock()
+    controller.submit_round = AsyncMock()
+    result = {"result_type": "answer", "output": "resumed"}
+    react_agent = MagicMock()
+    react_agent.invoke = AsyncMock(return_value=result)
+    agent._react_agent = react_agent
+    write_result = AsyncMock()
+    build_next_work = MagicMock(return_value=None)
+
+    monkeypatch.setattr(
+        agent,
+        "prepare_interaction_task_loop",
+        AsyncMock(return_value=(coordinator, controller)),
+    )
+    monkeypatch.setattr(agent, "_write_round_result_to_stream", write_result)
+    monkeypatch.setattr(agent, "_build_interaction_next_work", build_next_work)
+    monkeypatch.setattr(agent, "save_state", MagicMock())
+    monkeypatch.setattr(agent, "clear_state", MagicMock())
+
+    outcome = await agent.run_one_round(work, "task-1", session)
+
+    effective_inputs = react_agent.invoke.await_args.args[0]
+    assert isinstance(effective_inputs["query"], InteractiveInput)
+    assert effective_inputs["query"].user_inputs == interactive_input.user_inputs
+    coordinator.reset.assert_not_called()
+    controller.submit_round.assert_not_awaited()
+    build_next_work.assert_not_called()
+    write_result.assert_awaited_once_with(result, session)
+    assert outcome.error_code is None


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/community/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openjiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!--
选择下面一种标签替换下方 `/kind <label>`，可选标签类型有：
- /kind bug
- /kind task
- /kind feature
- /kind refactor
- /kind clean_code
如PR描述不符合规范，修改PR描述后需要/check-pr重新检查PR规范。
-->
/kind bug


**Self-checklist**:（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

+ - [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
+ - [x] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
+ - [x] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
+ - [ ] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
+ - [ ] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] 是否导致无法前向兼容 -->
<!-- + - [ ] 是否涉及依赖的三方库变更 -->

### 问题背景

技能演进评审可能因默认迭代上限不足提前结束；结构化中断恢复输入也会被 `send_input()` 的字符串校验拒绝。

### 修改内容

- 提高技能演进subagent的步数上限。
- 支持通过 `send_input()` 传入 `InteractiveInput` 并沿用现有中断恢复流程。
- 保持普通文本输入和 dispatch mode 行为不变，并补充单元测试。

### 验证结果

- 相关 DeepAgent、中断恢复和演进 rail 单元测试：`343 passed, 6 warnings`
- `git diff --check` 通过