### PR TITLE
fix(llm): Map Ollama's reasoning field in the OpenAI client

### DIFF
--- a/openjiuwen/core/foundation/llm/model_clients/openai_model_client.py
+++ b/openjiuwen/core/foundation/llm/model_clients/openai_model_client.py
@@ -555,7 +555,17 @@ class OpenAIModelClient(BaseModelClient):
 
     @staticmethod
     def _extract_reasoning_content(msg_or_delta: Any) -> Optional[str]:
-        return getattr(msg_or_delta, 'reasoning_content', None)
+        # Providers disagree on the field name for reasoning/thinking output:
+        # DeepSeek-style APIs use ``reasoning_content`` while Ollama's
+        # OpenAI-compatible endpoint uses ``reasoning``. Fall back to the
+        # latter so thinking output is not silently dropped. Only accept
+        # string values so absent attributes (or non-string sentinels) do
+        # not leak a non-str into the AssistantMessage.
+        for attr in ('reasoning_content', 'reasoning'):
+            value = getattr(msg_or_delta, attr, None)
+            if isinstance(value, str):
+                return value
+        return None
 
     async def _parse_response(
             self,


### PR DESCRIPTION
# fix(llm): Map Ollama's `reasoning` field in the OpenAI client

## Problem

`OpenAIModelClient._extract_reasoning_content` reads reasoning/thinking output only from the `reasoning_content` field. Ollama's OpenAI-compatible endpoint (`/v1/chat/completions`) reports thinking output in a **`reasoning`** field instead. As a result, on a thinking model (e.g. `qwen3.6`) both `content` and `reasoning_content` come back empty even though the model produced a full reasoning trace — the reasoning is silently dropped before it reaches `AssistantMessage`.

This affects normal chat (thinking output is hidden), and any downstream logic that checks for a non-empty response.

## Fix

Extract reasoning by trying `reasoning_content` first (unchanged for DeepSeek-style providers), then falling back to `reasoning`. Only accept `str` values, so an absent attribute or a non-string sentinel cannot leak a non-`str` into `AssistantMessage.reasoning_content` (which is `Optional[str]`).

The helper is shared by both parse paths — non-stream `_parse_response` and streaming `_parse_stream_chunk` — so a single change covers both.

```python
@staticmethod
def _extract_reasoning_content(msg_or_delta: Any) -> Optional[str]:
    for attr in ('reasoning_content', 'reasoning'):
        value = getattr(msg_or_delta, attr, None)
        if isinstance(value, str):
            return value
    return None
```

## Testing

- `pytest tests/unit_tests/core/foundation/llm/`: **294 passed, 3 skipped**.
- End-to-end against a real Ollama backend (`qwen3.6:27b`): `reasoning_content` is now populated (type `str`) on both the non-stream and streaming paths, where it was previously `None`.
