### PR TITLE
fix(harness): remove unsupported regex lookarounds from worktree schema

### DIFF
--- a/openjiuwen/harness/prompts/tools/enter_worktree.py
+++ b/openjiuwen/harness/prompts/tools/enter_worktree.py
@@ -35,7 +35,7 @@ DESCRIPTION: Dict[str, str] = {
         "Create or resume an isolated git worktree and switch the current session into it.\n\n"
         "## When to Use\n\n"
         "- Use this tool only when the user explicitly asks to work in a worktree\n"
-        "- The user says \"worktree\" (for example: start a worktree, work in a worktree,"
+        '- The user says "worktree" (for example: start a worktree, work in a worktree,'
         " create a worktree, use a worktree)\n\n"
         "## When NOT to Use\n\n"
         "- Only need to create or switch branches -- use git commands\n"
@@ -81,10 +81,11 @@ PARAMS_NAME: Dict[str, str] = {
     ),
 }
 
-_WORKTREE_NAME_PATTERN = (
-    r"^(?=.{1,64}$)(?!(?:.*(?:^|/)\.{1,2}(?:/|$)))"
-    r"[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*$"
-)
+# Responses backends may reject regex lookaround. ``maxLength`` enforces the
+# total length, while this segment pattern excludes only "." and ".." without
+# weakening the execution-time ``validate_slug`` safety check.
+_WORKTREE_SEGMENT_PATTERN = r"(?:[A-Za-z0-9._-]*[A-Za-z0-9_-][A-Za-z0-9._-]*|\.{3,})"
+_WORKTREE_NAME_PATTERN = rf"^{_WORKTREE_SEGMENT_PATTERN}(?:/{_WORKTREE_SEGMENT_PATTERN})*$"
 
 
 def get_enter_worktree_input_params(language: str = "cn") -> Dict[str, Any]:

--- a/tests/unit_tests/harness/tools/worktree/test_tools.py
+++ b/tests/unit_tests/harness/tools/worktree/test_tools.py
@@ -119,11 +119,39 @@ async def test_enter_rejects_invalid_slug(bad_name):
     assert "Invalid worktree name" in (result.error or "")
 
 
-@pytest.mark.parametrize("bad_name", ["../escape", r"..\escape", r"C:\escape"])
+@pytest.mark.parametrize(
+    "bad_name",
+    [
+        "",
+        ".",
+        "..",
+        "safe/../escape",
+        "safe//escape",
+        "../escape",
+        r"..\escape",
+        r"C:\escape",
+        "a" * 65,
+    ],
+)
 def test_enter_schema_rejects_invalid_slug(bad_name):
     schema = get_enter_worktree_input_params("en")
     with pytest.raises(JsonSchemaValidationError):
         validate_json_schema({"name": bad_name}, schema)
+
+
+@pytest.mark.parametrize(
+    "valid_name",
+    ["valid", "user/feature-login", ".hidden", "trailing.", "...", "a/.../b"],
+)
+def test_enter_schema_accepts_valid_slug(valid_name):
+    schema = get_enter_worktree_input_params("en")
+    validate_json_schema({"name": valid_name}, schema)
+
+
+def test_enter_schema_pattern_avoids_regex_lookaround():
+    schema = get_enter_worktree_input_params("en")
+    pattern = schema["properties"]["name"]["pattern"]
+    assert all(token not in pattern for token in ("(?=", "(?!", "(?<=", "(?<!"))
 
 
 def test_enter_schema_rejects_unknown_fields():
@@ -337,6 +365,7 @@ async def test_enter_existing_worktree_by_name(tmp_path, monkeypatch):
     assert os.path.normcase(result.data["worktree_path"]) == os.path.normcase(worktree)
     assert result.data["worktree_branch"] == "worktree-bold-elm-1732"
     assert os.path.normcase(get_cwd()) == os.path.normcase(worktree)
+
 
 @pytest.mark.asyncio
 async def test_unnamed_enter_reuses_session_default_after_keep(tmp_path, monkeypatch):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openJiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!--
Choose one label from `bug`, `task`, `feature` and `refactor`, and replace `<label>` below the comment block.

If this pr is not only bugfix/task/feature and also a refactor, you can append `/kind refactor` label after `/kind bug`, `/kind task` and `/kind feature`.
-->
/kind bug


**What does this PR do / why do we need it**:

* The `enter_worktree` tool's `name.pattern` uses positive and negative regex lookarounds.
* Responses API backends do not support regex lookarounds and reject the complete tool definition before model execution.
* The returned error is:

  > Invalid JSON Schema: regex lookaround is not supported. Found at `$.properties.name.pattern`.

* This causes model requests containing the `enter_worktree` tool to fail even when the tool is not actually invoked.
* This PR replaces the existing expression with a lookaround-free segment pattern:
  * `maxLength=64` continues to enforce the total length constraint.
  * The segment pattern continues to reject `.` and `..`.
  * The existing runtime `validate_slug()` safety validation remains unchanged.
* Regression tests are added for invalid names, valid edge cases, and lookaround-free schema generation.
* No public API, configuration format, dependency, or runtime validation contract is changed.


**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #83 


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

* Verified that the generated worktree name pattern does not contain `(?=`, `(?!`, `(?<=`, or `(?<!`.
* Verified that valid names remain accepted, including:
  * Standard names
  * Nested names
  * Hidden names
  * Names containing three-dot path segments
* Verified that invalid names remain rejected, including:
  * Empty names
  * `.` and `..` path segments
  * Path traversal
  * Empty path segments
  * Backslash and Windows drive paths
  * Names longer than 64 characters
* Verified that the existing runtime slug validation behavior remains unchanged.
* Ran the worktree, slug, and OpenAIAccount Responses transport regression tests.
* Test result: `70 passed, 2 warnings`.
* The two warnings are existing Pydantic class-based configuration deprecation warnings and are unrelated to this change.
* Ruff lint passed.
* Ruff format check passed.
* `git diff --check` passed.
* No flake8 or Ruff suppression comments were introduced.
* No performance impact or third-party dependency changes are involved.


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contain a detailed description of the verification results regarding the achievement of the expected goals for this Bugfix.
+ - [ ] **Interface**: N/A — this PR does not change any external interface.
+ - [ ] **Document**: N/A — this PR does not require official website documentation changes.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->