### PR TITLE
fix(openai-auth): retry transient device polling failures

### DIFF
--- a/openjiuwen/extensions/external_provider/openai_auth/openai_account_auth.py
+++ b/openjiuwen/extensions/external_provider/openai_auth/openai_account_auth.py
@@ -28,6 +28,7 @@ OPENAI_ACCOUNT_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 OPENAI_ACCOUNT_OAUTH_TOKEN_URL = f"{OPENAI_ACCOUNT_AUTH_ISSUER}/oauth/token"
 OPENAI_ACCOUNT_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
 OPENAI_ACCOUNT_RATE_LIMITED_CODE = "openai_account_auth_rate_limited"
+_OPENAI_ACCOUNT_DEVICE_POLL_NETWORK_ERROR_CODE = "openai_account_device_code_poll_network_error"
 
 
 @dataclass(frozen=True, slots=True)
@@ -489,7 +490,7 @@ def poll_openai_account_device_authorization_once(
                 headers={"Content-Type": "application/json"},
             )
     except httpx.HTTPError as exc:
-        _raise_network_failed("device auth polling", "openai_account_device_code_poll_network_error", exc)
+        _raise_network_failed("device auth polling", _OPENAI_ACCOUNT_DEVICE_POLL_NETWORK_ERROR_CODE, exc)
     if response.status_code in {403, 404}:
         return None
     if response.status_code == 429:
@@ -513,21 +514,32 @@ def poll_openai_account_device_authorization(
 ) -> OpenAIAccountDeviceAuthorization:
     """Poll until the user completes device login and an authorization code is available."""
     start = monotonic()
+    last_network_error: Optional[OpenAIAccountAuthError] = None
     while monotonic() - start < max_wait_seconds:
         sleep(device_code.interval)
-        authorization = poll_openai_account_device_authorization_once(
-            device_code,
-            timeout_seconds=timeout_seconds,
-        )
+        try:
+            authorization = poll_openai_account_device_authorization_once(
+                device_code,
+                timeout_seconds=timeout_seconds,
+            )
+        except OpenAIAccountAuthError as exc:
+            if exc.code != _OPENAI_ACCOUNT_DEVICE_POLL_NETWORK_ERROR_CODE:
+                raise
+            last_network_error = exc
+            continue
+        last_network_error = None
         if authorization is None:
             continue
         return authorization
 
-    raise OpenAIAccountAuthError(
+    timeout_error = OpenAIAccountAuthError(
         "OpenAI account device login timed out.",
         code="openai_account_device_code_timeout",
         relogin_required=True,
     )
+    if last_network_error is not None:
+        raise timeout_error from last_network_error
+    raise timeout_error
 
 
 def exchange_openai_account_device_authorization(

--- a/tests/unit_tests/core/foundation/llm/test_openai_account_auth.py
+++ b/tests/unit_tests/core/foundation/llm/test_openai_account_auth.py
@@ -79,9 +79,10 @@ class _FakeHttpxClient:
 
     def post(self, url, *, headers=None, data=None, json=None):
         self.calls.append({"url": url, "headers": headers, "data": data, "json": json})
-        if self.responses:
-            return self.responses.pop(0)
-        return self.response
+        response = self.responses.pop(0) if self.responses else self.response
+        if isinstance(response, Exception):
+            raise response
+        return response
 
 
 def _patch_refresh_response(monkeypatch, response):
@@ -242,6 +243,69 @@ def test_poll_device_authorization_skips_pending_and_returns_authorization(monke
     }
 
 
+def test_poll_device_authorization_retries_transient_network_error(monkeypatch):
+    request = httpx.Request("POST", OPENAI_ACCOUNT_DEVICE_TOKEN_URL)
+    _patch_httpx_responses(
+        monkeypatch,
+        [
+            httpx.ConnectTimeout("temporary proxy timeout", request=request),
+            httpx.RemoteProtocolError("temporary TLS EOF", request=request),
+            _FakeResponse(200, {"authorization_code": "auth-code", "code_verifier": "verifier"}),
+        ],
+    )
+    sleeps = []
+    device_code = OpenAIAccountDeviceCode(user_code="ABCD-EFGH", device_auth_id="device-auth", interval=3)
+
+    authorization = poll_openai_account_device_authorization(
+        device_code,
+        sleep=sleeps.append,
+        monotonic=lambda: 0.0,
+    )
+
+    assert authorization == OpenAIAccountDeviceAuthorization(
+        authorization_code="auth-code",
+        code_verifier="verifier",
+    )
+    assert sleeps == [3, 3, 3]
+
+
+def test_poll_device_authorization_times_out_after_transient_network_error(monkeypatch):
+    request = httpx.Request("POST", OPENAI_ACCOUNT_DEVICE_TOKEN_URL)
+    network_error = httpx.RemoteProtocolError("server disconnected", request=request)
+    _patch_httpx_responses(monkeypatch, [network_error])
+    ticks = iter([0.0, 1.0, 3.0])
+    device_code = OpenAIAccountDeviceCode(user_code="ABCD-EFGH", device_auth_id="device-auth", interval=3)
+
+    with pytest.raises(OpenAIAccountAuthError) as error:
+        poll_openai_account_device_authorization(
+            device_code,
+            max_wait_seconds=2,
+            sleep=lambda seconds: None,
+            monotonic=lambda: next(ticks),
+        )
+
+    assert error.value.code == "openai_account_device_code_timeout"
+    assert isinstance(error.value.__cause__, OpenAIAccountAuthError)
+    assert error.value.__cause__.code == "openai_account_device_code_poll_network_error"
+    assert error.value.__cause__.__cause__ is network_error
+
+
+def test_poll_device_authorization_does_not_retry_terminal_error(monkeypatch):
+    _patch_refresh_response(monkeypatch, _FakeResponse(500, {}))
+    sleeps = []
+    device_code = OpenAIAccountDeviceCode(user_code="ABCD-EFGH", device_auth_id="device-auth", interval=3)
+
+    with pytest.raises(OpenAIAccountAuthError) as error:
+        poll_openai_account_device_authorization(
+            device_code,
+            sleep=sleeps.append,
+            monotonic=lambda: 0.0,
+        )
+
+    assert error.value.code == "openai_account_device_code_poll_failed"
+    assert sleeps == [3]
+
+
 def test_poll_device_authorization_once_returns_none_while_pending(monkeypatch):
     _patch_refresh_response(monkeypatch, _FakeResponse(404, {}))
     device_code = OpenAIAccountDeviceCode(user_code="ABCD-EFGH", device_auth_id="device-auth", interval=3)
@@ -271,6 +335,7 @@ def test_poll_device_authorization_timeout(monkeypatch):
 
     assert error.value.code == "openai_account_device_code_timeout"
     assert error.value.relogin_required is True
+    assert error.value.__cause__ is None
 
 
 def test_exchange_device_authorization_posts_authorization_form(monkeypatch):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openJiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**

/kind bug


**What does this PR do / why do we need it**:

* Retries typed transient network failures, such as `ConnectTimeout` and `RemoteProtocolError`, during blocking OpenAI Account device authorization polling.
* Keeps retrying within the configured `max_wait_seconds` budget instead of terminating the login flow after the first transient failure.
* Preserves immediate failure for terminal authorization errors.
* Preserves the existing timeout contract and chains the last transient network failure as its cause when the waiting budget is exhausted.
* Does not change the public API or one-shot polling behavior.


**Which issue(s) this PR fixes**:

Fixes [#1385](https://gitcode.com/openJiuwen/agent-core/issues/1385)


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

* Consecutive `ConnectTimeout` and `RemoteProtocolError` failures followed by successful authorization: passed.
* Repeated transient network failures until the waiting budget expires: passed, with the last network failure retained as the timeout cause.
* Normal pending authorization followed by timeout: passed without an unrelated stale exception cause.
* Terminal server errors: passed and confirmed to fail immediately without retry.
* Targeted OpenAI Account authentication tests: `33 passed`.
* OpenAI Account CLI consumer tests: `38 passed`.
* OpenAI Account provider regression suite: `74 passed`.
* Ruff lint and incremental source checks: passed.
* No real OAuth network or proxy-failure smoke test was performed.


**Self-checklist**:

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #149
<!-- /bot1-related-issues -->
