### PR TITLE
fix(sys_operation): scope the fs lock directory per user

### DIFF
--- a/openjiuwen/core/sys_operation/local/_rw_lock_manager.py
+++ b/openjiuwen/core/sys_operation/local/_rw_lock_manager.py
@@ -2,10 +2,12 @@
 # Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
 
 import asyncio
+import getpass
 import heapq
 import hashlib
 import os
 import pathlib
+import re
 import tempfile
 import time
 from contextlib import asynccontextmanager
@@ -60,11 +62,31 @@ class ReadWriteLockManager:
         return cls.ensure_lock_dir() / f"{digest}.db"
 
     @classmethod
+    def _lock_dir_name(cls) -> str:
+        """Return the per-user directory name for the lock databases."""
+        base = "openjiuwen-fs-rwlocks"
+        getuid = getattr(os, "getuid", None)
+        if getuid is not None:
+            return f"{base}-{getuid()}"
+        # Windows has no getuid; fall back to the login name, sanitized for path use.
+        user = getpass.getuser() or "unknown"
+        return f"{base}-{re.sub(r'[^A-Za-z0-9_.-]', '_', user)}"
+
+    @classmethod
     def ensure_lock_dir(cls) -> pathlib.Path:
         """Create or reuse the machine-local directory for lock databases."""
         if cls._lock_dir is None:
-            cls._lock_dir = pathlib.Path(tempfile.gettempdir()) / "openjiuwen-fs-rwlocks"
+            cls._lock_dir = pathlib.Path(tempfile.gettempdir()) / cls._lock_dir_name()
         cls._lock_dir.mkdir(parents=True, exist_ok=True)
+        # Owner-only: the databases are per-user now, and /tmp is world-readable.
+        try:
+            cls._lock_dir.chmod(0o700)
+        except OSError as exc:
+            sys_operation_logger.warning(
+                "Failed to restrict the read-write lock directory, lock_dir=%s, error=%s",
+                cls._lock_dir,
+                exc,
+            )
         return cls._lock_dir
 
     @classmethod

--- a/tests/unit_tests/core/sys_operation/local/test_rw_lock_dir.py
+++ b/tests/unit_tests/core/sys_operation/local/test_rw_lock_dir.py
@@ -1,0 +1,139 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Tests for the placement and permissions of the cross-process lock directory.
+
+The directory holds the SQLite databases that coordinate file locking between
+processes, so it has two requirements that pull against each other: every
+process of one user must derive the *same* path, and a directory another user
+created must never be the path this user is sent to.
+"""
+
+import getpass
+import os
+import pathlib
+import sqlite3
+import tempfile
+
+import pytest
+
+from openjiuwen.core.sys_operation.local._rw_lock_manager import ReadWriteLockManager
+
+
+@pytest.fixture
+def fake_tmp(tmp_path, monkeypatch):
+    """Redirect the lock directory into a private temp root, then restore it."""
+    root = tmp_path / "tmp"
+    root.mkdir()
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(root))
+    monkeypatch.setattr(ReadWriteLockManager, "_lock_dir", None)
+    yield root
+    ReadWriteLockManager._lock_dir = None
+
+
+def _derive(uid: int | None = None, monkeypatch=None) -> pathlib.Path:
+    """Force a fresh derivation of the lock directory."""
+    ReadWriteLockManager._lock_dir = None
+    if uid is not None:
+        monkeypatch.setattr(os, "getuid", lambda: uid, raising=False)
+    return ReadWriteLockManager.ensure_lock_dir()
+
+
+@pytest.mark.skipif(not hasattr(os, "getuid"), reason="POSIX-only: no uid to scope by")
+def test_lock_dir_is_scoped_per_uid(fake_tmp, monkeypatch):
+    """Two users on one machine must not be sent to the same directory."""
+    first = _derive(4242, monkeypatch)
+    second = _derive(4243, monkeypatch)
+
+    assert first != second
+    assert first.parent == second.parent == fake_tmp
+
+
+@pytest.mark.skipif(not hasattr(os, "getuid"), reason="POSIX-only: no uid to scope by")
+def test_lock_dir_is_stable_for_one_uid(fake_tmp, monkeypatch):
+    """One user's processes must all derive the same directory.
+
+    The databases exist to coordinate across processes, so a per-process
+    directory would hand every process a private lock and silently defeat the
+    mutual exclusion. Guards against "fix it with mkdtemp".
+    """
+    first = _derive(4242, monkeypatch)
+    second = _derive(4242, monkeypatch)
+
+    assert first == second
+
+
+def test_lock_dir_is_owner_only(fake_tmp):
+    """The databases sit in a world-readable temp root, so restrict the directory."""
+    lock_dir = ReadWriteLockManager.ensure_lock_dir()
+
+    assert lock_dir.stat().st_mode & 0o777 == 0o700
+
+
+def test_lock_dir_survives_a_chmod_failure(fake_tmp, monkeypatch):
+    """A filesystem that refuses chmod must not take file locking down with it."""
+    def refuse(self, mode):
+        raise OSError("chmod not supported")
+
+    monkeypatch.setattr(pathlib.Path, "chmod", refuse)
+
+    lock_dir = ReadWriteLockManager.ensure_lock_dir()
+
+    assert lock_dir.is_dir()
+
+
+def test_lock_dir_without_getuid_is_scoped_by_a_sanitized_login_name(fake_tmp, monkeypatch):
+    """Windows has no getuid, so the login name has to do the scoping.
+
+    It may carry a domain separator and spaces, none of which may end up
+    creating a nested path or a second directory component.
+    """
+    monkeypatch.delattr(os, "getuid", raising=False)
+
+    monkeypatch.setattr(getpass, "getuser", lambda: r"DOMAIN\Admin User")
+    ReadWriteLockManager._lock_dir = None
+    first = ReadWriteLockManager.ensure_lock_dir()
+
+    monkeypatch.setattr(getpass, "getuser", lambda: r"DOMAIN\Other User")
+    ReadWriteLockManager._lock_dir = None
+    second = ReadWriteLockManager.ensure_lock_dir()
+
+    assert first != second
+    assert first.parent == second.parent == fake_tmp
+    for lock_dir in (first, second):
+        assert not any(char in lock_dir.name for char in "\\/ ")
+        assert lock_dir.is_dir()
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not hasattr(os, "getuid"), reason="POSIX-only: mode bits, and no uid to scope by")
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="root ignores the mode bits this test relies on",
+)
+async def test_a_lock_dir_owned_by_another_user_does_not_deny_us(fake_tmp, tmp_path):
+    """The production failure: another account owns the shared directory.
+
+    The first user to run creates it and owns it; a later user finds a
+    directory it cannot write to, SQLite cannot create its database, and every
+    ``fs().read_file()`` fails with "unable to open database file" -- several
+    layers away from anything that mentions locking.
+
+    A directory that denies writes stands in for one owned by another uid:
+    what breaks the second user is the permission, not the ownership.
+    """
+    foreign = fake_tmp / "openjiuwen-fs-rwlocks"
+    foreign.mkdir()
+    foreign.chmod(0o555)
+    target = tmp_path / "target.txt"
+    target.write_text("payload", encoding="utf-8")
+
+    try:
+        async with ReadWriteLockManager.lock_guard(target, "read", timeout=5.0):
+            pass
+        assert ReadWriteLockManager._lock_dir != foreign
+    except sqlite3.OperationalError as exc:  # pragma: no cover - the unfixed path
+        pytest.fail(f"lock acquisition was denied by another user's directory: {exc}")
+    finally:
+        foreign.chmod(0o755)
+        await ReadWriteLockManager.stop()


### PR DESCRIPTION
Paired: [GitHub #283](https://github.com/openJiuwen-ai/agent-core/pull/283) ↔ [GitCode !2164](https://gitcode.com/openJiuwen/agent-core/merge_requests/2164)

**What type of PR is this?**

/kind bug

**What does this PR do / why do we need it**:

`ReadWriteLockManager` put its cross-process lock databases at a fixed path, `tempfile.gettempdir()/"openjiuwen-fs-rwlocks"`. On a shared host the first user to run creates that directory and owns it; every later user finds a directory it cannot write to, so SQLite cannot create its lock database and every filesystem operation fails with `unable to open database file`.

Because `fs().read_file()` takes this lock, the failure reaches everything built on it. `skill_tool` loads `SKILL.md` through `fs().read_file()`, so it reports failure for every skill and the agent falls back to reading skill files directly, which a sandboxed subagent is not permitted to do either. The visible symptom is a subagent unable to use any skill, several layers away from the cause.

This PR names the directory per uid (`openjiuwen-fs-rwlocks-<uid>`), falling back to a sanitized login name where `os.getuid` is unavailable, and chmods it to 0700.

The directory deliberately stays shared between the processes of one user: `get_lock_file()` hashes the target path so every process must derive the same database. A per-process temporary directory would give each process a private lock and silently defeat the mutual exclusion this class provides.

**Which issue(s) this PR fixes**:

Fixes #282

### Residual: the name is still predictable

`openjiuwen-fs-rwlocks-<uid>` is derivable by anyone who knows the uid. On a shared, sticky `/tmp`, another account can create that name first as a symlink; `mkdir(parents=True, exist_ok=True)` then succeeds on the symlink, and the lock databases are written through it into a directory of that account's choosing.

**The predictability is inherited and deliberate.** The old fixed name was equally precomputable, and the write-through-a-symlink effect reproduces unchanged on `develop` — it is not a regression. The directory has to keep a derivable name for the reason above: `get_lock_file()` hashes the target path, so every process of one user must arrive at the same database.

**One effect is new.** `develop` does not chmod this directory at all; the `chmod(0o700)` added here follows the symlink, so an account that wins the race can have this process re-mode a directory of its choosing to 0700. Reproduced with the same two calls the code makes: with the name pre-created as a symlink to a 0755 directory, this branch leaves that directory at 0700 where `develop` leaves it at 0755. The consequence is an availability nuisance for the other account — nothing of theirs becomes readable, and no lock data of ours is disclosed.

It is not fixed here. The fix is one guard — reject the path when `lstat` says it is a symlink or is owned by another uid, before `mkdir` and `chmod`. It belongs in its own change, applied to every fixed-name temporary directory at once rather than folded into one whose subject is the ownership collision, and it wants its own tests: every `fs().read_file()` reaches this code, so a wrongly rejected path fails every file read.

**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

Reproduced on a host where the shared lock directory already exists owned by another account, comparing this branch against its base:

| scenario                                   | base                                             | this PR                        |
| ------------------------------------------ | ------------------------------------------------ | ------------------------------ |
| `lock_guard()` on a workspace file         | `OperationalError: unable to open database file` | acquired                       |
| skill loaded through the agent             | `read_file` fails on every `SKILL.md`; some runs return no answer at all | no errors, runs complete |

The directory is created as `openjiuwen-fs-rwlocks-<uid>`, mode 0700. Processes of the same user still share it and still contend on the same target path, so cross-process exclusion is unchanged.

The same condition breaks the test suite, which makes the effect measurable rather than anecdotal. On such a host, running `tests/unit_tests` on this branch removes 95 failures across 12 files and introduces none. Beyond `core/sys_operation`, the recovered files are `harness/tools/test_filesystem_tools.py` (38), `harness/test_context_assemble_rail.py` (15), `harness/test_deep_agent_workspace.py` (14), `harness/tools/test_skill_tool.py` (9), `core/memory/lite/` (9) and five others, every one of them failing on `unable to open database file`. The failures that remain are present on the base as well and are unrelated to locking.

New unit tests in `tests/unit_tests/core/sys_operation/local/test_rw_lock_dir.py`. Four of the six fail against the base: the directory is not a function of the uid, it is not created 0700, the login-name fallback does not scope it, and a directory that denies writes stops a lock from being acquired with the same `unable to open database file` this change is about. The other two are guards rather than regressions: one pins the directory as stable across derivations, so a later change to per-process directories fails instead of silently defeating the locking; the other holds the chmod failure path open, since a filesystem that refuses chmod must not take file locking down with it.

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #282
<!-- /bot1-related-issues -->

