### PR TITLE
fix(web): restore the jina fallback and report Bing's anti-bot challenge

### DIFF
--- a/openjiuwen/harness/tools/web/_common.py
+++ b/openjiuwen/harness/tools/web/_common.py
@@ -28,6 +28,10 @@ _USER_AGENT = (
     "Chrome/124.0.0.0 Safari/537.36"
 )
 _REQUEST_HEADERS = {"User-Agent": _USER_AGENT}
+# r.jina.ai sits behind Cloudflare, which answers a desktop-browser User-Agent from a plainly
+# non-browser client with HTTP 403. Kept separate from _REQUEST_HEADERS: the engines want the
+# browser User-Agent on their own endpoints, so the two hosts want opposite things.
+_JINA_READER_HEADERS = {"User-Agent": "Mozilla/5.0"}
 
 # Environment variable names (centralized so every module reads the same key).
 _FREE_SEARCH_DEBUG_ENV = "FREE_SEARCH_DEBUG"

--- a/openjiuwen/harness/tools/web/fetch_webpage.py
+++ b/openjiuwen/harness/tools/web/fetch_webpage.py
@@ -28,6 +28,7 @@ from openjiuwen.harness.tools.web._common import (
     _FETCH_WEBPAGE_MAX_BYTES_ENV,
     _FETCH_WEBPAGE_MAX_CHARS_ENV,
     _FETCH_WEBPAGE_MAX_TIMEOUT_ENV,
+    _JINA_READER_HEADERS,
     _REQUEST_HEADERS,
     _decode_ddg_redirect,
     _parse_html,
@@ -92,7 +93,7 @@ class WebFetchWebpageTool(Tool):
             session,
             "GET",
             reader_url,
-            headers=_REQUEST_HEADERS,
+            headers=_JINA_READER_HEADERS,
             timeout_seconds=timeout_seconds,
             max_bytes=byte_cap,
         )

--- a/openjiuwen/harness/tools/web/free_search.py
+++ b/openjiuwen/harness/tools/web/free_search.py
@@ -34,6 +34,7 @@ from openjiuwen.harness.tools.web._common import (
     _FREE_SEARCH_DDG_ENABLED_ENV,
     _FREE_SEARCH_DEBUG_DIR_ENV,
     _FREE_SEARCH_DEBUG_ENV,
+    _JINA_READER_HEADERS,
     _contains_cjk,
     _decode_ddg_redirect,
     _decode_bing_redirect,
@@ -474,6 +475,21 @@ class WebFreeSearchTool(Tool):
         return any(marker in text for marker in markers)
 
     @staticmethod
+    def _is_bing_challenge_page(status_code: int, html: str) -> bool:
+        """Check if the response is a Bing CAPTCHA page, which is served with HTTP 200."""
+        if status_code in {202, 418, 429, 503}:
+            return True
+        text = (html or "").lower()
+        # Markup from the interstitial, not the bare words: a genuine result page contains those
+        # whenever the query is about them.
+        markers = [
+            'class="captcha"',
+            "captcha_header",
+            "/challenge/verify",
+        ]
+        return any(marker in text for marker in markers)
+
+    @staticmethod
     async def _search_duckduckgo(
         session: aiohttp.ClientSession,
         query: str,
@@ -517,7 +533,7 @@ class WebFreeSearchTool(Tool):
             session,
             "GET",
             url,
-            headers=_search_request_headers(query),
+            headers=_JINA_READER_HEADERS,
             timeout_seconds=timeout_seconds,
         )
         _http.raise_for_status_with_body(status, body, engine="duckduckgo-jina")
@@ -584,6 +600,15 @@ class WebFreeSearchTool(Tool):
                 "html_sections": _build_bing_debug_sections(html, soup),
             },
         )
+
+        # After the debug payload, not before: a blocked page is exactly the response an
+        # operator turns debugging on to look at, and raising first would discard it.
+        if WebFreeSearchTool._is_bing_challenge_page(status, html):
+            raise build_error(
+                StatusCode.TOOL_WEB_SEARCH_ENGINE_ERROR,
+                engine="bing",
+                reason="anti-bot challenge page returned",
+            )
 
         rows: list[dict[str, str]] = []
         seen: set[str] = set()

--- a/tests/unit_tests/harness/tools/web/test_web_tools_v2.py
+++ b/tests/unit_tests/harness/tools/web/test_web_tools_v2.py
@@ -758,3 +758,210 @@ async def test_request_extracts_inline_proxy_auth(monkeypatch):
     await _request(session, "GET", "https://target.example.com", timeout_seconds=5)
     assert session.last_kwargs["proxy"] == "http://gw.example.com:8080"
     assert session.last_kwargs["proxy_auth"] == aiohttp.BasicAuth("puser", "ppass")
+
+
+# --------------------------------------------------------------------------- #
+# Anti-bot challenge detection and per-host request headers
+# --------------------------------------------------------------------------- #
+# Bing serves its CAPTCHA interstitial with HTTP 200, so nothing upstream of the
+# parser rejects it and the b_algo extraction simply finds nothing. Detection has
+# to key on the interstitial's own markup, and must not key on the bare words
+# "captcha" or "challenge": a genuine result page carries those whenever the
+# query is about them, and a false positive would turn working searches into
+# reported engine failures.
+_BING_CHALLENGE_HTML = """
+<html><head><title>Bing</title></head>
+<body>
+  <div id="captchaHolder">
+    <div class="captcha">
+      <div class="captcha_header">Please verify you are a human</div>
+      <form action="/challenge/verify?u=abc123" method="POST">
+        <input type="hidden" name="token" value="abc123"/>
+      </form>
+    </div>
+  </div>
+</body></html>
+"""
+
+# A result page for a query that is *about* captchas: the words appear in the
+# title, in result titles, snippets, hostnames and an aria-label, in the same
+# places a live SERP puts them. What it must not contain is the interstitial's
+# markup.
+_BING_RESULTS_ABOUT_CAPTCHAS_HTML = """
+<html><head><title>captcha challenge - Search</title></head>
+<body><main aria-label="Search Results"><ol id="b_results">
+  <li class="b_algo">
+    <div class="b_tpcn"><a class="tilk" aria-label="captcha.net"></a></div>
+    <h2><a href="https://www.captcha.net/">CAPTCHA: Telling Humans and Computers Apart</a></h2>
+    <div class="b_caption"><p>A CAPTCHA is a challenge test used to tell humans and computers apart.</p></div>
+  </li>
+  <li class="b_algo">
+    <h2><a href="https://example.org/how-captcha-challenge-works">How a captcha challenge works</a></h2>
+    <div class="b_caption"><p>Every captcha challenge asks the visitor to verify that they are human.</p></div>
+  </li>
+</ol></main></body></html>
+"""
+
+
+def test_bing_challenge_detection_ignores_the_bare_words():
+    """The words alone must not trip detection, however often they appear."""
+    html = _BING_RESULTS_ABOUT_CAPTCHAS_HTML
+    assert html.lower().count("captcha") >= 5
+    assert html.lower().count("challenge") >= 3
+
+    assert WebFreeSearchTool._is_bing_challenge_page(200, html) is False
+    assert WebFreeSearchTool._is_bing_challenge_page(200, _BING_CHALLENGE_HTML) is True
+
+
+@pytest.mark.asyncio
+async def test_bing_challenge_page_is_reported_as_a_block_not_as_no_results(monkeypatch):
+    """A blocked request must not be indistinguishable from a query with no hits."""
+    monkeypatch.setenv("FREE_SEARCH_DDG_ENABLED", "false")
+    monkeypatch.setenv("FREE_SEARCH_BING_ENABLED", "true")
+    _patch_request(
+        monkeypatch,
+        lambda method, url, body: _resp(200, _BING_CHALLENGE_HTML.encode("utf-8")),
+    )
+
+    tool = WebFreeSearchTool(language="cn")
+    result = await tool.invoke({"query": "test query", "max_results": 5})
+
+    assert "anti-bot challenge page returned" in result
+    assert "low-quality or empty result" not in result
+
+
+@pytest.mark.asyncio
+async def test_bing_results_about_captchas_are_returned_not_reported_as_a_block(monkeypatch):
+    """The direction that costs users: a genuine page must survive detection."""
+    monkeypatch.setenv("FREE_SEARCH_DDG_ENABLED", "false")
+    monkeypatch.setenv("FREE_SEARCH_BING_ENABLED", "true")
+    _patch_request(
+        monkeypatch,
+        lambda method, url, body: _resp(200, _BING_RESULTS_ABOUT_CAPTCHAS_HTML.encode("utf-8")),
+    )
+
+    tool = WebFreeSearchTool(language="cn")
+    result = await tool.invoke({"query": "captcha challenge", "max_results": 5})
+
+    assert "Free search results (Bing)" in result
+    assert "https://www.captcha.net/" in result
+    assert "[ERROR]" not in result
+
+
+def _user_agent_for(recorder, host: str) -> str:
+    """Return the User-Agent sent to the first recorded request against ``host``."""
+    for call in recorder.calls:
+        if host in call["url"]:
+            return (call["headers"] or {}).get("User-Agent", "")
+    raise AssertionError(f"no request was recorded against {host}; urls={[c['url'] for c in recorder.calls]}")
+
+
+@pytest.mark.asyncio
+async def test_jina_reader_is_not_sent_the_browser_user_agent(monkeypatch):
+    """r.jina.ai sits behind Cloudflare, which answers a browser UA from a
+    non-browser client with 403 -- so the reader fallback would fail exactly
+    when it is needed. The origin server still gets the browser UA.
+    """
+    def handler(method, url, body):
+        if "r.jina.ai" in url:
+            return _resp(200, b"Readable article text, long enough to be kept as content.")
+        return _resp(403, b"forbidden")
+
+    recorder = _patch_request(monkeypatch, handler)
+    tool = WebFetchWebpageTool(language="cn")
+    result = await tool.invoke({"url": "https://example.com/article"})
+
+    assert "Readable article text" in result
+    assert "Chrome" not in _user_agent_for(recorder, "r.jina.ai")
+    assert "Chrome" in _user_agent_for(recorder, "example.com/article")
+
+
+@pytest.mark.asyncio
+async def test_duckduckgo_via_jina_is_not_sent_the_browser_user_agent(monkeypatch):
+    """Same host, same reason: the jina proxy wants a plain client."""
+    monkeypatch.setenv("FREE_SEARCH_DDG_ENABLED", "true")
+    monkeypatch.setenv("FREE_SEARCH_BING_ENABLED", "false")
+    markdown = "[Example Title](https://example.com/page1)\n[Another](https://example.org/page2)\n"
+
+    def handler(method, url, body):
+        if "r.jina.ai" in url:
+            return _resp(200, markdown.encode("utf-8"))
+        return _resp(500, b"")
+
+    recorder = _patch_request(monkeypatch, handler)
+    tool = WebFreeSearchTool(language="cn")
+    await tool.invoke({"query": "example", "max_results": 5})
+
+    assert "Chrome" not in _user_agent_for(recorder, "r.jina.ai")
+
+
+@pytest.mark.asyncio
+async def test_search_engines_still_get_the_browser_user_agent(monkeypatch):
+    """The engines' own endpoints want the browser UA; only the proxy differs."""
+    monkeypatch.setenv("FREE_SEARCH_DDG_ENABLED", "true")
+    monkeypatch.setenv("FREE_SEARCH_BING_ENABLED", "true")
+
+    def handler(method, url, body):
+        if "bing.com" in url:
+            return _resp(200, _BING_RESULTS_ABOUT_CAPTCHAS_HTML.encode("utf-8"))
+        return _resp(500, b"")
+
+    recorder = _patch_request(monkeypatch, handler)
+    tool = WebFreeSearchTool(language="cn")
+    await tool.invoke({"query": "captcha challenge", "max_results": 5})
+
+    assert "Chrome" in _user_agent_for(recorder, "duckduckgo.com/html")
+    assert "Chrome" in _user_agent_for(recorder, "bing.com")
+
+
+@pytest.mark.asyncio
+async def test_bing_challenge_page_is_still_captured_for_debugging(monkeypatch, tmp_path):
+    """A blocked page is the response debugging exists for; raising must not discard it."""
+    monkeypatch.setenv("FREE_SEARCH_DDG_ENABLED", "false")
+    monkeypatch.setenv("FREE_SEARCH_BING_ENABLED", "true")
+    monkeypatch.setenv("FREE_SEARCH_DEBUG", "true")
+    monkeypatch.setenv("FREE_SEARCH_DEBUG_DIR", str(tmp_path / "debug"))
+    _patch_request(
+        monkeypatch,
+        lambda method, url, body: _resp(200, _BING_CHALLENGE_HTML.encode("utf-8")),
+    )
+
+    tool = WebFreeSearchTool(language="cn")
+    result = await tool.invoke({"query": "test query", "max_results": 5})
+
+    assert "anti-bot challenge page returned" in result
+    dumps = list((tmp_path / "debug").glob("*_bing_raw.json"))
+    assert dumps, "the blocked response was not captured"
+    payload = json.loads(dumps[0].read_text(encoding="utf-8"))
+    assert 'class="captcha"' in payload["raw_html"]
+    assert payload["html_sections"]["counts"]["b_algo"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "expected_reason"),
+    [
+        (202, "anti-bot challenge page returned"),
+        (429, "HTTP 429"),
+        (503, "HTTP 503"),
+    ],
+)
+async def test_bing_non_ok_statuses_are_attributed(monkeypatch, status, expected_reason):
+    """Pins which check owns which status.
+
+    ``_is_bing_challenge_page`` also treats 202/418/429/503 as a block, but
+    ``_search_bing`` calls ``raise_for_status_with_body`` first, so everything at
+    or above 400 is reported by status before the detector ever sees it. Only
+    202 reaches the detector. Both routes raise the same engine error, so the
+    caller cannot confuse either with an empty result -- this test exists so a
+    later reordering has to be a deliberate choice.
+    """
+    monkeypatch.setenv("FREE_SEARCH_DDG_ENABLED", "false")
+    monkeypatch.setenv("FREE_SEARCH_BING_ENABLED", "true")
+    _patch_request(monkeypatch, lambda method, url, body: _resp(status, b"<html>blocked</html>"))
+
+    tool = WebFreeSearchTool(language="cn")
+    result = await tool.invoke({"query": "test query", "max_results": 5})
+
+    assert expected_reason in result
+    assert "low-quality or empty result" not in result


### PR DESCRIPTION
Paired: [GitHub #285](https://github.com/openJiuwen-ai/agent-core/pull/285) ↔ [GitCode !2165](https://gitcode.com/openJiuwen/agent-core/merge_requests/2165)

**What type of PR is this?**

/kind bug


**What does this PR do / why do we need it**:

Two independent defects in `openjiuwen/harness/tools/web`, both of which only bite on a host whose address the search engines challenge — the case the fallbacks exist for. They are unrelated to each other and are described separately below.

**The r.jina.ai reader was called with a browser User-Agent.**

Both `r.jina.ai` callers passed `_REQUEST_HEADERS`, the browser-like headers built for the search engines themselves. Cloudflare in front of `r.jina.ai` answers a client claiming desktop Chrome, with a Python TLS handshake and no `sec-ch-ua`/`sec-fetch` headers, with HTTP 403. This disabled both paths that exist for when a direct fetch fails: `free_search`'s `duckduckgo-jina` engine and `fetch_webpage`'s reader fallback.

The reader calls now send a neutral `Mozilla/5.0`. The browser User-Agent is kept everywhere else deliberately: on DuckDuckGo's own HTML endpoint the relationship is inverted, where a neutral User-Agent draws the challenge and the browser one is served normally. The two hosts want opposite things, so this is scoped to the reader rather than applied to `_REQUEST_HEADERS`.

Only the User-Agent is neutralized, not the whole header set. The DuckDuckGo proxy search keeps the query-aligned `Accept-Language` it already sent: the reader fetches DuckDuckGo server-side, so that header belongs to the fetch it performs rather than to the User-Agent check in front of it. Dropping the header alongside the User-Agent would have routed every CJK query to an English result page. `fetch_webpage`'s reader fallback has no query to align to and sends the neutral header set alone.

**A Bing block was indistinguishable from a query with no hits.**

Bing serves its CAPTCHA interstitial with HTTP 200, so `raise_for_status_with_body` passes and `b_algo` extraction finds nothing. The engine returned an empty list and the caller recorded "low-quality or empty result", making a blocked request indistinguishable from a query with no hits. DuckDuckGo already had `_is_ddg_challenge_page`; this adds `_is_bing_challenge_page` beside it, raising the same `TOOL_WEB_SEARCH_ENGINE_ERROR`, so the failure is attributable in logs and in the error chain returned from the tool.

Detection uses structural markers from the interstitial — the captcha container div, its header class, and the `/challenge/verify` endpoint — rather than the bare words "captcha" or "challenge", which appear in genuine result pages whenever the query is about them.

The check runs after the debug payload is written rather than before it. A blocked page is precisely the response an operator turns `FREE_SEARCH_DEBUG` on to inspect, and raising first would discard the one capture worth having.

The markers are matched as exact substrings, which decides the direction this degrades in. If Bing changes the interstitial's quoting or adds a class beside `captcha`, detection stops firing and the behaviour falls back to what it is today rather than flagging a genuine result page. Widening the match would invert that trade, and a false positive is the expensive one.

Neither change works around a block: the Bing half reports one. Bing remains unreachable from a challenged address.

Complementary to #524, which routes further status codes through the same reader: that PR increases the traffic this one keeps from being rejected at the door. The two touch `fetch_webpage.py` in nearby places but do not overlap functionally — #524 changes which responses reach the reader, this changes the headers the reader is called with.


**Which issue(s) this PR fixes**:

Fixes #284


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

Compared this branch against its base on a host where both direct engines are challenged, calling the engines directly with no model involved:

| engine                     | base                          | this PR                                   |
| -------------------------- | ----------------------------- | ----------------------------------------- |
| `duckduckgo`               | engine error: challenge page  | engine error: challenge page (unchanged)  |
| `duckduckgo-jina`          | `HTTP 403`                    | 5 results                                 |
| `bing`                     | 0 results, no error           | engine error: anti-bot challenge page     |
| `_search_free` (aggregate) | all web search engines failed | OK via `duckduckgo-jina`, 5 results        |

`r.jina.ai` with one dimension varied, same client and URL: the browser User-Agent returns HTTP 403 and a neutral `Mozilla/5.0` returns HTTP 200. The same result holds with urllib, curl and aiohttp, and a control request to a non-DuckDuckGo target through the same reader shows the rejection belongs to `r.jina.ai`.

Bing detector, checked in both directions against live responses. It fires on the interstitial, served with HTTP 200 and containing `<div class="captcha">` with zero `b_algo` blocks. It does not fire on live Bing result pages, including one for the query "captcha" that carries the word 66 times and "challenge" four times across its title, result titles, snippets and hostnames while containing none of the interstitial's markup. That is the direction that costs users, since a false positive would turn working searches into reported engine failures. The detector also treats HTTP 202, 418, 429 and 503 as a block, but `raise_for_status_with_body` runs first in `_search_bing`, so everything at or above 400 is reported by status and only 202 ever reaches the detector; both routes raise the same engine error, so neither can be mistaken for an empty result.

Tests: `tests/unit_tests/harness/tools/web/` has no failures on this branch, and the whole-suite failure set is identical to the base name by name, with only the new tests added. Twelve unit tests were added to `test_web_tools_v2.py`. Six fail against the base, and six are guards that pass against the base and with the change alike. Two of the guards, parametrized over an ASCII and a CJK query, pin the other half of the header decision: the proxy search still sends the `Accept-Language` matching the query language while sending the neutral User-Agent. They fail if the header set is replaced wholesale rather than having its User-Agent substituted. The guards are the ones worth naming: a genuine result page about captchas still returns its results, the engines' own endpoints still receive the browser User-Agent, and a parametrized test pins which check owns which status. One limit is worth stating: the interstitial fixture is reconstructed from the markers the detector matches, so the committed tests demonstrate that the raise path fires and is attributable, not that the markers are the right ones — that rests on the live verification above. The result-page fixture carries the words in the positions a live SERP puts them, which is what makes the false-positive assertion meaningful.

Note the end-user impact is on the search tool, not necessarily on the final answer: an agent whose `free_search` fails this way may still reach the answer through `fetch_webpage`, at the cost of the wasted calls.


Rebased onto `develop` at `6dfda012`. There was no conflict, and the files this change touches have not moved.

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #284
<!-- /bot1-related-issues -->


