### PR TITLE
feat: Implement a tool to allow the browser subagent to parse images in web…

### DIFF
--- a/openjiuwen/harness/subagents/browser_agent.py
+++ b/openjiuwen/harness/subagents/browser_agent.py
@@ -48,6 +48,9 @@ from openjiuwen.harness.tools.browser_move.playwright_runtime.runtime import (
 from openjiuwen.harness.tools.browser_move.playwright_runtime.runtime_tools import (
     build_browser_runtime_tools,
 )
+from openjiuwen.harness.tools.browser_move.playwright_runtime.vision_rail import (
+    BrowserVisionRail,
+)
 
 try:
     from openjiuwen.harness.prompts import resolve_language
@@ -118,6 +121,12 @@ DEFAULT_BROWSER_AGENT_SYSTEM_PROMPT_EN = (
     "When several fields are needed from the same page, extract them together in one "
     "browser_batch_interact call with named extract_text/extract_value steps, or consume one "
     "browser_probe_cards result that already contains all fields. "
+    "Use browser_vision when the answer exists only as pixels: charts, graphs, canvas elements, "
+    "images without alt text, tables whose values are drawn rather than written, CAPTCHAs, or "
+    "when you need to verify layout. When a probe result reports visual_content.has_visual_only "
+    "or a card marked visual_only, call browser_vision instead of inferring the value from "
+    "surrounding text — never guess at a chart you have not looked at. Do not call browser_vision "
+    "for text or structured data the compact probes can already extract. "
     "Use browser_snapshot only when compact probes are insufficient, when accessibility structure "
     "is needed, or when exact element references are required by a Playwright MCP action. "
     "When an older browser result is replaced by a <persisted-output> marker and its preview is "
@@ -178,6 +187,11 @@ DEFAULT_BROWSER_AGENT_SYSTEM_PROMPT_CN = (
     "动态页面应使用 wait_for_url、wait_for_first_card_title、wait_for_sort_state、"
     "wait_for_result_count、wait_for_dom_text_change 或 wait_for_stable，并设置总 timeout。"
     "“等待完全加载”或“适当停顿”表示等待条件稳定，不表示固定 sleep 3 秒。"
+    "当答案只以像素形式存在时使用 browser_vision：图表、曲线图、canvas 元素、没有 alt 文本的图片、"
+    "以图形而非文字呈现数值的表格、验证码，或需要核实页面布局时。"
+    "当探测结果中出现 visual_content.has_visual_only，或某张卡片被标记为 visual_only 时，"
+    "应调用 browser_vision，而不是根据周围文字推测数值——绝不要对没有看过的图表进行猜测。"
+    "对于紧凑探测已经可以提取的文本或结构化数据，不要调用 browser_vision。"
     "仅在紧凑探测不足、需要无障碍结构，或 Playwright MCP 操作需要精确元素引用时使用 browser_snapshot。"
     "旧浏览器结果被替换为 <persisted-output> 且预览不足时，使用标记中的 handle 调用 "
     "browser_recall_offload。页面导航后，恢复结果里的 ref/selector 已过期，只能作为证据，禁止用于交互。"
@@ -437,6 +451,7 @@ def create_browser_agent(
     injected_rails: List[AgentRail] = [
         BrowserRuntimeRail(browser_backend),
         BrowserWorkingContextRail(working_context_config),
+        BrowserVisionRail(model=model),
     ]
     injected_tools.append(BrowserOffloadRecallTool(workspace, language=resolved_language))
 

--- a/openjiuwen/harness/tools/browser_move/playwright_runtime/probes.py
+++ b/openjiuwen/harness/tools/browser_move/playwright_runtime/probes.py
@@ -89,6 +89,175 @@ async (page) => {
 """.strip()
 
 
+VISUAL_CONTENT_HINT = (
+    "This page contains content that exists only as pixels and cannot be read from the DOM. "
+    "Call browser_vision to look at it before answering."
+)
+
+# Shared page-scan for content the DOM cannot express. Injected verbatim into both
+# probe templates so a probe that returns little still tells the model *why*, and
+# what to call next. Without this the model has no evidence that a chart exists at
+# all and tends to confabulate from surrounding text.
+_VISUAL_SCAN_JS = """
+    const __visualRegions = () => {
+      const MAX_REGIONS = 8;
+      const out = [];
+      const seen = new Set();
+
+      const hintFor = (el) => {
+        const id = el.getAttribute('id');
+        if (id) return '#' + id;
+        const testid = el.getAttribute('data-testid') || el.getAttribute('data-test');
+        if (testid) return '[data-testid="' + testid + '"]';
+        const cls = String(el.getAttribute('class') || '').split(' ').filter(Boolean)[0];
+        const tag = el.tagName.toLowerCase();
+        return cls ? tag + '.' + cls : tag;
+      };
+
+      const usableRect = (el) => {
+        const rect = el.getBoundingClientRect();
+        if (rect.width < 48 || rect.height < 48) return null;
+        if (rect.bottom <= 0 || rect.right <= 0) return null;
+        if (rect.top >= window.innerHeight || rect.left >= window.innerWidth) return null;
+        let style = null;
+        try {
+          style = window.getComputedStyle(el);
+        } catch (_) {
+          style = null;
+        }
+        if (style) {
+          if (style.visibility === 'hidden' || style.display === 'none') return null;
+          if (Number(style.opacity || '1') < 0.05) return null;
+        }
+        return rect;
+      };
+
+      const add = (el, kind, note) => {
+        if (out.length >= MAX_REGIONS || !el || seen.has(el)) return;
+        const rect = usableRect(el);
+        if (!rect) return;
+        seen.add(el);
+        out.push({
+          kind,
+          note,
+          selector_hint: hintFor(el),
+          bbox: [
+            Math.round(rect.x),
+            Math.round(rect.y),
+            Math.round(rect.width),
+            Math.round(rect.height)
+          ]
+        });
+      };
+
+      const textOf = (el) => String(el.textContent || '').trim();
+
+      try {
+        for (const el of Array.from(document.querySelectorAll('canvas'))) {
+          add(el, 'canvas', 'Canvas pixels have no DOM representation.');
+        }
+
+        for (const el of Array.from(document.querySelectorAll('svg'))) {
+          // Icons carry few marks; a chart carries many. Heavily labelled SVG is
+          // already readable as text, so only flag the geometry-encoded ones.
+          const marks = el.querySelectorAll('path, rect, circle, polyline, line').length;
+          if (marks < 5) continue;
+          if (textOf(el).length > 200) continue;
+          add(el, 'svg_graphic', 'SVG encodes values in geometry, not text.');
+        }
+
+        for (const el of Array.from(document.querySelectorAll('img'))) {
+          if (String(el.getAttribute('alt') || '').trim()) continue;
+          if (String(el.getAttribute('aria-label') || '').trim()) continue;
+          if (el.getAttribute('aria-hidden') === 'true') continue;
+          add(el, 'image_without_alt', 'Image carries no alt text.');
+        }
+
+        for (const el of Array.from(document.querySelectorAll('table'))) {
+          const cells = Array.from(el.querySelectorAll('td, th')).slice(0, 60);
+          if (cells.length < 3) continue;
+          const visualCells = cells.filter((cell) => {
+            return !textOf(cell) && cell.querySelector('svg, canvas, img');
+          });
+          if (visualCells.length < 3) continue;
+          add(el, 'visual_table', visualCells.length + ' cells render values visually with no text.');
+        }
+      } catch (_) {
+        // Best-effort only: never fail the surrounding probe over this.
+      }
+
+      return out;
+    };
+
+    const __visualContent = () => {
+      const regions = __visualRegions();
+      return {
+        has_visual_only: regions.length > 0,
+        regions,
+        hint: regions.length > 0 ? __VISUAL_CONTENT_HINT__ : null
+      };
+    };
+""".strip("\n")
+
+
+def _visual_scan_js() -> str:
+    """Return the visual-content scan with the hint text baked in as a JS literal."""
+    return _VISUAL_SCAN_JS.replace(
+        "__VISUAL_CONTENT_HINT__",
+        json.dumps(VISUAL_CONTENT_HINT, ensure_ascii=False),
+    )
+
+
+def build_screenshot_js(*, full_page: bool = False, quality: int = 60) -> str:
+    """Build JavaScript that returns the current page as a base64 JPEG.
+
+    ``page.screenshot()`` returns a Node Buffer, so encoding it here sends the
+    capture back over the ordinary text channel. That sidesteps
+    ``extract_mcp_tool_result_content``, which collapses MCP image blocks to a
+    placeholder string.
+    """
+    params: Dict[str, Any] = {
+        "full_page": bool(full_page),
+        "quality": _clamp_int(quality, default=60, minimum=20, maximum=90),
+    }
+    params_json = json.dumps(params, ensure_ascii=False)
+
+    return f"""
+async (page) => {{
+  const params = {params_json};
+
+  const buffer = await page.screenshot({{
+    type: 'jpeg',
+    quality: params.quality,
+    fullPage: params.full_page === true
+  }});
+
+  const meta = await page.evaluate(() => ({{
+    url: window.location.href,
+    title: document.title,
+    viewport: {{
+      width: window.innerWidth,
+      height: window.innerHeight,
+      scroll_x: window.scrollX,
+      scroll_y: window.scrollY,
+      device_pixel_ratio: window.devicePixelRatio || 1
+    }}
+  }}));
+
+  return {{
+    ok: true,
+    url: meta.url,
+    title: meta.title,
+    viewport: meta.viewport,
+    full_page: params.full_page === true,
+    quality: params.quality,
+    image_base64: buffer.toString('base64'),
+    error: null
+  }};
+}}
+""".strip()
+
+
 def build_interactive_probe_js(
     *,
     max_items: int = 50,
@@ -105,12 +274,15 @@ def build_interactive_probe_js(
         "generation_id": str(generation_id or "g0"),
     }
     params_json = json.dumps(params, ensure_ascii=False)
+    visual_scan_js = _visual_scan_js()
 
     return f"""
 async (page) => {{
   const params = {params_json};
 
   return await page.evaluate((params) => {{
+{visual_scan_js}
+
     const maxItems = Math.max(1, Math.min(Number(params.max_items || 50), 100));
     const viewportOnly = params.viewport_only !== false;
     const query = String(params.query || '').trim().toLowerCase();
@@ -499,6 +671,7 @@ async (page) => {{
       total_candidates: candidates.length,
       returned: elements.length,
       elements,
+      visual_content: __visualContent(),
       error: null
     }};
   }}, params);
@@ -534,6 +707,8 @@ async (page) => {
   const params = __PARAMS__;
 
   return await page.evaluate((params) => {
+__VISUAL_SCAN_JS__
+
     const maxCards = Math.max(1, Math.min(Number(params.max_cards || 20), 50));
     const viewportOnly = params.viewport_only !== false;
     const includeButtons = params.include_buttons !== false;
@@ -1578,6 +1753,32 @@ async (page) => {
       return Boolean(root.querySelector('img, picture, source[srcset]'));
     };
 
+    // A card whose payload is pixels: chart/canvas/SVG geometry, or an image with
+    // no alt text. Text extraction returns nothing useful for these, so the card
+    // carries the reason and browser_vision is the resolution.
+    const visualOnlyKind = (root) => {
+      if (root.querySelector('canvas')) return 'canvas';
+
+      const svg = root.querySelector('svg');
+      if (svg) {
+        const marks = svg.querySelectorAll('path, rect, circle, polyline, line').length;
+        const labelLength = String(svg.textContent || '').trim().length;
+        if (marks >= 5 && labelLength <= 200) return 'svg_graphic';
+      }
+
+      const images = Array.from(root.querySelectorAll('img'));
+      const unlabelled = images.filter((img) => {
+        if (String(img.getAttribute('alt') || '').trim()) return false;
+        if (String(img.getAttribute('aria-label') || '').trim()) return false;
+        return img.getAttribute('aria-hidden') !== 'true';
+      });
+      if (unlabelled.length > 0 && unlabelled.length === images.length) {
+        return 'image_without_alt';
+      }
+
+      return '';
+    };
+
     const structuralSignature = (el, fields) => {
       const tag = el.tagName.toLowerCase();
       const classTokens = normalize(el.getAttribute('class') || '', 160)
@@ -1682,6 +1883,7 @@ async (page) => {
         const reviewCount = extractReviewCount(rootText);
         const availability = extractAvailability(rootText);
         const imagePresent = hasImage(el);
+        const visualOnly = visualOnlyKind(el);
 
         const fields = {
           title: title.value,
@@ -1780,6 +1982,7 @@ async (page) => {
             ? 'navigate_primary_link'
             : (cardClickable ? 'use_validated_selector' : 'use_actionable_child_control'),
           has_image: imagePresent,
+          visual_only: visualOnly || null,
           buttons,
           text_preview: normalize(rootText, 280),
           bbox: [
@@ -2054,10 +2257,11 @@ async (page) => {
       returned: cards.length,
       recurring_signatures: recurringSignatures,
       cards,
+      visual_content: __visualContent(),
       error: null
     };
   }, params);
 }
 """.strip()
 
-    return template.replace("__PARAMS__", params_json)
+    return template.replace("__PARAMS__", params_json).replace("__VISUAL_SCAN_JS__", _visual_scan_js())

--- a/openjiuwen/harness/tools/browser_move/playwright_runtime/runtime.py
+++ b/openjiuwen/harness/tools/browser_move/playwright_runtime/runtime.py
@@ -44,9 +44,11 @@ from .probes import (
     build_interactive_probe_js,
 )
 from .page_state import BrowserPageState, BrowserTarget
+from .probes import build_card_probe_js, build_interactive_probe_js, build_screenshot_js
 from .service import MAX_ITERATION_MESSAGE, BrowserService, BrowserTaskProgressState
 from .site_profiles import builtin_site_profiles, get_selector_cache
 from .status_logging import BrowserSubagentStatusLogger, is_browser_subagent_status_log_enabled
+from .vision_image import DEFAULT_MAX_DIMENSION, prepare_screenshot
 
 
 _BROWSER_PROGRESS_STATE_KEY = "__browser_subagent_progress_state__"
@@ -1363,6 +1365,70 @@ class BrowserAgentRuntime:
         page_state.register_interactives(parsed)
         parsed["page_state"] = page_state.export()
         return parsed
+
+    async def capture_screenshot(
+        self,
+        *,
+        full_page: bool = False,
+        quality: int = 60,
+        max_dimension: int = DEFAULT_MAX_DIMENSION,
+    ) -> Dict[str, Any]:
+        """Capture the rendered page as a base64 JPEG for multimodal delivery."""
+        await self.ensure_runtime_ready()
+
+        if self._code_executor is None:
+            return {
+                "ok": False,
+                "error": "browser_code_executor_not_ready",
+                "image_base64": "",
+            }
+
+        js_code = build_screenshot_js(full_page=full_page, quality=quality)
+
+        try:
+            raw = await self._code_executor(js_code)
+            raw = self._unwrap_mcp_text_result(raw)
+        except Exception as exc:
+            return {
+                "ok": False,
+                "error": f"browser_vision capture failed: {exc}",
+                "image_base64": "",
+            }
+
+        parsed = extract_json_object(raw)
+        if not parsed:
+            return {
+                "ok": False,
+                "error": "Could not parse browser_vision result JSON",
+                "raw_preview": str(raw)[:400],
+                "image_base64": "",
+            }
+
+        image_base64 = str(parsed.get("image_base64") or "")
+        if not image_base64:
+            return {
+                "ok": False,
+                "error": str(parsed.get("error") or "browser_vision returned no image data"),
+                "image_base64": "",
+            }
+
+        prepared = prepare_screenshot(image_base64, max_dimension=max_dimension)
+        viewport = parsed.get("viewport") if isinstance(parsed.get("viewport"), dict) else {}
+
+        return {
+            "ok": True,
+            "error": None,
+            "url": str(parsed.get("url") or ""),
+            "title": str(parsed.get("title") or ""),
+            "viewport": viewport,
+            "full_page": bool(parsed.get("full_page")),
+            "image_base64": prepared.base64_jpeg,
+            "data_url": prepared.data_url,
+            "image_width": prepared.width,
+            "image_height": prepared.height,
+            "downscaled": prepared.downscaled,
+            "approx_bytes": prepared.approx_bytes,
+        }
 
     async def probe_cards(
         self,

--- a/openjiuwen/harness/tools/browser_move/playwright_runtime/runtime_tools.py
+++ b/openjiuwen/harness/tools/browser_move/playwright_runtime/runtime_tools.py
@@ -123,6 +123,38 @@ _PROBE_INTERACTIVES_PARAMS: Dict[str, Any] = {
     "required": [],
 }
 
+_VISION_DESC = (
+    "Look at the rendered page as an image when the DOM cannot express what you need. "
+    "Use this for charts, graphs, canvas elements, images without alt text, tables whose "
+    "values are drawn rather than written, CAPTCHAs, and for verifying layout or whether a "
+    "modal visually covers the page. The probes flag these regions as visual_content in "
+    "their result — when they do, call this instead of guessing from surrounding text. "
+    "Do NOT use this for text or structured data the probes can already extract: "
+    "browser_probe_cards and browser_probe_interactives stay the default and are cheaper. "
+    "The screenshot is attached to the conversation for the next model step only; take a "
+    "fresh one after the page changes."
+)
+_VISION_PARAMS: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "reason": {
+            "type": "string",
+            "description": (
+                "What you need to read from the pixels, e.g. 'peak value of the revenue chart'. "
+                "Keep it short; it is echoed back with the capture."
+            ),
+        },
+        "full_page": {
+            "type": "boolean",
+            "description": (
+                "Capture the whole scrollable page instead of the viewport. Default false. "
+                "Use sparingly: a full-page capture of a long page loses detail once downscaled."
+            ),
+        },
+    },
+    "required": [],
+}
+
 _PROBE_CARDS_DESC = (
     "Return compact repeated card/listing structures from the current page. "
     "Use this first on product pages, marketplace pages, search-result pages, catalog pages, "
@@ -827,6 +859,104 @@ class BrowserRuntimeHealthTool(Tool):
             yield None
 
 
+class BrowserVisionTool(Tool):
+    """On-demand screenshot for content the DOM cannot express."""
+
+    def __init__(self, runtime: "BrowserAgentRuntime", language: str = "cn") -> None:
+        del language
+        super().__init__(
+            ToolCard(
+                name="browser_vision",
+                description=_VISION_DESC,
+                input_params=_VISION_PARAMS,
+            )
+        )
+        self._runtime = runtime
+
+    async def invoke(self, inputs: Dict[str, Any], **kwargs: Any) -> ToolOutput:
+        del kwargs
+
+        full_page_raw = inputs.get("full_page", False)
+        if isinstance(full_page_raw, str):
+            full_page = full_page_raw.strip().lower() in {"1", "true", "yes"}
+        else:
+            full_page = bool(full_page_raw)
+
+        reason = str(inputs.get("reason") or "").strip()
+
+        try:
+            data = await self._runtime.capture_screenshot(full_page=full_page)
+        except Exception as exc:
+            return ToolOutput(success=False, error=str(exc))
+
+        if not data.get("ok"):
+            return ToolOutput(success=False, error=str(data.get("error") or "browser_vision failed"))
+
+        return ToolOutput(success=True, data=_build_vision_tool_data(data, reason=reason))
+
+    async def stream(self, inputs: Dict[str, Any], **kwargs: Any) -> AsyncIterator[Any]:
+        del inputs, kwargs
+        if False:
+            yield None
+
+
+def _build_vision_tool_data(capture: Dict[str, Any], *, reason: str) -> Dict[str, Any]:
+    """Split a capture into model-visible text and an attached image block.
+
+    ``ability_manager._build_tool_message_content`` renders only ``content`` into
+    the ToolMessage, and ``ReActAgent._build_multimodal_tool_results_message``
+    turns ``multimodal`` into a following UserMessage. Keeping the base64 out of
+    ``content`` is what stops the payload being sent twice — once as text.
+    """
+    url = str(capture.get("url") or "")
+    viewport = capture.get("viewport") if isinstance(capture.get("viewport"), dict) else {}
+    width = capture.get("image_width")
+    height = capture.get("image_height")
+
+    parts = [f"Screenshot attached for: {url or 'the current page'}"]
+    title = str(capture.get("title") or "")
+    if title:
+        parts.append(f"title: {title}")
+    if reason:
+        parts.append(f"looking for: {reason}")
+    if width and height:
+        parts.append(f"attached image: {width}x{height} jpeg")
+    if capture.get("full_page"):
+        parts.append("scope: full scrollable page")
+    else:
+        scroll_y = viewport.get("scroll_y")
+        scope = "scope: current viewport only"
+        if scroll_y:
+            scope += f" (scrolled {int(scroll_y)}px down; scroll and re-capture to see the rest)"
+        parts.append(scope)
+    parts.append("Image bytes are attached as multimodal input and omitted from this tool result.")
+    parts.append(
+        "This capture reflects the page at capture time and is not refreshed by later actions; "
+        "take a new one after the page changes."
+    )
+
+    return {
+        "content": "\n".join(parts),
+        "multimodal": [
+            {
+                "type": "image",
+                "source": "browser_vision",
+                "source_path": f"browser_vision:{url}" if url else "browser_vision",
+                "mime_type": "image/jpeg",
+                "data_url": str(capture.get("data_url") or ""),
+            }
+        ],
+        "url": url,
+        "title": title,
+        "viewport": viewport,
+        "full_page": bool(capture.get("full_page")),
+        "image_width": width,
+        "image_height": height,
+        "downscaled": bool(capture.get("downscaled")),
+        "approx_bytes": capture.get("approx_bytes"),
+    }
+
+
 def build_browser_runtime_tools(
     runtime: "BrowserAgentRuntime",
     language: str = "cn",
@@ -843,6 +973,7 @@ def build_browser_runtime_tools(
         BrowserClearCancelTool(runtime, language),
         BrowserProbeInteractivesTool(runtime, language),
         BrowserProbeCardsTool(runtime, language),
+        BrowserVisionTool(runtime, language),
         BrowserBatchInteractTool(runtime, language),
         BrowserCustomActionTool(runtime, language),
         BrowserListActionsTool(runtime, language),

--- a/openjiuwen/harness/tools/browser_move/playwright_runtime/vision_image.py
+++ b/openjiuwen/harness/tools/browser_move/playwright_runtime/vision_image.py
@@ -1,0 +1,101 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Screenshot post-processing for ``browser_vision``.
+
+Payload size is controlled capture-side first — JPEG quality plus the page's own
+viewport — so Pillow is only a secondary clamp and stays an optional import.
+``browser_move`` must not inherit the ``mobile-gui`` extra just to look at a page;
+without Pillow the capture is passed through unchanged.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import io
+from dataclasses import dataclass
+from typing import Optional
+
+from openjiuwen.core.common.logging import logger
+
+DEFAULT_MAX_DIMENSION = 1280
+_RESIZED_JPEG_QUALITY = 70
+
+
+@dataclass(frozen=True)
+class PreparedScreenshot:
+    """A capture ready to enter model context."""
+
+    base64_jpeg: str
+    width: Optional[int]
+    height: Optional[int]
+    downscaled: bool
+
+    @property
+    def data_url(self) -> str:
+        """The capture as a data URL, ready for an ``image_url`` content block."""
+        return f"data:image/jpeg;base64,{self.base64_jpeg}"
+
+    @property
+    def approx_bytes(self) -> int:
+        """Decoded size of the JPEG, for logging and budget checks."""
+        return len(self.base64_jpeg) * 3 // 4
+
+
+def prepare_screenshot(
+    image_base64: str,
+    *,
+    max_dimension: int = DEFAULT_MAX_DIMENSION,
+) -> PreparedScreenshot:
+    """Clamp a base64 JPEG to ``max_dimension`` on its longest side.
+
+    Returns the input untouched when Pillow is unavailable, when the image is
+    already small enough, or when decoding fails: a slightly oversized screenshot
+    is worth more to the model than no screenshot at all.
+    """
+    cleaned = str(image_base64 or "").strip()
+    if not cleaned:
+        return PreparedScreenshot(base64_jpeg="", width=None, height=None, downscaled=False)
+
+    try:
+        from PIL import Image  # noqa: PLC0415 — optional dependency, imported on use
+    except ImportError:
+        logger.debug("[browser_vision] Pillow not installed; sending the capture unscaled")
+        return PreparedScreenshot(base64_jpeg=cleaned, width=None, height=None, downscaled=False)
+
+    try:
+        raw = base64.b64decode(cleaned, validate=True)
+        with Image.open(io.BytesIO(raw)) as img:
+            width, height = img.size
+            if max(width, height) <= max_dimension:
+                return PreparedScreenshot(
+                    base64_jpeg=cleaned,
+                    width=width,
+                    height=height,
+                    downscaled=False,
+                )
+
+            ratio = max_dimension / float(max(width, height))
+            target = (max(1, int(width * ratio)), max(1, int(height * ratio)))
+            resized = img.convert("RGB").resize(target, Image.LANCZOS)
+
+            buffer = io.BytesIO()
+            resized.save(buffer, format="JPEG", quality=_RESIZED_JPEG_QUALITY)
+            encoded = base64.b64encode(buffer.getvalue()).decode("ascii")
+    except (OSError, ValueError) as exc:
+        logger.warning("[browser_vision] could not downscale the capture (%s); sending it unscaled", exc)
+        return PreparedScreenshot(base64_jpeg=cleaned, width=None, height=None, downscaled=False)
+
+    return PreparedScreenshot(
+        base64_jpeg=encoded,
+        width=target[0],
+        height=target[1],
+        downscaled=True,
+    )
+
+
+__all__ = [
+    "DEFAULT_MAX_DIMENSION",
+    "PreparedScreenshot",
+    "prepare_screenshot",
+]

--- a/openjiuwen/harness/tools/browser_move/playwright_runtime/vision_rail.py
+++ b/openjiuwen/harness/tools/browser_move/playwright_runtime/vision_rail.py
@@ -1,0 +1,111 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Context hygiene for ``browser_vision`` captures.
+
+Delivery itself needs no rail: ``ReActAgent`` already turns a tool result's
+``multimodal`` list into a UserMessage after the ToolMessages. What is missing is
+eviction — an on-demand screenshot goes stale as soon as the page changes, and
+nothing removes it. This rail keeps the most recent captures and replaces older
+image blocks with an explicit placeholder, so context stays flat across a long run
+and the model is told the old view is outdated rather than silently losing it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from openjiuwen.core.common.logging import logger
+from openjiuwen.core.single_agent.rail.base import (
+    AgentCallbackContext,
+    AgentRail,
+    ModelCallInputs,
+)
+from openjiuwen.harness.image_modality_probe import get_cached_image_support
+
+OUTDATED_VIEW_PLACEHOLDER = (
+    "A browser_vision screenshot from an earlier step is no longer attached, to save context. "
+    "The page has probably changed since then; call browser_vision again if you still need to "
+    "look at it. If you already extracted what you needed from that view, rely on your notes."
+)
+
+DEFAULT_CAPTURES_TO_KEEP = 1
+
+
+def _has_image_block(msg) -> bool:
+    if not isinstance(msg.content, list):
+        return False
+    return any(isinstance(block, dict) and block.get("type") == "image_url" for block in msg.content)
+
+
+def _replace_image_blocks(msg) -> None:
+    """Swap image blocks for placeholder text, preserving the multimodal shape."""
+    next_content: list = []
+    for block in msg.content:
+        if isinstance(block, dict) and block.get("type") == "image_url":
+            next_content.append({"type": "text", "text": OUTDATED_VIEW_PLACEHOLDER})
+        else:
+            next_content.append(block)
+    msg.content = next_content or [{"type": "text", "text": OUTDATED_VIEW_PLACEHOLDER}]
+
+
+class BrowserVisionRail(AgentRail):
+    """Keep the last N screenshots attached; retire the rest to a placeholder."""
+
+    priority: int = 85
+
+    def __init__(self, model: Any = None, captures_to_keep: int = DEFAULT_CAPTURES_TO_KEEP) -> None:
+        super().__init__()
+        self._model = model
+        self._captures_to_keep = max(0, captures_to_keep)
+        self._warned_about_image_support = False
+
+    async def before_model_call(self, ctx: AgentCallbackContext) -> None:
+        if not isinstance(ctx.inputs, ModelCallInputs) or ctx.context is None:
+            return
+        self._warn_if_model_is_text_only()
+        self._retire_old_captures(ctx)
+
+    def _warn_if_model_is_text_only(self) -> None:
+        """Say so once if the configured model cannot accept image input.
+
+        The verdict is cached process-wide by DeepAgent's own probe, so this only
+        reports a result someone else already paid for; it never probes itself.
+        """
+        if self._warned_about_image_support or self._model is None:
+            return
+        if get_cached_image_support(self._model) is False:
+            self._warned_about_image_support = True
+            logger.warning(
+                "[BrowserVisionRail] the configured model does not accept image input; "
+                "browser_vision captures will not be readable by it"
+            )
+
+    def _retire_old_captures(self, ctx: AgentCallbackContext) -> None:
+        messages = ctx.context.get_messages()
+        if not messages:
+            return
+
+        capture_indices = [index for index, msg in enumerate(messages) if msg.role == "user" and _has_image_block(msg)]
+        if len(capture_indices) <= self._captures_to_keep:
+            return
+
+        stale = (
+            capture_indices[: len(capture_indices) - self._captures_to_keep]
+            if self._captures_to_keep
+            else capture_indices
+        )
+        for index in stale:
+            _replace_image_blocks(messages[index])
+
+        ctx.context.set_messages(messages)
+        logger.info(
+            "[BrowserVisionRail] retired %s stale screenshot(s) from context",
+            len(stale),
+        )
+
+
+__all__ = [
+    "BrowserVisionRail",
+    "DEFAULT_CAPTURES_TO_KEEP",
+    "OUTDATED_VIEW_PLACEHOLDER",
+]

--- a/openjiuwen/harness/tools/mobile_gui/tiktoken_multimodal_patch.py
+++ b/openjiuwen/harness/tools/mobile_gui/tiktoken_multimodal_patch.py
@@ -24,5 +24,6 @@ def apply_tiktoken_counter_multimodal_patch() -> None:
 
 
 __all__ = [
+    "DEFAULT_IMAGE_PLACEHOLDER_TOKENS",
     "apply_tiktoken_counter_multimodal_patch",
 ]

--- a/tests/unit_tests/harness/tools/browser_move/test_browser_runtime_tools.py
+++ b/tests/unit_tests/harness/tools/browser_move/test_browser_runtime_tools.py
@@ -19,6 +19,7 @@ from openjiuwen.harness.tools.browser_move.playwright_runtime.runtime_tools impo
     BrowserProbeCardsTool,
     BrowserProbeInteractivesTool,
     BrowserRuntimeHealthTool,
+    BrowserVisionTool,
     build_browser_runtime_tools,
 )
 
@@ -47,7 +48,7 @@ def _make_runtime() -> BrowserAgentRuntime:
 
 def test_build_browser_runtime_tools_returns_helper_tools_by_default() -> None:
     tools = build_browser_runtime_tools(_make_runtime())
-    assert len(tools) == 8
+    assert len(tools) == 9
 
 
 def test_each_tool_is_tool_subclass() -> None:
@@ -67,6 +68,7 @@ def test_default_helper_tool_names() -> None:
         "browser_clear_cancel",
         "browser_probe_interactives",
         "browser_probe_cards",
+        "browser_vision",
         "browser_batch_interact",
         "browser_custom_action",
         "browser_list_custom_actions",
@@ -80,6 +82,7 @@ def test_helper_tool_classes() -> None:
         clear_cancel,
         probe_interactives,
         probe_cards,
+        vision,
         batch_interact,
         custom_action,
         list_actions,
@@ -89,6 +92,7 @@ def test_helper_tool_classes() -> None:
     assert isinstance(clear_cancel, BrowserClearCancelTool)
     assert isinstance(probe_interactives, BrowserProbeInteractivesTool)
     assert isinstance(probe_cards, BrowserProbeCardsTool)
+    assert isinstance(vision, BrowserVisionTool)
     assert isinstance(batch_interact, BrowserBatchInteractTool)
     assert isinstance(custom_action, BrowserCustomActionTool)
     assert isinstance(list_actions, BrowserListActionsTool)

--- a/tests/unit_tests/harness/tools/browser_move/test_browser_vision_rail.py
+++ b/tests/unit_tests/harness/tools/browser_move/test_browser_vision_rail.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+# coding: utf-8
+# pylint: disable=protected-access
+"""Tests for BrowserVisionRail screenshot retirement."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from openjiuwen.core.foundation.llm import AssistantMessage, UserMessage
+from openjiuwen.harness.tools.browser_move.playwright_runtime.vision_rail import (
+    OUTDATED_VIEW_PLACEHOLDER,
+    BrowserVisionRail,
+)
+
+
+def _capture_message(index: int = 0) -> UserMessage:
+    return UserMessage(
+        content=[
+            {"type": "text", "text": f"Screenshot attached for: https://example.test/{index}"},
+            {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,QQ=="}},
+        ]
+    )
+
+
+def _fake_context(messages: list[Any]) -> SimpleNamespace:
+    class _MessageContext:
+        def __init__(self, items: list[Any]) -> None:
+            self._items = list(items)
+
+        def get_messages(self) -> list[Any]:
+            return self._items
+
+        def set_messages(self, items: list[Any]) -> None:
+            self._items = list(items)
+
+    return SimpleNamespace(context=_MessageContext(messages))
+
+
+def _image_blocks(msg) -> list[dict]:
+    return [b for b in msg.content if isinstance(b, dict) and b.get("type") == "image_url"]
+
+
+def test_rail_keeps_only_the_most_recent_capture() -> None:
+    ctx = _fake_context([_capture_message(i) for i in range(4)])
+
+    BrowserVisionRail(captures_to_keep=1)._retire_old_captures(ctx)
+
+    messages = ctx.context.get_messages()
+    for msg in messages[:-1]:
+        assert not _image_blocks(msg)
+        assert any(OUTDATED_VIEW_PLACEHOLDER in b.get("text", "") for b in msg.content)
+    assert _image_blocks(messages[-1])
+
+
+def test_rail_is_a_noop_at_or_below_the_budget() -> None:
+    ctx = _fake_context([_capture_message(0), _capture_message(1)])
+
+    BrowserVisionRail(captures_to_keep=2)._retire_old_captures(ctx)
+
+    for msg in ctx.context.get_messages():
+        assert _image_blocks(msg)
+
+
+def test_rail_preserves_surrounding_text_and_other_messages() -> None:
+    other = AssistantMessage(content="probing the page")
+    ctx = _fake_context([_capture_message(0), other, _capture_message(1)])
+
+    BrowserVisionRail(captures_to_keep=1)._retire_old_captures(ctx)
+
+    messages = ctx.context.get_messages()
+    # The retired turn keeps its descriptive text block; only the image goes.
+    assert messages[0].content[0]["text"].startswith("Screenshot attached for:")
+    assert len(messages[0].content) == 2
+    assert messages[1] is other
+    assert _image_blocks(messages[2])
+
+
+def test_rail_can_retire_every_capture() -> None:
+    ctx = _fake_context([_capture_message(0), _capture_message(1)])
+
+    BrowserVisionRail(captures_to_keep=0)._retire_old_captures(ctx)
+
+    for msg in ctx.context.get_messages():
+        assert not _image_blocks(msg)
+
+
+def test_rail_ignores_text_only_conversations() -> None:
+    ctx = _fake_context([UserMessage(content="read the chart"), AssistantMessage(content="ok")])
+
+    BrowserVisionRail(captures_to_keep=1)._retire_old_captures(ctx)
+
+    assert ctx.context.get_messages()[0].content == "read the chart"
+
+
+def test_rail_applies_the_multimodal_token_patch() -> None:
+    from openjiuwen.core.context_engine.token.tiktoken_counter import TiktokenCounter
+
+    BrowserVisionRail()
+
+    counter = TiktokenCounter()
+    big_data_url = "data:image/jpeg;base64," + ("A" * 200_000)
+    message = UserMessage(
+        content=[
+            {"type": "text", "text": "look"},
+            {"type": "image_url", "image_url": {"url": big_data_url}},
+        ]
+    )
+
+    # Unpatched counting repr()s the list and charges ~50k tokens for the blob.
+    assert counter.count_messages([message]) < 5_000

--- a/tests/unit_tests/harness/tools/browser_move/test_browser_vision_tool.py
+++ b/tests/unit_tests/harness/tools/browser_move/test_browser_vision_tool.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python
+# coding: utf-8
+# pylint: disable=protected-access
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+from openjiuwen.core.foundation.tool import McpServerConfig
+from openjiuwen.core.single_agent.ability_manager import AbilityManager
+from openjiuwen.core.single_agent.agents.react_agent import ReActAgent
+from openjiuwen.harness.tools.base_tool import ToolOutput
+from openjiuwen.harness.tools.browser_move.playwright_runtime.config import BrowserRunGuardrails
+from openjiuwen.harness.tools.browser_move.playwright_runtime.probes import (
+    build_screenshot_js,
+)
+from openjiuwen.harness.tools.browser_move.playwright_runtime.runtime import (
+    BrowserAgentRuntime,
+)
+from openjiuwen.harness.tools.browser_move.playwright_runtime.runtime_tools import (
+    BrowserVisionTool,
+    build_browser_runtime_tools,
+)
+from openjiuwen.harness.tools.browser_move.playwright_runtime.vision_image import (
+    prepare_screenshot,
+)
+
+# 1x1 JPEG, enough to exercise decode paths without a fixture file.
+_TINY_JPEG_B64 = (
+    "/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a"
+    "HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAA"
+    "AAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AKp//2Q=="
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _make_runtime() -> BrowserAgentRuntime:
+    mcp_cfg = McpServerConfig(
+        server_id="test-playwright-vision",
+        server_name="test-playwright-vision",
+        server_path="stdio://playwright",
+        client_type="stdio",
+        params={"cwd": str(Path.cwd())},
+    )
+
+    return BrowserAgentRuntime(
+        provider="openai",
+        api_key="test-key",
+        api_base="https://example.invalid/v1",
+        model_name="test-model",
+        mcp_cfg=mcp_cfg,
+        guardrails=BrowserRunGuardrails(
+            max_steps=3,
+            max_failures=1,
+            timeout_s=30,
+            retry_once=False,
+        ),
+    )
+
+
+def _capture(**overrides):
+    data = {
+        "ok": True,
+        "error": None,
+        "url": "https://example.test/report",
+        "title": "Quarterly report",
+        "viewport": {"width": 1280, "height": 720, "scroll_x": 0, "scroll_y": 0},
+        "full_page": False,
+        "image_base64": "AAAA",
+        "data_url": "data:image/jpeg;base64,AAAA",
+        "image_width": 1280,
+        "image_height": 720,
+        "downscaled": False,
+        "approx_bytes": 3,
+    }
+    data.update(overrides)
+    return data
+
+
+def test_build_screenshot_js_encodes_buffer_as_base64() -> None:
+    js = build_screenshot_js(full_page=False, quality=60)
+
+    assert "page.screenshot" in js
+    assert "toString('base64')" in js
+    assert '"quality": 60' in js
+    assert "device_pixel_ratio" in js
+
+
+def test_build_screenshot_js_clamps_quality() -> None:
+    assert '"quality": 90' in build_screenshot_js(quality=500)
+    assert '"quality": 20' in build_screenshot_js(quality=1)
+
+
+def test_vision_tool_keeps_base64_out_of_the_tool_message() -> None:
+    runtime = _make_runtime()
+    runtime.capture_screenshot = AsyncMock(return_value=_capture())
+    tool = BrowserVisionTool(runtime, language="en")
+
+    result = _run(tool.invoke({"reason": "peak revenue"}))
+
+    assert result.success is True
+    # The model-visible text must describe the capture without carrying it.
+    assert "data:image/jpeg" not in result.data["content"]
+    assert "peak revenue" in result.data["content"]
+    assert result.data["multimodal"][0]["data_url"].startswith("data:image/jpeg;base64,")
+
+    # This is the contract that keeps the payload out of the ToolMessage.
+    message_content = AbilityManager._build_tool_message_content(result)
+    assert "data:image/jpeg" not in message_content
+    assert message_content == result.data["content"]
+
+
+def test_vision_tool_result_is_delivered_as_an_image_user_message() -> None:
+    runtime = _make_runtime()
+    runtime.capture_screenshot = AsyncMock(return_value=_capture())
+    tool = BrowserVisionTool(runtime, language="en")
+
+    result = _run(tool.invoke({}))
+    message = ReActAgent._build_multimodal_tool_results_message([result])
+
+    assert message is not None
+    assert message.role == "user"
+    image_blocks = [b for b in message.content if b.get("type") == "image_url"]
+    assert len(image_blocks) == 1
+    assert image_blocks[0]["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+
+def test_vision_tool_passes_full_page_flag_and_parses_string_form() -> None:
+    runtime = _make_runtime()
+    runtime.capture_screenshot = AsyncMock(return_value=_capture(full_page=True))
+    tool = BrowserVisionTool(runtime, language="en")
+
+    result = _run(tool.invoke({"full_page": "true"}))
+
+    runtime.capture_screenshot.assert_called_once_with(full_page=True)
+    assert "full scrollable page" in result.data["content"]
+
+
+def test_vision_tool_reports_capture_failure() -> None:
+    runtime = _make_runtime()
+    runtime.capture_screenshot = AsyncMock(
+        return_value={"ok": False, "error": "browser_code_executor_not_ready", "image_base64": ""}
+    )
+    tool = BrowserVisionTool(runtime, language="en")
+
+    result = _run(tool.invoke({}))
+
+    assert result.success is False
+    assert result.error == "browser_code_executor_not_ready"
+
+
+def test_capture_screenshot_unwraps_and_prepares_the_image() -> None:
+    runtime = _make_runtime()
+    runtime.ensure_runtime_ready = AsyncMock(return_value=None)
+    runtime._code_executor = AsyncMock(
+        return_value={
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        '{"ok": true, "url": "https://example.test/", "title": "T", '
+                        '"viewport": {"width": 800, "height": 600, "scroll_y": 0}, '
+                        '"full_page": false, "image_base64": "' + _TINY_JPEG_B64 + '"}'
+                    ),
+                }
+            ]
+        }
+    )
+
+    data = _run(runtime.capture_screenshot())
+
+    assert data["ok"] is True
+    assert data["url"] == "https://example.test/"
+    assert data["data_url"].startswith("data:image/jpeg;base64,")
+    assert data["image_base64"] == _TINY_JPEG_B64
+
+
+def test_capture_screenshot_fails_without_a_code_executor() -> None:
+    runtime = _make_runtime()
+    runtime.ensure_runtime_ready = AsyncMock(return_value=None)
+    runtime._code_executor = None
+
+    data = _run(runtime.capture_screenshot())
+
+    assert data["ok"] is False
+    assert data["error"] == "browser_code_executor_not_ready"
+
+
+def test_capture_screenshot_reports_missing_image_data() -> None:
+    runtime = _make_runtime()
+    runtime.ensure_runtime_ready = AsyncMock(return_value=None)
+    runtime._code_executor = AsyncMock(return_value='{"ok": true, "image_base64": ""}')
+
+    data = _run(runtime.capture_screenshot())
+
+    assert data["ok"] is False
+    assert "no image data" in data["error"]
+
+
+def test_prepare_screenshot_passes_small_captures_through() -> None:
+    prepared = prepare_screenshot(_TINY_JPEG_B64, max_dimension=1280)
+
+    assert prepared.base64_jpeg == _TINY_JPEG_B64
+    assert prepared.downscaled is False
+    assert prepared.data_url.startswith("data:image/jpeg;base64,")
+
+
+def test_prepare_screenshot_survives_undecodable_input() -> None:
+    prepared = prepare_screenshot("not-base64-at-all", max_dimension=64)
+
+    # A slightly wrong screenshot beats no screenshot: the capture is passed through.
+    assert prepared.base64_jpeg == "not-base64-at-all"
+    assert prepared.downscaled is False
+
+
+def test_prepare_screenshot_downscales_when_pillow_is_available() -> None:
+    try:
+        from PIL import Image
+    except ImportError:  # pragma: no cover - exercised only where the extra is absent
+        return
+
+    import io
+
+    buffer = io.BytesIO()
+    Image.new("RGB", (2000, 1000), (10, 20, 30)).save(buffer, format="JPEG")
+    encoded = base64.b64encode(buffer.getvalue()).decode("ascii")
+
+    prepared = prepare_screenshot(encoded, max_dimension=500)
+
+    assert prepared.downscaled is True
+    assert prepared.width == 500
+    assert prepared.height == 250
+    assert len(prepared.base64_jpeg) < len(encoded)
+
+
+def test_browser_vision_is_registered_as_a_runtime_tool() -> None:
+    tools = build_browser_runtime_tools(_make_runtime(), language="en")
+    names = [tool.card.name for tool in tools]
+
+    assert "browser_vision" in names
+
+    card = next(tool.card for tool in tools if tool.card.name == "browser_vision")
+    # The description must keep the probes as the default path.
+    assert "chart" in card.description.lower()
+    assert "browser_probe_cards" in card.description
+
+
+def test_vision_tool_output_is_a_tool_output() -> None:
+    runtime = _make_runtime()
+    runtime.capture_screenshot = AsyncMock(return_value=_capture())
+    tool = BrowserVisionTool(runtime, language="en")
+
+    result = _run(tool.invoke({}))
+
+    assert isinstance(result, ToolOutput)

--- a/tests/unit_tests/harness/tools/browser_move/test_browser_visual_signal.py
+++ b/tests/unit_tests/harness/tools/browser_move/test_browser_visual_signal.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# coding: utf-8
+"""Tests for the visual-only discovery signal emitted by the compact probes."""
+
+from __future__ import annotations
+
+from openjiuwen.harness.tools.browser_move.playwright_runtime.probes import (
+    VISUAL_CONTENT_HINT,
+    build_card_probe_js,
+    build_interactive_probe_js,
+)
+
+
+def test_both_probes_carry_the_visual_scan() -> None:
+    for js in (build_interactive_probe_js(), build_card_probe_js()):
+        assert "__visualRegions" in js
+        assert "visual_content: __visualContent()" in js
+        # The template placeholders must be fully substituted.
+        assert "__VISUAL_SCAN_JS__" not in js
+        assert "__VISUAL_CONTENT_HINT__" not in js
+
+
+def test_visual_scan_names_browser_vision_as_the_resolution() -> None:
+    js = build_interactive_probe_js()
+
+    assert "browser_vision" in VISUAL_CONTENT_HINT
+    assert "browser_vision" in js
+
+
+def test_visual_scan_covers_every_dom_blind_spot() -> None:
+    js = build_card_probe_js()
+
+    for kind in ("canvas", "svg_graphic", "image_without_alt", "visual_table"):
+        assert f"'{kind}'" in js
+
+
+def test_card_probe_marks_visual_only_cards() -> None:
+    js = build_card_probe_js()
+
+    assert "visualOnlyKind" in js
+    assert "visual_only: visualOnly || null" in js
+    # has_image stays: visual_only is an addition, not a replacement.
+    assert "has_image: imagePresent" in js


### PR DESCRIPTION
Paired: [GitHub #318](https://github.com/openJiuwen-ai/agent-core/pull/318) ↔ [GitCode !2184](https://gitcode.com/openJiuwen/agent-core/merge_requests/2184)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openJiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
Choose one label from `bug`, `task`, `feature` and `refactor`, and replace `<label>` below the comment block. 

If this pr is not only bugfix/task/feature and also a refactor, you can append `/kind refactor` label after `/kind bug`, `/kind task` and `/kind feature`.
-->
/kind feature


**What does this PR do / why do we need it**:
* Currently, the mobile and the browser agents use two different strategies: while the former uses exclusively screenshots of the UI, the latter relies entirely on the HTML and the DOM. This has a clear limitation for the browser agent: it cannot read images in web pages even when the underlying LLM can interpret them.
* The solution proposed in this PR is to equip the browser agent with a tool: `browser-vision` that allows it to take screenshots when needed.
* It works by identifying which regions have visually relevant signals. This uses a heuristic through the tags: `canvas`, `svg` with many shapes and not much text, `img` without `alt` text and `table` that contain multiple of the previous three tags.


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：
In addition to the unit tests, the following script was tested with a Gemma4-26B model:

```python
import asyncio
import os
import uuid

from openjiuwen.core.foundation.llm import init_model
from openjiuwen.core.runner.runner import Runner
from openjiuwen.harness.subagents.browser_agent import create_browser_agent

os.environ.setdefault("API_BASE", "ApiBase")
os.environ.setdefault("API_KEY", "ApiKey")
os.environ.setdefault("MODEL_PROVIDER", "OpenAI")
os.environ.setdefault("MODEL_NAME", "Gemma4-26B")
os.environ.setdefault("LLM_SSL_VERIFY", "false")

os.environ.setdefault("PLAYWRIGHT_MCP_ARGS", "-y @playwright/mcp@latest --browser chromium")

CHART_URL = "https://www.chartjs.org/docs/latest/samples/bar/vertical.html"

TASK = (
    f"Open {CHART_URL} and report the index values in the x-axis as well as the colors of the bars"
)

# Create the model the browser agent drives. The browser runtime reuses this
# client config (provider / key / base / model name) for its own settings.
model = init_model(
    provider=os.getenv("MODEL_PROVIDER"),
    model_name=os.getenv("MODEL_NAME"),
    api_key=os.getenv("API_KEY"),
    api_base=os.getenv("API_BASE"),
    verify_ssl=os.getenv("LLM_SSL_VERIFY").lower() == "true",
)

# Create the browser agent. It mounts the Playwright MCP tools plus the runtime
# helpers, including browser_vision for canvas-only content like this chart.
browser_agent = create_browser_agent(
    model=model,
    workspace=None,
    max_iterations=25,
    language="en",
    browser_key="vision-check",
)


# Run Agent
async def main():
    await Runner.start()
    try:
        await browser_agent.ensure_initialized()
        await browser_agent.prepare_task_resources()
        try:
            invoke_result = await Runner.run_agent(
                browser_agent,
                {
                    "query": TASK,
                    "conversation_id": f"browser_vision_{uuid.uuid4().hex[:12]}",
                },
            )
        finally:
            await browser_agent.cleanup_task_resources()
    finally:
        await Runner.stop()

    print(f"result_type >>> {invoke_result.get('result_type')}")
    print(f"BrowserAgent output result >>> {invoke_result.get('output')}")


asyncio.run(main())

```

The model correctly answered the question with no need to explicitly mention the browser-vision tool. Additionally, when no browser compatible with Playwright was detected, the model itself correctly reported the problem in its answer. No crash. 
