### PR TITLE
feat(edge_router): add edge-cloud router model client

### DIFF
--- a/docs/edge_cloud_router_design.md
+++ b/docs/edge_cloud_router_design.md
@@ -1,0 +1,526 @@
+# Inference-Only Edge–Cloud Router Design
+
+> One agent-core model provider routes requests by complexity across two local and three cloud deployments.
+> Optional privacy enforcement adds S2 redaction and S3 forced-local routing. Router inference is included;
+> router training and RL are not.
+
+---
+
+## 1. Design decision
+
+The router is exposed as a built-in agent-core provider:
+
+```python
+ProviderType.EdgeCloudRouter = "EdgeCloudRouter"
+```
+
+`EdgeCloudRouterModelClient` implements the normal `BaseModelClient` interface, so agents, workflows,
+JiuwenSwarm, trajectories, and evaluators use it like any other model provider.
+
+The implementation is split across two repositories:
+
+| Owner | Responsibilities |
+|---|---|
+| `agent-xrouter` / `agent_xrouter` | Privacy detection and redaction, classifier prompt and output parsing, complexity policy, and `RoutePlan`. |
+| agent-core | Built-in provider wiring, configuration, agent-core/request conversion, classifier/local/cloud child clients, transport, streaming, fallback, response conversion, and metadata. |
+
+`agent-xrouter` is an in-process Python library, not a proxy or service. It imports neither agent-core nor EdgeTRL
+and implements no model transport. It receives complexity inference through a small async callback supplied by
+the agent-core adapter.
+
+### Why the adapter remains built-in
+
+Agent-core has no automatic discovery path for third-party model-client providers. A registry-only provider is
+unknown until its module is imported and can fail `ModelClientConfig` validation before that happens.
+`ProviderType.EdgeCloudRouter` plus a lazy branch in `_builtin_model_client()` gives deterministic validation,
+construction, and JiuwenSwarm provider discovery.
+
+This does not require the routing engine to live in agent-core. IntelliRouter uses the same useful boundary: a
+built-in `BaseModelClient` adapter delegates to the optional external `intelli_router` package maintained in the
+`agent-protocol` repository. IntelliRouter is a health/quota/load-balancing router and owns its provider
+transport. `agent-xrouter` is different only in what it does: it owns privacy and semantic routing policy, returns
+a plan, and leaves all transport to agent-core.
+
+---
+
+## 2. Scope
+
+### Current scope
+
+- A sole-purpose, separately installable router distribution exposed as the `agent_xrouter` package.
+- Configurable S1/S2/S3 privacy enforcement and request-scoped S2 redaction, disabled by default.
+- Five complexity levels: `SIMPLE`, `MEDIUM`, `COMPLEX`, `RESEARCH`, and `REASONING`.
+- Explicit `llm` classifier and model-free `heuristic` modes; the classifier is local and may be served on CPU or GPU.
+- Five fixed deployments with a different model/provider configuration for every complexity level.
+- `SIMPLE` and `MEDIUM` use local deployments; `COMPLEX`, `RESEARCH`, and `REASONING` use cloud deployments.
+- Non-streaming and streaming chat, tools, output parsers, provider usage fields, token IDs, and logprobs where
+  supported.
+- Cloud-to-local failure fallback and sanitized route metadata.
+- JiuwenSwarm activation through YAML using its normal constructed-model-client validation, without a
+  router-specific runtime path.
+
+### Out of scope
+
+- Router RL, rewards, trajectories for router training, trainers, Ray/verl changes, or model updates.
+- EdgeTRL proxy/process management, routing memory, cache, dual-track storage, or speculative local execution.
+- A router service, sidecar, dashboard, or dedicated router JSONL sink.
+- Image, speech, or video routing.
+- JiuwenSwarm UI authoring for the nested router configuration.
+- KV-cache affinity through the wrapper.
+- Restoring private values into cloud responses or streamed tool-call arguments.
+
+Online bandit memory belongs in a separate `agent_xrouter.evolution` package when added. RL-based evolution may
+follow later, while the fixed inference router remains usable without training dependencies.
+
+---
+
+## 3. Runtime flow
+
+```text
+Agent / workflow / JiuwenSwarm
+              |
+              v
+EdgeCloudRouterModelClient                         agent-core
+  1. retain the untouched request
+  2. convert messages and tools to RouterRequest
+              |
+              v
+EdgeRouterEngine                                   agent-xrouter
+  3. when privacy is enabled, inspect privacy
+       S3 / unknown / error -> LOCAL; skip classifier
+       S2                   -> redact canonical copy
+       S1                   -> safe canonical copy
+     otherwise              -> treat as S1 and classify the original copy
+  4. build classifier input
+  5. call injected ComplexityBackend
+       timeout / error / bad output -> LOCAL
+  6. return RoutePlan
+              |
+              v
+EdgeCloudRouterModelClient                         agent-core
+  7. LOCAL -> local_fast/local_medium with untouched original
+     CLOUD -> cloud_complex/cloud_research/cloud_reasoning with safe/redacted payload
+              |
+              v
+AssistantMessage / AssistantMessageChunk
+```
+
+A representative package interface is:
+
+```python
+class ComplexityBackend(Protocol):
+    async def classify(self, request: ClassifierRequest) -> str: ...
+
+plan = await EdgeRouterEngine(policy).route(request, classifier=backend)
+```
+
+The classifier child owns its configured timeout and transport errors. The important package contract is that
+`agent-xrouter` owns prompt construction/parsing while agent-core performs the model call.
+In explicit heuristic mode the callback is omitted and classification runs in-process. An LLM failure never
+silently switches to the heuristic; it still forces local.
+
+`RoutePlan` is asymmetric:
+
+- A local plan contains the decision but no outbound payload or matched sensitive values. The adapter uses the
+  original request it retained.
+- A cloud plan contains only the canonical safe/redacted payload.
+- No public result contains the redaction reverse map.
+
+Here, “local” means the operator-configured cheap/local model. When privacy is enabled, the router guarantees
+that S3 and indeterminate requests never use the configured classifier or cloud answer client. The deployment
+must point the local child at its intended local endpoint; v1 does not try to prove where that endpoint is hosted.
+
+`invoke()` and `stream()` must share the same `_prepare_route()` path so their privacy behavior cannot diverge.
+
+---
+
+## 4. Routing, privacy, and complexity
+
+When `privacy.enabled: true`, routing follows this table:
+
+| Privacy | Complexity | Destination | Answer payload |
+|---|---|---|---|
+| S1 | SIMPLE | `local_fast` | original |
+| S1 | MEDIUM | `local_medium` | original |
+| S1 | COMPLEX / RESEARCH / REASONING | matching cloud deployment | safe copy |
+| S2 | SIMPLE | `local_fast` | original |
+| S2 | MEDIUM | `local_medium` | original |
+| S2 | COMPLEX / RESEARCH / REASONING | matching cloud deployment | redacted messages and tools |
+| S3 | not evaluated | `local_medium` | original; classifier skipped |
+| detector/classifier failure | unknown | `local_medium` | original |
+
+When enabled, privacy runs before complexity:
+
+- S3 never reaches the classifier or cloud answer client.
+- S2 is redacted before the classifier sees it.
+- Only the local model receives original S2/S3 content.
+
+This fixes an EdgeTRL issue: its router builds the S2 redacted copy but passes the original messages to
+`ComplexityJudge.classify()`.
+
+### Privacy rules
+
+Privacy detection is deterministic and rule-based in v1. It does not use a privacy model or another inference
+client. `privacy.enabled` defaults to `false` for complexity-only experiments. In that mode the router skips
+privacy inspection, treats the request as S1, and lets complexity select a local or cloud deployment using the
+original canonical request.
+
+Port EdgeTRL's PII, credential, high-risk keyword, path, tool-name, and typed-placeholder rules as a baseline,
+then harden the behavior:
+
+1. Any detector error or unknown content forces local; it must never become S1.
+2. Inspect all message roles, text parts, historical tool calls, and current tool definitions.
+3. Unknown/multimodal content forces local in v1.
+4. Never mutate the agent's request. Redact an independent canonical copy and keep the reverse map private and
+   request-scoped.
+5. Never log raw prompts, matched values, credentials, classifier prompts, reverse maps, or exception text.
+6. Keep privacy behavior explicit: enabled means redaction and forced-local rules are active; disabled means
+   neither rule is applied.
+
+Tool redaction must preserve structure. Parse tool-call argument JSON, redact scalar values recursively, and
+serialize valid JSON again. Preserve tool names and schema/property identifiers. Tool descriptions and
+default/example values may be redacted only when their structure remains valid. If arguments cannot be parsed
+or safe redaction would break the tool protocol/schema, force local.
+
+Cloud responses retain placeholders such as `[REDACTED:PHONE_0]` in v1. Stateful restoration, particularly for
+streamed text and tool arguments, is deferred.
+
+### Complexity rules
+
+- Use the five EdgeTRL labels and a bounded recent-conversation prompt. With privacy enabled the prompt uses
+  privacy-approved content; otherwise it uses the original canonical content.
+- Exclude runtime system scaffolding from complexity scoring; include only safe structural counts where useful.
+- Use deterministic sampling with a small completion limit.
+- Accept exactly one known label using a case-insensitive full match.
+- Timeout, child failure, or invalid output forces local. Do not use EdgeTRL's heuristic escalation fallback.
+- Heuristic mode is an explicit configuration, not an automatic fallback from failed LLM inference.
+
+The adapter validates all five fixed deployments and their `local` or `cloud` privacy scope.
+
+---
+
+## 5. Agent-core adapter contract
+
+Create the classifier and five answer children once when constructing the router client:
+
+```python
+classifier_client = create_model_client(classifier.client_config, classifier.request_config)
+local_fast = create_model_client(...)
+local_medium = create_model_client(...)
+cloud_complex = create_model_client(...)
+cloud_research = create_model_client(...)
+cloud_reasoning = create_model_client(...)
+```
+
+### Request arguments
+
+Keep argument behavior explicit and small:
+
+- `model`: ignore the caller's router model name for answer dispatch. Use the model configured for the selected
+  fixed deployment.
+- `temperature`, `top_p`, `max_tokens`, `stop`: explicit call value, then a router-level value explicitly set by
+  the user, then the selected child's default. Do not treat Pydantic's automatically populated defaults as
+  explicitly configured values; use `model_fields_set` or equivalent parsed-config state.
+- `tools` and `output_parser`: forward the call values to the selected answer child only.
+- `timeout`: an explicit call value overrides the selected answer child's configured timeout. The classifier
+  keeps its own configured timeout.
+- Provider-specific request options stay with their child. Forward only a small allowlist of understood call kwargs
+  to cloud; local calls may keep their original kwargs.
+
+Request-level custom headers are not forwarded to cloud by default. Each child uses its own configured headers.
+This prevents local gateway, tenant, authorization, session, and cache-affinity values from leaking.
+
+The top-level `stream_first_chunk_timeout` is an end-to-end budget covering privacy, classification, selected
+child startup, and any cloud-to-local fallback before the first emitted chunk.
+
+### Failure behavior
+
+- When privacy is enabled, privacy failure routes locally with the original request. Canonical-conversion,
+  classifier, or unexpected `agent-xrouter` failure also routes locally.
+- Cloud `invoke()` failure after the cloud child's retries: make one local attempt.
+- Cloud stream failure before the first emitted chunk: make one local streaming attempt.
+- A cloud stream that ends without yielding a chunk is also a pre-first-chunk failure.
+- Cloud stream failure after a chunk was emitted: propagate the error; never splice two answers.
+- Local failure: propagate the normal model error. Cloud is never a fallback for a local/S3 decision.
+
+### Response behavior
+
+Preserve the selected child's content, reasoning, tool calls, finish reason, usage fields, parser content, token
+IDs, and logprobs. Add one sanitized namespace:
+
+```json
+{
+  "edge_cloud_router": {
+    "target": "local",
+    "privacy_enabled": true,
+    "privacy_tier": "S2",
+    "complexity_level": "MEDIUM",
+    "selected_deployment": "local_medium",
+    "selected_provider": "InferenceAffinity",
+    "selected_model": "Qwen3-4B",
+    "route_reason": "local_complexity",
+    "fallback_reason": null,
+    "policy_origin": "local",
+    "classifier_model": "Qwen3-0.6B"
+  }
+}
+```
+
+Metadata describes the endpoint that produced the answer. A successful cloud-to-local fallback therefore reports
+the local provider/model plus a sanitized reason code. The router preserves the selected answer child's normal
+`UsageMetadata`, but does not calculate cost, collect classifier usage, or use cost in routing decisions.
+
+For streaming, add route metadata to the first emitted chunk and preserve it through aggregation. This requires:
+
+- merging metadata in `AssistantMessageChunk.__add__`;
+- copying accumulated metadata when the current ReAct agent builds its final `AssistantMessage`;
+- copying metadata when that message is stored in context; and
+- preserving it in the supported `llm_controller` aggregation path.
+
+Add a ReAct test that checks metadata on the aggregated message and saved context.
+
+Image, speech, and video methods must be concrete so the provider can be instantiated, but v1 raises
+`MODEL_CALL_FAILED` for those operations. This is a router-specific v1 choice; existing clients are inconsistent.
+
+### Trajectory and training behavior
+
+The router does not invoke a judge or training loop. Standard trajectories/evaluators continue to see the answer.
+Cloud answers are off-policy for the local model and usually lack the token IDs/logprobs required for online PPO.
+The provider records `policy_origin` and never invents logprobs; any existing on-policy training flow must select
+local-origin samples itself.
+
+---
+
+## 6. Configuration
+
+Use one nested `edge_cloud_router` object in `ModelClientConfig`:
+
+```yaml
+models:
+  defaults:
+    - model_client_config:
+        model_name: edge-cloud-router
+        client_provider: EdgeCloudRouter
+        edge_cloud_router:
+          privacy:
+            enabled: false
+
+          complexity:
+            mode: llm
+            privacy_scope: local
+            model_client_config:
+              client_provider: OpenAI
+              api_base: ${ROUTER_JUDGE_API_BASE}
+              api_key: ${ROUTER_JUDGE_API_KEY:-EMPTY}
+              timeout: 5
+            model_request_config:
+              model: Qwen3-0.6B
+              temperature: 0
+              max_tokens: 16
+
+          deployments:
+            local_fast:
+              privacy_scope: local
+              model_client_config:
+                client_provider: OpenAI
+                api_base: ${LOCAL_FAST_API_BASE}
+                api_key: ${LOCAL_FAST_API_KEY:-EMPTY}
+              model_request_config:
+                model: gemma-4b
+
+            local_medium:
+              privacy_scope: local
+              model_client_config:
+                client_provider: OpenAI
+                api_base: ${LOCAL_MEDIUM_API_BASE}
+                api_key: ${LOCAL_MEDIUM_API_KEY:-EMPTY}
+              model_request_config:
+                model: Qwen3-8B
+
+            cloud_complex:
+              privacy_scope: cloud
+              model_client_config:
+                client_provider: OpenRouter
+                api_base: https://openrouter.ai/api/v1
+                api_key: ${CLOUD_API_KEY}
+              model_request_config:
+                model: deepseek/deepseek-v3
+
+            cloud_research:
+              privacy_scope: cloud
+              model_client_config:
+                client_provider: OpenRouter
+                api_base: https://openrouter.ai/api/v1
+                api_key: ${CLOUD_API_KEY}
+              model_request_config:
+                model: deepseek/deepseek-v4
+
+            cloud_reasoning:
+              privacy_scope: cloud
+              model_client_config:
+                client_provider: OpenRouter
+                api_base: https://openrouter.ai/api/v1
+                api_key: ${CLOUD_API_KEY}
+              model_request_config:
+                model: moonshotai/kimi-k2
+
+      model_config_obj:
+        temperature: 0.7
+      is_default: true
+```
+
+Agent-core parses this once into private adapter configuration and passes only portable privacy/policy settings
+to `agent-xrouter`. Credentials, provider headers, and agent-core config objects never cross the package boundary.
+For model-free routing, replace the classifier block with `complexity: {mode: heuristic}`. In `llm` mode, the
+classifier child can point to a local CPU- or GPU-backed OpenAI-compatible endpoint; the router policy is
+hardware-neutral. Agent-core can call a CPU service such as a llama.cpp-compatible server, but it does not
+load or manage model weights or inference processes. An optional `agent-xrouter` inference launcher/service is
+deferred.
+Runnable baseline and router model sections, including Ollama and llama.cpp launch examples, live in
+`examples/edge_cloud_router/`.
+
+The examples define three directly comparable experiments:
+
+1. Local baseline: no router; every request uses `local_medium`.
+2. Cloud baseline: no router; every request uses the most capable configured cloud model.
+3. Router: all five fixed deployments plus the local complexity classifier.
+
+Run the same tasks and sampling settings through all three configurations. Compare answer quality, latency, route
+distribution, and fallback rate. Capture only billed cloud dollar cost from the external provider's usage or
+billing system; treat the local answer models and local classifier as zero-cost for these reports.
+
+Construction rejects:
+
+- a missing/incompatible `agent-xrouter` package, with `MODEL_SERVICE_CONFIG_ERROR` and install guidance;
+- a router child configured as `EdgeCloudRouter`;
+- missing classifier configuration in `llm` mode;
+- a classifier with a privacy scope other than `local`;
+- a missing fixed deployment or deployment model name;
+- a `local_*` deployment without `privacy_scope: local` or a `cloud_*` deployment without
+  `privacy_scope: cloud`; and
+- unknown complexity modes or labels.
+
+JiuwenSwarm already passes nested model configuration and resolves nested environment variables. Its generic
+model-usability guard accepts any model whose agent-core client was constructed successfully while still rejecting
+documentation-placeholder endpoints. `EdgeCloudRouter` does not require provider-specific runtime handling. Its
+current model settings UI cannot author this nested structure, so UI configuration is deferred.
+
+---
+
+## 7. Code structure
+
+```text
+agent-xrouter/                                  separate repository/distribution
+├── pyproject.toml                           distribution: agent-xrouter
+├── src/agent_xrouter/
+│   ├── __init__.py                          public API
+│   ├── engine.py                            privacy -> callback -> RoutePlan
+│   ├── models.py                            portable requests/config/results/enums
+│   ├── request.py                           validation and immutable copies
+│   ├── privacy.py                           detection and structured redaction
+│   ├── complexity.py                        prompt, parser, ComplexityBackend
+│   ├── policy.py                            pure routing decision
+│   └── evolution/                           optional bandit memory (added separately)
+└── tests/
+    ├── test_engine.py
+    ├── test_request.py
+    ├── test_privacy.py
+    ├── test_complexity.py
+    └── test_policy.py
+
+agent-core/
+├── openjiuwen/core/foundation/llm/
+│   ├── model_clients/
+│   │   ├── __init__.py                      lazy built-in factory branch
+│   │   └── edge_cloud_router_model_client.py adapter, config, children, and dispatch
+│   └── schema/
+│       ├── config.py                        ProviderType.EdgeCloudRouter
+│       └── message_chunk.py                 metadata aggregation
+├── openjiuwen/core/single_agent/agents/
+│   └── react_agent.py                       preserve metadata after aggregation/context save
+├── openjiuwen/core/application/llm_agent/
+│   └── llm_controller.py                    preserve metadata after aggregation
+└── tests/unit_tests/core/foundation/llm/
+    ├── test_edge_cloud_router_model_client.py provider/config/conversion/dispatch tests
+    ├── test_message_chunk.py                existing; add metadata regression
+    └── test_model_client_config.py          existing; add enum/config cases
+
+jiuwenswarm/
+├── jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
+│                                               use generic constructed-client validation
+└── tests/unit_tests/agentserver/               focused compatibility test
+```
+
+`agent-xrouter` exports only `EdgeRouterEngine`, `ComplexityBackend`, canonical request/config types, and typed
+results. Internal patterns and helpers remain private. Agent-core requires a compatible installed package and
+must not contain a second policy implementation. The agent-core adapter intentionally stays in one provider file,
+matching the existing `*_model_client.py` layout; the reusable policy remains modular in `agent-xrouter`.
+
+---
+
+## 8. EdgeTRL reuse boundary
+
+EdgeTRL is a source and test reference, not a runtime dependency.
+
+| Disposition | Land in | What |
+|---|---|---|
+| Direct port | `agent-xrouter` | `ComplexityLevel`; five labels; PII/credential/high-risk patterns; tool/path lists; placeholder format; useful fixtures and decision cases. |
+| Adapt | `agent-xrouter` | `PrivacyDetector.check()`, traversal, tool inspection, rule engine, redaction, classifier prompt/parser, bounded preview, and `Router._make_decision()`. |
+| Reimplement | `agent-xrouter` | Portable request/result/config types, `EdgeRouterEngine`, `ComplexityBackend`, conservative normalization, and safe error/logging behavior. |
+| Reimplement | agent-core | `EdgeCloudRouterModelClient`, nested config, conversions, classifier backend, child construction, invoke/stream fallback, argument/header isolation, response metadata, and aggregation fixes. |
+| Do not port | neither | `CloudClient`, proxy/OPD, routing memory, dual-track context, side turns, heuristic failure escalation, cache/training fields, trainers, rewards, and dashboards. |
+
+Important adaptations:
+
+- Detector failure becomes indeterminate/local instead of S1.
+- Scan system messages and current tool definitions, not only conversational text/history.
+- Redact S2 before invoking the classifier callback.
+- Parse classifier output with a strict full match instead of searching arbitrary prose.
+- Replace `BLOCK` with a local S3 plan.
+- Parse/redact/reserialize tool argument JSON; never copy EdgeTRL's raw string replacement.
+
+---
+
+## 9. Validation contracts
+
+### `agent-xrouter`
+
+- Imports and runs without agent-core, EdgeTRL, or answer-model transport.
+- Covers every S1/S2/S3 and complexity decision.
+- Covers privacy disabled by default and explicit privacy enablement.
+- Covers explicit `llm` and `heuristic` modes without automatic LLM-to-heuristic fallback.
+- S2 classifier/cloud payload contains placeholders and no matched raw values.
+- S3 and privacy failures never call the classifier.
+- Unknown content, invalid tool JSON, callback errors, timeouts, and bad labels force local.
+- Concurrent requests do not share redaction state.
+- Local plans contain no payload; cloud plans contain only the safe/redacted payload.
+- Logs/results contain no raw PII, credentials, reverse map, prompts, or exception text.
+
+### Agent-core and integration
+
+- Provider enum, lazy construction, optional-package error, nested config, and recursion validation.
+- Correct argument precedence, selected deployment/model, headers, and cloud-kwargs allowlisting for each child.
+- Original requests are unchanged; classifier/cloud receive only allowed canonical payloads.
+- Child response fields and truthful fallback metadata are preserved for `invoke()` and `stream()`.
+- Empty/pre-first-chunk cloud streams fall back; post-chunk failures propagate.
+- Metadata survives chunk addition, ReAct conversion, and context save.
+- ReAct aggregated and saved messages preserve sanitized route metadata; normal token usage metadata remains
+  provider-agnostic.
+- Each complexity level reaches its fixed deployment. With privacy enabled, S2 reaches cloud only redacted and
+  S3 reaches `local_medium` only.
+- No router trainer, reward judge, proxy, sidecar, Ray actor, or EdgeTRL process starts.
+
+---
+
+## 10. Deferred
+
+- Stateful restoration of S2 values in cloud responses/tool calls.
+- Session-aware cloud context after an earlier S3 message.
+- KV-cache release/affinity through nested providers.
+- Routing caches, budgets, and cost policies.
+- JiuwenSwarm UI authoring.
+- Online bandit and outcome-memory evolution (`agent_xrouter.evolution`).
+- RL-based router evolution and training.
+- An optional small local privacy model; v1 privacy detection remains rule-based.
+- An optional `agent-xrouter` inference launcher/service for local models. V1 instead consumes operator-managed
+  OpenAI-compatible endpoints such as vLLM, Ollama, or llama.cpp.

--- a/examples/edge_cloud_router/README.md
+++ b/examples/edge_cloud_router/README.md
@@ -1,0 +1,404 @@
+# Edge-cloud router experiments
+
+This directory contains the JiuwenSwarm model configuration for three controlled
+experiments:
+
+1. `jiuwenswarm-local-baseline.yaml` — no router; every request uses the local
+   medium model.
+2. `jiuwenswarm-baseline.yaml` — no router; every request uses the most capable
+   configured cloud model.
+3. `jiuwenswarm-router.yaml` — the local complexity classifier and all five
+   answer deployments.
+
+The goal is to compare answer quality, end-to-end latency, routing behavior, and
+externally billed cloud cost. Local answer models and the local classifier count
+as zero-cost for these experiments. Cost is not part of the routing policy.
+
+## Architecture and repository changes
+
+The implementation is split across three repositories. Clone the repositories
+side-by-side and use revisions that contain the router implementation:
+
+```text
+workspace/
+├── agent-core/
+├── agent-xrouter/
+└── jiuwenswarm/
+```
+
+EdgeTRL is not needed on the testing machine.
+
+### `agent-xrouter`
+
+`agent-xrouter` contains the framework-neutral routing policy under
+`src/agent_xrouter/`:
+
+- canonical request, policy, and result types;
+- deterministic S1/S2/S3 privacy detection and structured redaction;
+- the five-level heuristic and LLM classifier prompt/parser;
+- the fixed complexity-to-deployment decision; and
+- the privacy → classification → `RoutePlan` engine.
+
+It has no agent-core, EdgeTRL, HTTP-client, GPU, or inference-engine dependency.
+There is no RL, bandit evolution, reward judge, routing memory, or training.
+
+### `agent-core`
+
+Agent-core adds the built-in `ProviderType.EdgeCloudRouter` model client. The
+adapter creates one classifier client in `llm` mode and five answer clients:
+
+| Complexity | Deployment | Privacy scope |
+|---|---|---|
+| `SIMPLE` | `local_fast` | `local` |
+| `MEDIUM` | `local_medium` | `local` |
+| `COMPLEX` | `cloud_complex` | `cloud` |
+| `RESEARCH` | `cloud_research` | `cloud` |
+| `REASONING` | `cloud_reasoning` | `cloud` |
+
+Privacy enforcement is configurable:
+
+- It is disabled by default in the supplied router experiment, so all requests
+  route only by complexity using their original content.
+- Set `privacy.enabled: true` to evaluate privacy behavior. In that mode S1
+  follows complexity, S2 is redacted before classification/cloud dispatch, and
+  S3 or privacy failure uses the original request with `local_medium`.
+- Classifier failure uses the original request with `local_medium` in either mode.
+- Cloud failure may fall back once to `local_medium` before any answer output.
+- Local failure is never sent to cloud.
+
+The client supports normal and streaming chat. It preserves the selected answer
+provider's response and usage metadata and adds sanitized route metadata. It
+does not calculate cost, collect classifier usage, or use cost when routing.
+
+### `jiuwenswarm`
+
+JiuwenSwarm has one provider-generic compatibility change: a model is usable
+when agent-core successfully constructed its client and its top-level endpoint
+is not a documentation placeholder. There is no router-specific runtime path.
+The UI cannot author the nested router configuration yet, so edit YAML directly.
+
+## Python environment
+
+Use Python `>=3.11,<3.14`. `agent-xrouter` is not published yet, so install the
+local checkouts into JiuwenSwarm's environment. JiuwenSwarm otherwise resolves
+agent-core from its configured upstream dependency.
+
+```bash
+cd workspace/jiuwenswarm
+uv sync --extra test
+
+uv pip install --python .venv/bin/python \
+  -e ../agent-core \
+  -e ../agent-xrouter
+```
+
+Verify that imports resolve to the local source trees:
+
+```bash
+uv run --no-sync python -c \
+  "import openjiuwen, agent_xrouter; print(openjiuwen.__file__); print(agent_xrouter.__file__)"
+```
+
+Both printed paths must point into `workspace/agent-core` and
+`workspace/agent-xrouter`. Use `uv run --no-sync` for later JiuwenSwarm commands.
+Running a normal `uv sync` again may restore the upstream agent-core package; if
+that happens, reinstall the two editable packages.
+
+### Focused validation
+
+Run unit tests before starting the live experiment:
+
+```bash
+cd workspace/agent-xrouter
+uv sync --extra test
+uv run pytest -q
+
+cd ../agent-core
+uv sync
+uv pip install --python .venv/bin/python -e ../agent-xrouter
+PYTHONPATH=../agent-xrouter/src uv run --no-sync pytest -q \
+  tests/unit_tests/core/foundation/llm/test_edge_cloud_router_model_client.py \
+  tests/unit_tests/core/foundation/llm/test_edge_cloud_router_metadata.py \
+  tests/unit_tests/core/foundation/llm/test_message_chunk.py \
+  tests/unit_tests/core/foundation/llm/test_model_client_config.py
+
+cd ../jiuwenswarm
+uv run --no-sync pytest -q \
+  tests/unit_tests/agentserver/test_deep_adapter_model_config.py
+```
+
+## Local inference endpoint requirement
+
+Neither agent-core, agent-xrouter, nor JiuwenSwarm loads model weights or starts an
+inference process. Before running the local baseline or router experiment, start
+OpenAI-compatible local endpoints yourself using **Ollama or llama.cpp**. vLLM
+is not required or used by this experiment guide.
+
+The router needs these three logical local models:
+
+| Purpose | Example model | Default configuration endpoint |
+|---|---|---|
+| Complexity classifier | Qwen3 0.6B | `http://127.0.0.1:8081/v1` |
+| `local_fast` answer | Gemma 3 4B | `http://127.0.0.1:8082/v1` |
+| `local_medium` answer | Qwen3 8B | `http://127.0.0.1:8083/v1` |
+
+The classifier is a sixth model, separate from the five answer deployments. It
+is always configured with `privacy_scope: local`. CPU and GPU execution are
+both acceptable; the router only sees an HTTP endpoint.
+
+### Option A: Ollama (quickest setup)
+
+Install Ollama using its platform instructions, then download suitable model
+tags. These tags are examples; use tags available for the installed Ollama
+version and record the exact choices:
+
+```bash
+ollama pull qwen3:0.6b
+ollama pull gemma3:4b
+ollama pull qwen3:8b
+```
+
+Start the server if the desktop/service installation has not already started
+it:
+
+```bash
+OLLAMA_CONTEXT_LENGTH=8192 ollama serve
+```
+
+Ollama serves all installed models from one OpenAI-compatible base URL. Override
+the three model configurations before starting JiuwenSwarm:
+
+```bash
+export CLASSIFIER_API_BASE="http://127.0.0.1:11434/v1"
+export CLASSIFIER_API_KEY="EMPTY"
+export CLASSIFIER_MODEL="qwen3:0.6b"
+
+export LOCAL_FAST_API_BASE="http://127.0.0.1:11434/v1"
+export LOCAL_FAST_API_KEY="EMPTY"
+export LOCAL_FAST_MODEL="gemma3:4b"
+
+export LOCAL_MEDIUM_API_BASE="http://127.0.0.1:11434/v1"
+export LOCAL_MEDIUM_API_KEY="EMPTY"
+export LOCAL_MEDIUM_MODEL="qwen3:8b"
+```
+
+Ollama's OpenAI-compatible chat endpoint supports reasoning control. The
+classifier configuration in `jiuwenswarm-router.yaml` therefore includes:
+
+```yaml
+reasoning_effort: none
+```
+
+The classifier must return only one label. If the server still includes thinking
+or explanatory prose, fix the local model/template configuration before the
+experiment; invalid classifier output deliberately routes to `local_medium`.
+
+Use `ollama ps` to see whether each loaded model is running on CPU, GPU, or a
+mixture. Model swapping on a memory-constrained machine can add latency, so keep
+the serving setup unchanged across comparable runs.
+
+### Option B: llama.cpp
+
+Use GGUF files appropriate for the testing machine. Start one `llama-server`
+process per model and set each API alias to the model identifier expected by the
+YAML:
+
+```bash
+llama-server \
+  --model /models/Qwen3-0.6B-Q4_K_M.gguf \
+  --alias Qwen/Qwen3-0.6B \
+  --host 127.0.0.1 \
+  --port 8081 \
+  --ctx-size 8192
+
+llama-server \
+  --model /models/gemma-3-4b-it-Q4_K_M.gguf \
+  --alias google/gemma-3-4b-it \
+  --host 127.0.0.1 \
+  --port 8082 \
+  --ctx-size 8192
+
+llama-server \
+  --model /models/Qwen3-8B-Q4_K_M.gguf \
+  --alias Qwen/Qwen3-8B \
+  --host 127.0.0.1 \
+  --port 8083 \
+  --ctx-size 8192
+```
+
+The file names are placeholders; set them to the downloaded GGUF files. CPU/GPU
+offload flags depend on the llama.cpp build and machine, so check
+`llama-server --help`. Keep the API aliases aligned with the YAML model names,
+or override the corresponding environment variables. If the selected
+llama.cpp build/model rejects `reasoning_effort`, remove that setting and disable
+thinking through its model template or server configuration instead.
+
+Recent llama.cpp versions also support a multi-model router server, but three
+explicit processes are easier to inspect for the first experiment.
+
+### Endpoint smoke test
+
+Before starting JiuwenSwarm, check every configured base URL:
+
+```bash
+curl -s http://127.0.0.1:8081/v1/models
+curl -s http://127.0.0.1:8082/v1/models
+curl -s http://127.0.0.1:8083/v1/models
+```
+
+For Ollama, use its shared endpoint instead:
+
+```bash
+curl -s http://127.0.0.1:11434/v1/models
+```
+
+Also send a small `/v1/chat/completions` request to each configured model. Check
+that the returned model identifier matches the configuration and that the
+classifier can produce exactly one of:
+
+```text
+SIMPLE
+MEDIUM
+COMPLEX
+RESEARCH
+REASONING
+```
+
+Do not proceed with the router run if a local endpoint is unreachable. Client
+construction does not start or attest the physical location of these services;
+`privacy_scope: local` is enforced by pointing it only at the local endpoints.
+
+## Cloud configuration
+
+Set the external provider credentials and verify each model identifier with that
+provider. The YAML defaults use OpenRouter-style names, but all values are
+overridable:
+
+```bash
+export CLOUD_API_BASE="https://openrouter.ai/api/v1"
+export CLOUD_API_KEY="..."
+
+export BASELINE_API_BASE="$CLOUD_API_BASE"
+export BASELINE_API_KEY="$CLOUD_API_KEY"
+export BASELINE_MODEL="moonshotai/kimi-k2"
+
+export CLOUD_COMPLEX_MODEL="deepseek/deepseek-v3"
+export CLOUD_RESEARCH_MODEL="deepseek/deepseek-v4"
+export CLOUD_REASONING_MODEL="moonshotai/kimi-k2"
+```
+
+Use the actual model identifiers supported by the provider account. Do not put
+real API keys directly in the checked-in YAML files.
+
+## JiuwenSwarm configuration
+
+Initialize JiuwenSwarm once:
+
+```bash
+cd workspace/jiuwenswarm
+uv run --no-sync jiuwenswarm-init
+```
+
+The active configuration is normally:
+
+```text
+~/.jiuwenswarm/config/config.yaml
+```
+
+Keep the rest of that file and replace only its `models` section with one of the
+three YAML examples in this directory. Restart the runtime between controlled
+runs so no model clients or conversation state are reused:
+
+```bash
+uv run --no-sync jiuwenswarm-start
+```
+
+## Experiment 1: all-local baseline
+
+Use `jiuwenswarm-local-baseline.yaml`.
+
+- No router or classifier is involved.
+- Every request goes directly to the same `local_medium` model used by the
+  router, normally Qwen3 8B.
+- The local endpoint must already be running.
+- Experimental dollar cost is zero.
+
+## Experiment 2: all-cloud baseline
+
+Use `jiuwenswarm-baseline.yaml`.
+
+- No router or classifier is involved.
+- Every request goes to the most capable configured cloud model, normally the
+  same model used by `cloud_reasoning`.
+- Capture billed dollar cost from the external provider's usage or billing
+  system.
+
+## Experiment 3: five-level router
+
+Use `jiuwenswarm-router.yaml`.
+
+- The local classifier selects one of the five complexity levels.
+- `SIMPLE` and `MEDIUM` use the two local answer models.
+- `COMPLEX`, `RESEARCH`, and `REASONING` use their corresponding cloud models.
+- Privacy is disabled by default so this experiment measures complexity routing.
+- To test privacy separately, set `privacy.enabled: true`; S2 is then redacted
+  before classification/cloud dispatch, and S3 or detector failure uses the
+  original request with `local_medium`.
+- Classifier failure uses the original request with `local_medium`.
+- Cloud failure can fall back once to `local_medium` before output starts.
+
+Router responses retain sanitized `edge_cloud_router` metadata containing the
+privacy-enabled flag, privacy tier, complexity result, selected deployment/model,
+and fallback reason.
+
+## Controlled comparison
+
+Use one fixed workload for all three experiments. Include representative simple,
+medium, complex, research, and reasoning tasks. For a separate privacy-enabled
+run, add synthetic S2/S3 cases. Never use real secrets as test fixtures.
+
+For every task:
+
+- use a fresh conversation/session;
+- keep the prompt, tools, timeouts, and sampling settings identical;
+- keep `temperature: 0` as configured;
+- record the final answer and end-to-end latency; and
+- for router runs, record the route and fallback metadata when available.
+
+Run the experiments in this order:
+
+1. all-local baseline;
+2. all-cloud baseline; and
+3. five-level router.
+
+Compare:
+
+- answer quality;
+- end-to-end latency;
+- route distribution and fallback rate; and
+- externally billed cloud dollar cost.
+
+Only the dollar amount reported by the cloud provider counts as experiment cost.
+Treat local model and classifier inference as zero-cost. The router preserves
+normal answer-provider usage metadata but does not calculate or aggregate cost,
+and cost never affects routing decisions.
+
+## Troubleshooting checklist
+
+- Confirm `openjiuwen.__file__` and `agent_xrouter.__file__` point to the local
+  editable checkouts.
+- Confirm every local model appears in `/v1/models` under the configured name.
+- Confirm the classifier emits one exact label without thinking text.
+- Confirm environment variables are present in the JiuwenSwarm process.
+- Restart JiuwenSwarm after replacing the `models` section.
+- Use fresh sessions to avoid context leaking between experiments.
+- A missing `agent-xrouter` package should produce `MODEL_SERVICE_CONFIG_ERROR`;
+  reinstall the local editable package rather than copying router policy into
+  agent-core.
+
+## Serving references
+
+- [Ollama OpenAI compatibility](https://docs.ollama.com/api/openai-compatibility)
+- [Ollama CLI reference](https://docs.ollama.com/cli)
+- [Ollama FAQ for context size and CPU/GPU inspection](https://docs.ollama.com/faq)
+- [llama.cpp HTTP server](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md)

--- a/examples/edge_cloud_router/jiuwenswarm-baseline.yaml
+++ b/examples/edge_cloud_router/jiuwenswarm-baseline.yaml
@@ -1,0 +1,17 @@
+# Replace only the `models` section in ~/.jiuwenswarm/config/config.yaml.
+# Use the same workload, tools, and sampling settings as the router run.
+models:
+  defaults:
+    - alias: baseline
+      model_client_config:
+        api_base: ${BASELINE_API_BASE:-https://openrouter.ai/api/v1}
+        api_key: ${BASELINE_API_KEY}
+        model_name: ${BASELINE_MODEL:-moonshotai/kimi-k2}
+        client_provider: ${BASELINE_PROVIDER:-OpenRouter}
+        timeout: 360
+        stream_first_chunk_timeout: 300
+        stream_idle_timeout: 60
+        verify_ssl: true
+      model_config_obj:
+        temperature: 0
+      is_default: true

--- a/examples/edge_cloud_router/jiuwenswarm-local-baseline.yaml
+++ b/examples/edge_cloud_router/jiuwenswarm-local-baseline.yaml
@@ -1,0 +1,17 @@
+# Replace only the `models` section in ~/.jiuwenswarm/config/config.yaml.
+# This baseline sends every request to the same local medium model used by the router.
+models:
+  defaults:
+    - alias: baseline-local
+      model_client_config:
+        api_base: ${LOCAL_MEDIUM_API_BASE:-http://127.0.0.1:8083/v1}
+        api_key: ${LOCAL_MEDIUM_API_KEY:-EMPTY}
+        model_name: ${LOCAL_MEDIUM_MODEL:-Qwen/Qwen3-8B}
+        client_provider: ${LOCAL_MEDIUM_PROVIDER:-OpenAI}
+        timeout: 360
+        stream_first_chunk_timeout: 300
+        stream_idle_timeout: 60
+        verify_ssl: false
+      model_config_obj:
+        temperature: 0
+      is_default: true

--- a/examples/edge_cloud_router/jiuwenswarm-router.yaml
+++ b/examples/edge_cloud_router/jiuwenswarm-router.yaml
@@ -1,0 +1,99 @@
+# Replace only the `models` section in ~/.jiuwenswarm/config/config.yaml.
+models:
+  defaults:
+    - alias: edge-cloud-router
+      model_client_config:
+        model_name: edge-cloud-router
+        client_provider: EdgeCloudRouter
+        timeout: 360
+        stream_first_chunk_timeout: 300
+        stream_idle_timeout: 60
+        edge_cloud_router:
+          privacy:
+            enabled: false
+
+          complexity:
+            mode: llm
+            privacy_scope: local
+            classifier_preview_chars: 1500
+            model_client_config:
+              client_provider: OpenAI
+              api_base: ${CLASSIFIER_API_BASE:-http://127.0.0.1:8081/v1}
+              api_key: ${CLASSIFIER_API_KEY:-EMPTY}
+              timeout: 10
+              verify_ssl: false
+            model_request_config:
+              model: ${CLASSIFIER_MODEL:-Qwen/Qwen3-0.6B}
+              temperature: 0
+              max_tokens: 16
+              reasoning_effort: none
+
+          deployments:
+            local_fast:
+              privacy_scope: local
+              model_client_config:
+                client_provider: OpenAI
+                api_base: ${LOCAL_FAST_API_BASE:-http://127.0.0.1:8082/v1}
+                api_key: ${LOCAL_FAST_API_KEY:-EMPTY}
+                timeout: 360
+                verify_ssl: false
+              model_request_config:
+                model: ${LOCAL_FAST_MODEL:-google/gemma-3-4b-it}
+                extra_body:
+                  chat_template_kwargs:
+                    enable_thinking: false
+
+            local_medium:
+              privacy_scope: local
+              model_client_config:
+                client_provider: OpenAI
+                api_base: ${LOCAL_MEDIUM_API_BASE:-http://127.0.0.1:8083/v1}
+                api_key: ${LOCAL_MEDIUM_API_KEY:-EMPTY}
+                timeout: 360
+                verify_ssl: false
+              model_request_config:
+                model: ${LOCAL_MEDIUM_MODEL:-Qwen/Qwen3-8B}
+                extra_body:
+                  chat_template_kwargs:
+                    enable_thinking: false
+
+            cloud_complex:
+              privacy_scope: cloud
+              model_client_config:
+                client_provider: OpenRouter
+                api_base: ${CLOUD_API_BASE:-https://openrouter.ai/api/v1}
+                api_key: ${CLOUD_API_KEY}
+                timeout: 360
+                verify_ssl: true
+              model_request_config:
+                model: ${CLOUD_COMPLEX_MODEL:-deepseek/deepseek-v3.2}
+                reasoning_effort: none
+
+            cloud_research:
+              privacy_scope: cloud
+              model_client_config:
+                client_provider: OpenRouter
+                api_base: ${CLOUD_API_BASE:-https://openrouter.ai/api/v1}
+                api_key: ${CLOUD_API_KEY}
+                timeout: 360
+                verify_ssl: true
+              model_request_config:
+                model: ${CLOUD_RESEARCH_MODEL:-deepseek/deepseek-v4-pro}
+                reasoning_effort: none
+
+            cloud_reasoning:
+              privacy_scope: cloud
+              model_client_config:
+                client_provider: OpenRouter
+                api_base: ${CLOUD_API_BASE:-https://openrouter.ai/api/v1}
+                api_key: ${CLOUD_API_KEY}
+                timeout: 360
+                verify_ssl: true
+              model_request_config:
+                model: ${CLOUD_REASONING_MODEL:-moonshotai/kimi-k2-thinking}
+
+      # Explicit router-level sampling values override each selected child's
+      # defaults and keep the baseline/router comparison repeatable.
+      model_config_obj:
+        temperature: 0
+      is_default: true

--- a/openjiuwen/core/application/llm_agent/llm_controller.py
+++ b/openjiuwen/core/application/llm_agent/llm_controller.py
@@ -681,7 +681,7 @@ class LLMController(BaseController):
         llm_inputs = MessageHandlerUtils.format_llm_inputs(inputs, chat_history, self.config, system_prompt_keywords)
 
         if UserConfig.is_sensitive():
-            logger.info(f"React llm inputs")
+            logger.info("React llm inputs")
         else:
             logger.info(f"React llm inputs: {llm_inputs}")
 
@@ -696,7 +696,7 @@ class LLMController(BaseController):
             )
 
             if UserConfig.is_sensitive():
-                logger.info(f"React llm output")
+                logger.info("React llm output")
             else:
                 logger.info(f"React llm output: {llm_output}")
 
@@ -794,6 +794,10 @@ class LLMController(BaseController):
                 finish_reason=accumulated_chunk.finish_reason,
                 parser_content=accumulated_chunk.parser_content,
                 reasoning_content=accumulated_chunk.reasoning_content,
+                prompt_token_ids=accumulated_chunk.prompt_token_ids,
+                completion_token_ids=accumulated_chunk.completion_token_ids,
+                logprobs=accumulated_chunk.logprobs,
+                metadata=accumulated_chunk.metadata,
             )
 
         except Exception as e:
@@ -970,7 +974,7 @@ class LLMController(BaseController):
         # Check if message content already has InteractiveInput
         if event.content.interactive_input is not None:
             interactive_input = event.content.interactive_input
-            logger.info(f"Using InteractiveInput from message for resuming workflow directly")
+            logger.info("Using InteractiveInput from message for resuming workflow directly")
         else:
             # Create InteractiveInput from query
             query = event.content.get_query()

--- a/openjiuwen/core/foundation/llm/model_clients/__init__.py
+++ b/openjiuwen/core/foundation/llm/model_clients/__init__.py
@@ -55,6 +55,11 @@ def _builtin_model_client(provider, client_config: ModelClientConfig, model_conf
         from openjiuwen.core.foundation.llm.model_clients.intelli_router_model_client import \
             IntelliRouterModelClient
         return IntelliRouterModelClient(model_config=model_config, model_client_config=client_config)
+
+    if provider == ProviderType.EdgeCloudRouter.value:
+        from openjiuwen.core.foundation.llm.model_clients.edge_cloud_router_model_client import \
+            EdgeCloudRouterModelClient
+        return EdgeCloudRouterModelClient(model_config=model_config, model_client_config=client_config)
     return None
 
 

--- a/openjiuwen/core/foundation/llm/model_clients/edge_cloud_router_model_client.py
+++ b/openjiuwen/core/foundation/llm/model_clients/edge_cloud_router_model_client.py
@@ -1,0 +1,602 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Privacy-aware edge/cloud routing model client."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, List, Literal, NoReturn, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from openjiuwen.core.common.exception.codes import StatusCode
+from openjiuwen.core.common.exception.errors import build_error
+from openjiuwen.core.foundation.llm.model_clients.base_model_client import BaseModelClient
+from openjiuwen.core.foundation.llm.output_parsers.output_parser import BaseOutputParser
+from openjiuwen.core.foundation.llm.schema.config import ModelClientConfig, ModelRequestConfig, ProviderType
+from openjiuwen.core.foundation.llm.schema.generation_response import (
+    AudioGenerationResponse,
+    ImageGenerationResponse,
+    VideoGenerationResponse,
+)
+from openjiuwen.core.foundation.llm.schema.message import AssistantMessage, BaseMessage, UserMessage
+from openjiuwen.core.foundation.llm.schema.message_chunk import AssistantMessageChunk
+from openjiuwen.core.foundation.tool import ToolInfo
+
+
+_DEPLOYMENT_NAMES = (
+    "local_fast",
+    "local_medium",
+    "cloud_complex",
+    "cloud_research",
+    "cloud_reasoning",
+)
+_LEVEL_DEPLOYMENTS = {
+    "SIMPLE": "local_fast",
+    "MEDIUM": "local_medium",
+    "COMPLEX": "cloud_complex",
+    "RESEARCH": "cloud_research",
+    "REASONING": "cloud_reasoning",
+}
+_CLOUD_ALLOWED_KWARGS = {
+    "frequency_penalty",
+    "include_reasoning_encrypted_content",
+    "logprobs",
+    "parallel_tool_calls",
+    "presence_penalty",
+    "reasoning",
+    "reasoning_effort",
+    "response_format",
+    "return_token_ids",
+    "seed",
+    "tool_choice",
+    "top_logprobs",
+}
+_TRANSPORT_OWNED_REQUEST_FIELDS = {
+    "custom_headers",
+    "extra_body",
+    "extra_headers",
+    "messages",
+    "stream",
+    "timeout",
+    "tools",
+}
+
+
+class _ChildConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    model_client_config: ModelClientConfig
+    model_request_config: ModelRequestConfig = Field(default_factory=ModelRequestConfig)
+
+
+class _ComplexityConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    mode: Literal["llm", "heuristic"] = "llm"
+    privacy_scope: Literal["local"] = "local"
+    model_client_config: ModelClientConfig | None = None
+    model_request_config: ModelRequestConfig | None = None
+    classifier_preview_chars: int = Field(default=6000, ge=256)
+
+
+class _PrivacyConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+
+
+class _DeploymentConfig(_ChildConfig):
+    privacy_scope: Literal["local", "cloud"]
+
+
+class _DeploymentsConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    local_fast: _DeploymentConfig
+    local_medium: _DeploymentConfig
+    cloud_complex: _DeploymentConfig
+    cloud_research: _DeploymentConfig
+    cloud_reasoning: _DeploymentConfig
+
+    @model_validator(mode="after")
+    def validate_privacy_scopes(self) -> "_DeploymentsConfig":
+        for name in _DEPLOYMENT_NAMES:
+            expected_scope = "local" if name.startswith("local_") else "cloud"
+            if getattr(self, name).privacy_scope != expected_scope:
+                raise ValueError(f"{name} privacy_scope must be {expected_scope}")
+        return self
+
+
+class _EdgeCloudRouterConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    privacy: _PrivacyConfig = Field(default_factory=_PrivacyConfig)
+    complexity: _ComplexityConfig = Field(default_factory=_ComplexityConfig)
+    deployments: _DeploymentsConfig
+
+    @model_validator(mode="after")
+    def validate_routes(self) -> "_EdgeCloudRouterConfig":
+        if self.complexity.mode == "llm":
+            if self.complexity.model_client_config is None or self.complexity.model_request_config is None:
+                raise ValueError("llm complexity mode requires classifier client and request configuration")
+            if not self.complexity.model_request_config.model_name.strip():
+                raise ValueError("classifier model name cannot be empty")
+
+        deployments = [getattr(self.deployments, name) for name in _DEPLOYMENT_NAMES]
+        if any(not deployment.model_request_config.model_name.strip() for deployment in deployments):
+            raise ValueError("every router deployment requires a model name")
+
+        for name in _DEPLOYMENT_NAMES:
+            deployment = getattr(self.deployments, name)
+            if deployment.privacy_scope != "cloud":
+                continue
+            request_extras = deployment.model_request_config.__pydantic_extra__ or {}
+            reserved_fields = sorted(_TRANSPORT_OWNED_REQUEST_FIELDS & request_extras.keys())
+            if reserved_fields:
+                raise ValueError(
+                    f"{name} model request configuration cannot override router-owned fields: "
+                    f"{', '.join(reserved_fields)}"
+                )
+
+        child_configs = [deployment.model_client_config for deployment in deployments]
+        if self.complexity.model_client_config is not None:
+            child_configs.append(self.complexity.model_client_config)
+        if any(
+            _provider_value(config.client_provider) == ProviderType.EdgeCloudRouter.value for config in child_configs
+        ):
+            raise ValueError("EdgeCloudRouter cannot contain another EdgeCloudRouter child")
+        return self
+
+    @classmethod
+    def from_model_client_config(cls, config: ModelClientConfig) -> "_EdgeCloudRouterConfig":
+        extra = config.__pydantic_extra__ or {}
+        raw = extra.get("edge_cloud_router")
+        if not isinstance(raw, dict):
+            _raise_config_error("edge_cloud_router configuration is required")
+        try:
+            parsed = cls.model_validate(raw)
+        except ValidationError:
+            _raise_config_error("edge_cloud_router configuration is invalid")
+        return parsed
+
+
+def _raise_config_error(message: str) -> NoReturn:
+    raise build_error(StatusCode.MODEL_SERVICE_CONFIG_ERROR, error_msg=message)
+
+
+def _provider_value(provider: ProviderType | str) -> str:
+    return provider.value if isinstance(provider, ProviderType) else str(provider)
+
+
+def _load_agent_xrouter() -> Any:
+    try:
+        import agent_xrouter as edge_router
+    except ImportError:
+        _raise_config_error(
+            "agent-xrouter package is missing or incompatible; install agent-xrouter to use EdgeCloudRouter"
+        )
+    required_symbols = (
+        "ComplexityLevel",
+        "ComplexityMode",
+        "EdgeRouterEngine",
+        "PrivacyTier",
+        "RoutePlan",
+        "RouteTarget",
+        "RouterPolicy",
+        "RouterRequest",
+    )
+    if any(not hasattr(edge_router, symbol) for symbol in required_symbols):
+        _raise_config_error(
+            "agent-xrouter package is missing or incompatible; install agent-xrouter to use EdgeCloudRouter"
+        )
+    return edge_router
+
+
+@dataclass(frozen=True, slots=True)
+class _RouteSelection:
+    deployment_name: str
+    # BaseModelClient.stream is typed as a coroutine although implementations
+    # are async iterators, so keep the selected child transport-neutral here.
+    child: Any
+    messages: Any
+    tools: Any
+    model: str
+    cloud: bool
+
+
+@dataclass(frozen=True, slots=True)
+class _AnswerOptions:
+    temperature: float | None
+    top_p: float | None
+    max_tokens: int | None
+    stop: str | None
+    output_parser: BaseOutputParser | None
+    timeout: float | None
+    kwargs: dict[str, Any]
+
+
+class _AgentCoreComplexityBackend:
+    def __init__(self, client: BaseModelClient, model: str) -> None:
+        self._client = client
+        self._model = model
+
+    async def classify(self, request: Any) -> str:
+        response = await self._client.invoke(
+            request.prompt,
+            model=self._model,
+            tools=None,
+            output_parser=None,
+        )
+        if isinstance(response.content, str):
+            return response.content
+        if isinstance(response.content, list):
+            parts: list[str] = []
+            for part in response.content:
+                if isinstance(part, str):
+                    parts.append(part)
+                elif isinstance(part, dict) and part.get("type") == "text":
+                    parts.append(str(part.get("text", "")))
+            return "".join(parts)
+        return ""
+
+
+class EdgeCloudRouterModelClient(BaseModelClient):
+    """A built-in model client backed by the external ``agent-xrouter`` policy engine."""
+
+    __client_name__ = ProviderType.EdgeCloudRouter.value
+
+    def __init__(self, model_config: ModelRequestConfig, model_client_config: ModelClientConfig):
+        self._edge = _load_agent_xrouter()
+        super().__init__(model_config, model_client_config)
+        self._config = _EdgeCloudRouterConfig.from_model_client_config(model_client_config)
+
+        self._deployment_clients = {
+            name: self._create_child(getattr(self._config.deployments, name)) for name in _DEPLOYMENT_NAMES
+        }
+        self._classifier_client: BaseModelClient | None = None
+        self._classifier_model: str | None = None
+        if self._config.complexity.mode == "llm":
+            classifier_config = _ChildConfig(
+                model_client_config=self._config.complexity.model_client_config,
+                model_request_config=self._classifier_model_config(),
+            )
+            self._classifier_client = self._create_child(classifier_config)
+            self._classifier_model = classifier_config.model_request_config.model_name
+
+        policy = self._edge.RouterPolicy(
+            privacy_enabled=self._config.privacy.enabled,
+            complexity_mode=self._edge.ComplexityMode(self._config.complexity.mode),
+            classifier_preview_chars=self._config.complexity.classifier_preview_chars,
+        )
+        self._engine = self._edge.EdgeRouterEngine(policy)
+
+    def _validate_config(self) -> None:
+        """The wrapper has child credentials, not top-level credentials."""
+
+        if not isinstance(self.model_client_config.verify_ssl, bool):
+            _raise_config_error("model client config verify_ssl must be a boolean type")
+
+    @staticmethod
+    def _create_child(config: _ChildConfig) -> BaseModelClient:
+        from openjiuwen.core.foundation.llm.model_clients import create_model_client
+
+        return create_model_client(config.model_client_config, config.model_request_config)
+
+    def _classifier_model_config(self) -> ModelRequestConfig:
+        config = self._config.complexity.model_request_config
+        if config is None:
+            _raise_config_error("classifier model configuration is required")
+        updates: dict[str, Any] = {}
+        if "temperature" not in config.model_fields_set:
+            updates["temperature"] = 0.0
+        if "max_tokens" not in config.model_fields_set:
+            updates["max_tokens"] = 16
+        return config.model_copy(update=updates)
+
+    async def _prepare_route(self, messages, tools):
+        classifier_backend = None
+        if self._classifier_client is not None and self._classifier_model is not None:
+            classifier_backend = _AgentCoreComplexityBackend(self._classifier_client, self._classifier_model)
+        try:
+            canonical_messages = self._convert_messages_to_dict(messages)
+            canonical_tools = self._convert_tools_to_dict(tools)
+            request = self._edge.RouterRequest.from_data(canonical_messages, canonical_tools)
+            plan = await self._engine.route(request, classifier=classifier_backend)
+            if not isinstance(plan, self._edge.RoutePlan):
+                raise TypeError("agent-xrouter returned an invalid route plan")
+        except Exception:
+            plan = self._edge.RoutePlan(
+                target=self._edge.RouteTarget.LOCAL,
+                privacy_tier=self._edge.PrivacyTier.INDETERMINATE,
+                complexity_level=None,
+                complexity_source=None,
+                reason_code="router_failed",
+            )
+        return plan
+
+    def _resolve_answer_arg(self, name: str, call_value: Any) -> Any:
+        if call_value is not None:
+            return call_value
+        if name in self.model_config.model_fields_set:
+            return getattr(self.model_config, name)
+        return None
+
+    @staticmethod
+    def _child_kwargs(kwargs: dict[str, Any], *, cloud: bool) -> dict[str, Any]:
+        if not cloud:
+            return dict(kwargs)
+        return {key: value for key, value in kwargs.items() if key in _CLOUD_ALLOWED_KWARGS}
+
+    def _select_route(self, plan, original_messages, original_tools) -> _RouteSelection:
+        if plan.target is self._edge.RouteTarget.CLOUD:
+            messages, tools = plan.cloud_request.to_data()
+            deployment_name = _LEVEL_DEPLOYMENTS[plan.complexity_level.name]
+        else:
+            messages, tools = original_messages, original_tools
+            deployment_name = (
+                "local_fast" if plan.complexity_level is self._edge.ComplexityLevel.SIMPLE else "local_medium"
+            )
+        deployment = getattr(self._config.deployments, deployment_name)
+        cloud = deployment.privacy_scope == "cloud"
+        return _RouteSelection(
+            deployment_name=deployment_name,
+            child=self._deployment_clients[deployment_name],
+            messages=messages,
+            tools=tools,
+            model=deployment.model_request_config.model_name,
+            cloud=cloud,
+        )
+
+    def _select_local_fallback(self, messages, tools) -> _RouteSelection:
+        deployment_name = "local_medium"
+        deployment = self._config.deployments.local_medium
+        return _RouteSelection(
+            deployment_name=deployment_name,
+            child=self._deployment_clients[deployment_name],
+            messages=messages,
+            tools=tools,
+            model=deployment.model_request_config.model_name,
+            cloud=False,
+        )
+
+    def _metadata(
+        self,
+        plan,
+        *,
+        deployment_name: str,
+        cloud: bool,
+        model: str,
+        fallback_reason: str | None,
+    ) -> dict[str, Any]:
+        child_config = getattr(self._config.deployments, deployment_name)
+        target = "cloud" if cloud else "local"
+        return {
+            "target": target,
+            "privacy_enabled": self._config.privacy.enabled,
+            "privacy_tier": plan.privacy_tier.value,
+            "complexity_level": plan.complexity_level.name if plan.complexity_level is not None else None,
+            "complexity_source": plan.complexity_source,
+            "selected_deployment": deployment_name,
+            "selected_provider": _provider_value(child_config.model_client_config.client_provider),
+            "selected_model": model,
+            "route_reason": plan.reason_code,
+            "fallback_reason": fallback_reason,
+            "policy_origin": target,
+            "classifier_model": self._classifier_model,
+        }
+
+    @staticmethod
+    def _with_message_metadata(message: AssistantMessage, metadata: dict[str, Any]) -> AssistantMessage:
+        merged = dict(message.metadata)
+        merged["edge_cloud_router"] = metadata
+        return message.model_copy(update={"metadata": merged})
+
+    @staticmethod
+    def _with_chunk_metadata(chunk: AssistantMessageChunk, metadata: dict[str, Any]) -> AssistantMessageChunk:
+        merged = dict(chunk.metadata)
+        merged["edge_cloud_router"] = metadata
+        return chunk.model_copy(update={"metadata": merged})
+
+    async def _invoke_child(
+        self,
+        selection: _RouteSelection,
+        options: _AnswerOptions,
+    ) -> AssistantMessage:
+        return await selection.child.invoke(
+            selection.messages,
+            tools=selection.tools,
+            temperature=options.temperature,
+            top_p=options.top_p,
+            model=selection.model,
+            max_tokens=options.max_tokens,
+            stop=options.stop,
+            output_parser=options.output_parser,
+            timeout=options.timeout,
+            **self._child_kwargs(options.kwargs, cloud=selection.cloud),
+        )
+
+    async def invoke(
+        self,
+        messages: Union[str, List[BaseMessage], List[dict]],
+        *,
+        tools: Union[List[ToolInfo], List[dict], None] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        stop: Optional[str] = None,
+        model: str = None,
+        output_parser: Optional[BaseOutputParser] = None,
+        timeout: float = None,
+        **kwargs,
+    ) -> AssistantMessage:
+        plan = await self._prepare_route(messages, tools)
+        selection = self._select_route(plan, messages, tools)
+        options = _AnswerOptions(
+            temperature=self._resolve_answer_arg("temperature", temperature),
+            top_p=self._resolve_answer_arg("top_p", top_p),
+            max_tokens=self._resolve_answer_arg("max_tokens", max_tokens),
+            stop=self._resolve_answer_arg("stop", stop),
+            output_parser=output_parser,
+            timeout=timeout,
+            kwargs=kwargs,
+        )
+        try:
+            response = await self._invoke_child(selection, options)
+            metadata = self._metadata(
+                plan,
+                deployment_name=selection.deployment_name,
+                cloud=selection.cloud,
+                model=selection.model,
+                fallback_reason=None,
+            )
+            return self._with_message_metadata(response, metadata)
+        except Exception:
+            if not selection.cloud:
+                raise
+
+        selection = self._select_local_fallback(messages, tools)
+        response = await self._invoke_child(selection, options)
+        metadata = self._metadata(
+            plan,
+            deployment_name=selection.deployment_name,
+            cloud=False,
+            model=selection.model,
+            fallback_reason="cloud_invoke_failed",
+        )
+        return self._with_message_metadata(response, metadata)
+
+    async def stream(
+        self,
+        messages: Union[str, List[BaseMessage], List[dict]],
+        *,
+        tools: Union[List[ToolInfo], List[dict], None] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        stop: Optional[str] = None,
+        model: str = None,
+        output_parser: Optional[BaseOutputParser] = None,
+        timeout: float = None,
+        **kwargs,
+    ) -> AsyncIterator[AssistantMessageChunk]:
+        plan = await self._prepare_route(messages, tools)
+        selection = self._select_route(plan, messages, tools)
+        options = _AnswerOptions(
+            temperature=self._resolve_answer_arg("temperature", temperature),
+            top_p=self._resolve_answer_arg("top_p", top_p),
+            max_tokens=self._resolve_answer_arg("max_tokens", max_tokens),
+            stop=self._resolve_answer_arg("stop", stop),
+            output_parser=output_parser,
+            timeout=timeout,
+            kwargs=kwargs,
+        )
+        emitted = False
+        try:
+            async for chunk in selection.child.stream(
+                selection.messages,
+                tools=selection.tools,
+                temperature=options.temperature,
+                top_p=options.top_p,
+                model=selection.model,
+                max_tokens=options.max_tokens,
+                stop=options.stop,
+                output_parser=options.output_parser,
+                timeout=options.timeout,
+                **self._child_kwargs(options.kwargs, cloud=selection.cloud),
+            ):
+                if not emitted:
+                    metadata = self._metadata(
+                        plan,
+                        deployment_name=selection.deployment_name,
+                        cloud=selection.cloud,
+                        model=selection.model,
+                        fallback_reason=None,
+                    )
+                    chunk = self._with_chunk_metadata(chunk, metadata)
+                emitted = True
+                yield chunk
+        except Exception:
+            if not selection.cloud or emitted:
+                raise
+        else:
+            if emitted:
+                return
+            if not selection.cloud:
+                raise build_error(StatusCode.MODEL_CALL_FAILED, error_msg="local model returned no stream chunks")
+
+        selection = self._select_local_fallback(messages, tools)
+        local_emitted = False
+        async for chunk in selection.child.stream(
+            selection.messages,
+            tools=selection.tools,
+            temperature=options.temperature,
+            top_p=options.top_p,
+            model=selection.model,
+            max_tokens=options.max_tokens,
+            stop=options.stop,
+            output_parser=options.output_parser,
+            timeout=options.timeout,
+            **self._child_kwargs(options.kwargs, cloud=False),
+        ):
+            if not local_emitted:
+                metadata = self._metadata(
+                    plan,
+                    deployment_name=selection.deployment_name,
+                    cloud=False,
+                    model=selection.model,
+                    fallback_reason="cloud_stream_failed_before_first_chunk",
+                )
+                chunk = self._with_chunk_metadata(chunk, metadata)
+            local_emitted = True
+            yield chunk
+        if not local_emitted:
+            raise build_error(StatusCode.MODEL_CALL_FAILED, error_msg="local fallback returned no stream chunks")
+
+    @staticmethod
+    def _unsupported_media() -> NoReturn:
+        raise build_error(StatusCode.MODEL_CALL_FAILED, error_msg="EdgeCloudRouter supports chat requests only")
+
+    async def generate_image(
+        self,
+        messages: List[UserMessage],
+        *,
+        model: Optional[str] = None,
+        size: Optional[str] = "1664*928",
+        negative_prompt: Optional[str] = None,
+        n: Optional[int] = 1,
+        prompt_extend: bool = True,
+        watermark: bool = False,
+        seed: int = 0,
+        **kwargs,
+    ) -> ImageGenerationResponse:
+        self._unsupported_media()
+
+    async def generate_speech(
+        self,
+        messages: List[UserMessage],
+        *,
+        model: Optional[str] = None,
+        voice: Optional[str] = "Cherry",
+        language_type: Optional[str] = "Auto",
+        **kwargs,
+    ) -> AudioGenerationResponse:
+        self._unsupported_media()
+
+    async def generate_video(
+        self,
+        messages: List[UserMessage],
+        *,
+        img_url: Optional[str] = None,
+        audio_url: Optional[str] = None,
+        model: Optional[str] = None,
+        size: Optional[str] = None,
+        resolution: Optional[str] = None,
+        duration: Optional[int] = 5,
+        prompt_extend: bool = True,
+        watermark: bool = False,
+        negative_prompt: Optional[str] = None,
+        seed: Optional[int] = None,
+        **kwargs,
+    ) -> VideoGenerationResponse:
+        self._unsupported_media()

--- a/openjiuwen/core/foundation/llm/schema/config.py
+++ b/openjiuwen/core/foundation/llm/schema/config.py
@@ -22,6 +22,7 @@ class ProviderType(str, Enum):
     InferenceAffinity = "InferenceAffinity"
     AscendAffinity = "AscendAffinity"
     IntelliRouter = "intelli_router"
+    EdgeCloudRouter = "EdgeCloudRouter"
 
 
 _TOP_LEVEL_API_KEY_PROVIDERS = {

--- a/openjiuwen/core/foundation/llm/schema/message_chunk.py
+++ b/openjiuwen/core/foundation/llm/schema/message_chunk.py
@@ -212,6 +212,7 @@ class AssistantMessageChunk(AssistantMessage, BaseMessageChunk):
             self.completion_token_ids, other.completion_token_ids
         )
         merged_logprobs = _merge_logprobs(self.logprobs, other.logprobs)
+        merged_metadata = {**self.metadata, **other.metadata}
 
         return AssistantMessageChunk(
             role=self.role,
@@ -224,6 +225,7 @@ class AssistantMessageChunk(AssistantMessage, BaseMessageChunk):
             prompt_token_ids=merged_prompt_token_ids,
             completion_token_ids=merged_completion_token_ids,
             logprobs=merged_logprobs,
+            metadata=merged_metadata,
         )
 
 

--- a/openjiuwen/core/single_agent/agents/react_agent.py
+++ b/openjiuwen/core/single_agent/agents/react_agent.py
@@ -1118,9 +1118,11 @@ class ReActAgent(BaseAgent):
                 usage_metadata=accumulated_chunk.usage_metadata,
                 reasoning_content=accumulated_chunk.reasoning_content,
                 finish_reason=accumulated_chunk.finish_reason,
+                parser_content=accumulated_chunk.parser_content,
                 prompt_token_ids=accumulated_chunk.prompt_token_ids,
                 completion_token_ids=accumulated_chunk.completion_token_ids,
                 logprobs=accumulated_chunk.logprobs,
+                metadata=accumulated_chunk.metadata,
             )
         ctx.inputs.response = ai_message
         if ai_message.usage_metadata:
@@ -2051,6 +2053,11 @@ class ReActAgent(BaseAgent):
                                 reasoning_content=ai_message.reasoning_content,
                                 usage_metadata=ai_message.usage_metadata,
                                 finish_reason=ai_message.finish_reason,
+                                parser_content=ai_message.parser_content,
+                                prompt_token_ids=ai_message.prompt_token_ids,
+                                completion_token_ids=ai_message.completion_token_ids,
+                                logprobs=ai_message.logprobs,
+                                metadata=ai_message.metadata,
                             )
                         )
 

--- a/tests/unit_tests/core/foundation/llm/test_edge_cloud_router_metadata.py
+++ b/tests/unit_tests/core/foundation/llm/test_edge_cloud_router_metadata.py
@@ -1,0 +1,137 @@
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from openjiuwen.core.application.llm_agent.llm_controller import LLMController
+from openjiuwen.core.context_engine.base import ContextWindow
+from openjiuwen.core.foundation.llm.schema.message import UsageMetadata
+from openjiuwen.core.foundation.llm.schema.message_chunk import AssistantMessageChunk
+from openjiuwen.core.session.agent import Session
+from openjiuwen.core.single_agent.agents.react_agent import ReActAgent, ReActAgentConfig
+from openjiuwen.core.single_agent.rail.base import AgentCallbackContext
+from openjiuwen.core.single_agent.schema.agent_card import AgentCard
+
+
+class _StreamingReActAgent(ReActAgent):
+    async def call_model_for_test(self, *, ctx: AgentCallbackContext, context):
+        return await self._call_model(ctx=ctx, context=context, tools=None)
+
+
+class _MetadataStreamingModel:
+    def supports_kv_cache_release(self) -> bool:
+        return False
+
+    async def stream(self, *args, **kwargs) -> AsyncIterator[AssistantMessageChunk]:
+        yield AssistantMessageChunk(
+            content="hello",
+            metadata={"edge_cloud_router": {"target": "cloud", "policy_origin": "cloud"}},
+        )
+        yield AssistantMessageChunk(content=" world", usage_metadata=UsageMetadata(total_tokens=2))
+
+
+@pytest.mark.asyncio
+async def test_react_stream_aggregation_preserves_router_metadata() -> None:
+    config = ReActAgentConfig()
+    config.configure_model_client(
+        provider="OpenAI",
+        api_key="test-key",
+        api_base="http://model.invalid/v1",
+        model_name="test-model",
+    )
+    config.configure_context_engine(max_context_message_num=100)
+    agent = _StreamingReActAgent(card=AgentCard(name="test", id="test")).configure(config)
+    agent.set_llm(_MetadataStreamingModel())
+
+    session = MagicMock(spec=Session)
+    session.get_session_id.return_value = "session-1"
+    session.write_stream = AsyncMock()
+    model_context = MagicMock()
+    model_context.get_messages.return_value = []
+    model_context.session_id.return_value = "session-1"
+    model_context.get_context_window = AsyncMock(
+        return_value=ContextWindow(system_messages=[], context_messages=[], tools=[])
+    )
+    model_context.detect_context_window_change.return_value = None
+    ctx = AgentCallbackContext(
+        agent=agent,
+        session=session,
+        inputs={},
+        extra={"_streaming": True},
+    )
+    ctx.context = model_context
+
+    response = await agent.call_model_for_test(ctx=ctx, context=model_context)
+
+    assert response.content == "hello world"
+    assert response.metadata["edge_cloud_router"] == {
+        "target": "cloud",
+        "policy_origin": "cloud",
+    }
+
+
+@pytest.mark.asyncio
+async def test_react_context_save_preserves_router_metadata() -> None:
+    config = ReActAgentConfig()
+    config.configure_model_client(
+        provider="OpenAI",
+        api_key="test-key",
+        api_base="http://model.invalid/v1",
+        model_name="test-model",
+    )
+    config.configure_context_engine(max_context_message_num=100)
+    agent = _StreamingReActAgent(card=AgentCard(name="test", id="test")).configure(config)
+    agent.set_llm(_MetadataStreamingModel())
+
+    session = MagicMock(spec=Session)
+    session.get_session_id.return_value = "session-1"
+    session.write_stream = AsyncMock()
+    model_context = MagicMock()
+    model_context.add_messages = AsyncMock()
+    model_context.get_messages.return_value = []
+    model_context.session_id.return_value = "session-1"
+    model_context.get_context_window = AsyncMock(
+        return_value=ContextWindow(system_messages=[], context_messages=[], tools=[])
+    )
+    model_context.detect_context_window_change.return_value = None
+    agent._init_context = AsyncMock(return_value=model_context)
+    agent._update_skill_prompt_builder_section = AsyncMock()
+    agent.ability_manager.list_tool_info = AsyncMock(return_value=[])
+    agent.context_engine.save_contexts = AsyncMock()
+
+    result = await agent._inner_invoke(
+        session=session,
+        inputs={"query": "hello"},
+        query="hello",
+        need_cleanup=False,
+        conversation_id="session-1",
+        _streaming=True,
+    )
+
+    saved_message = model_context.add_messages.await_args_list[-1].args[0]
+    assert result == {"output": "hello world", "result_type": "answer"}
+    assert saved_message.metadata["edge_cloud_router"] == {
+        "target": "cloud",
+        "policy_origin": "cloud",
+    }
+
+
+@pytest.mark.asyncio
+async def test_llm_controller_stream_aggregation_preserves_router_metadata() -> None:
+    controller = object.__new__(LLMController)
+    session = MagicMock(spec=Session)
+    session.write_stream = AsyncMock()
+
+    response = await controller._call_llm_get_output(
+        _MetadataStreamingModel(),
+        "test-model",
+        [],
+        [],
+        session,
+    )
+
+    assert response.content == "hello world"
+    assert response.metadata["edge_cloud_router"] == {
+        "target": "cloud",
+        "policy_origin": "cloud",
+    }

--- a/tests/unit_tests/core/foundation/llm/test_edge_cloud_router_model_client.py
+++ b/tests/unit_tests/core/foundation/llm/test_edge_cloud_router_model_client.py
@@ -1,0 +1,482 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from collections.abc import AsyncIterator
+from unittest.mock import patch
+
+import pytest
+
+from openjiuwen.core.common.exception.codes import StatusCode
+from openjiuwen.core.common.exception.errors import BaseError
+from openjiuwen.core.foundation.llm.model_clients.edge_cloud_router_model_client import (
+    EdgeCloudRouterModelClient,
+    _EdgeCloudRouterConfig,
+    _load_agent_xrouter,
+)
+from openjiuwen.core.foundation.llm.schema.config import ModelClientConfig, ModelRequestConfig, ProviderType
+from openjiuwen.core.foundation.llm.schema.message import AssistantMessage, UsageMetadata
+from openjiuwen.core.foundation.llm.schema.message_chunk import AssistantMessageChunk
+
+
+class FakeChild:
+    def __init__(
+        self,
+        *,
+        response: AssistantMessage | None = None,
+        chunks: list[AssistantMessageChunk] | None = None,
+        invoke_error: Exception | None = None,
+        stream_error: Exception | None = None,
+        error_after_chunks: bool = False,
+    ) -> None:
+        self.response = response or AssistantMessage(content="answer")
+        self.chunks = chunks if chunks is not None else [AssistantMessageChunk(content="answer")]
+        self.invoke_error = invoke_error
+        self.stream_error = stream_error
+        self.error_after_chunks = error_after_chunks
+        self.invoke_calls: list[tuple[object, dict]] = []
+        self.stream_calls: list[tuple[object, dict]] = []
+
+    async def invoke(self, messages, **kwargs) -> AssistantMessage:
+        self.invoke_calls.append((messages, kwargs))
+        if self.invoke_error:
+            raise self.invoke_error
+        return self.response
+
+    async def stream(self, messages, **kwargs) -> AsyncIterator[AssistantMessageChunk]:
+        self.stream_calls.append((messages, kwargs))
+        if self.stream_error and not self.error_after_chunks:
+            raise self.stream_error
+        for chunk in self.chunks:
+            yield chunk
+        if self.stream_error:
+            raise self.stream_error
+
+
+def _child_config(model: str, privacy_scope: str | None = None) -> dict:
+    config = {
+        "model_client_config": {
+            "client_provider": "OpenAI",
+            "api_base": "http://model.invalid/v1",
+            "api_key": "test-key",
+        },
+        "model_request_config": {"model": model},
+    }
+    if privacy_scope is not None:
+        config["privacy_scope"] = privacy_scope
+    return config
+
+
+def _router_config(*, mode: str = "llm", privacy_enabled: bool = False) -> ModelClientConfig:
+    complexity: dict = {"mode": mode, "privacy_scope": "local"}
+    if mode == "llm":
+        complexity.update(_child_config("classifier-model"))
+    return ModelClientConfig(
+        client_provider=ProviderType.EdgeCloudRouter,
+        edge_cloud_router={
+            "privacy": {"enabled": privacy_enabled},
+            "complexity": complexity,
+            "deployments": {
+                "local_fast": _child_config("local-fast", "local"),
+                "local_medium": _child_config("local-medium", "local"),
+                "cloud_complex": _child_config("cloud-complex", "cloud"),
+                "cloud_research": _child_config("cloud-research", "cloud"),
+                "cloud_reasoning": _child_config("cloud-reasoning", "cloud"),
+            },
+        },
+    )
+
+
+def _client(
+    local: FakeChild,
+    cloud: FakeChild,
+    classifier: FakeChild | None = None,
+    *,
+    mode: str = "llm",
+    privacy_enabled: bool = False,
+    model_config: ModelRequestConfig | None = None,
+    deployments: dict[str, FakeChild] | None = None,
+) -> EdgeCloudRouterModelClient:
+    try:
+        import agent_xrouter  # noqa: F401
+    except ImportError:
+        pytest.skip("agent-xrouter is not installed")
+
+    deployment_children = {
+        "local_fast": local,
+        "local_medium": local,
+        "cloud_complex": cloud,
+        "cloud_research": cloud,
+        "cloud_reasoning": cloud,
+        **(deployments or {}),
+    }
+    children = [
+        deployment_children[name]
+        for name in (
+            "local_fast",
+            "local_medium",
+            "cloud_complex",
+            "cloud_research",
+            "cloud_reasoning",
+        )
+    ]
+    if mode == "llm":
+        children.append(classifier or FakeChild(response=AssistantMessage(content="COMPLEX")))
+    with patch.object(EdgeCloudRouterModelClient, "_create_child", side_effect=children):
+        return EdgeCloudRouterModelClient(
+            model_config=model_config or ModelRequestConfig(model="edge-cloud-router"),
+            model_client_config=_router_config(mode=mode, privacy_enabled=privacy_enabled),
+        )
+
+
+@pytest.mark.asyncio
+async def test_s2_is_redacted_before_classifier_and_cloud() -> None:
+    private_value = "alice@example.com"
+    classifier = FakeChild(response=AssistantMessage(content="COMPLEX"))
+    cloud = FakeChild()
+    client = _client(FakeChild(), cloud, classifier, privacy_enabled=True)
+
+    response = await client.invoke([{"role": "user", "content": f"Analyze all records for {private_value}"}])
+
+    classifier_prompt, _ = classifier.invoke_calls[0]
+    cloud_messages, cloud_kwargs = cloud.invoke_calls[0]
+    assert isinstance(classifier_prompt, str)
+    assert private_value not in classifier_prompt
+    assert private_value not in str(cloud_messages)
+    assert "[REDACTED:EMAIL_0]" in str(cloud_messages)
+    assert cloud_kwargs["model"] == "cloud-complex"
+    assert response.metadata["edge_cloud_router"]["privacy_tier"] == "S2"
+    assert response.metadata["edge_cloud_router"]["privacy_enabled"] is True
+    assert response.metadata["edge_cloud_router"]["target"] == "cloud"
+    assert response.metadata["edge_cloud_router"]["selected_deployment"] == "cloud_complex"
+    assert response.metadata["edge_cloud_router"]["classifier_model"] == "classifier-model"
+    assert response.metadata["edge_cloud_router"]["route_reason"] == "cloud_complexity"
+    assert "classifier_usage" not in response.metadata["edge_cloud_router"]
+
+
+@pytest.mark.asyncio
+async def test_s3_skips_classifier_and_uses_original_local_request() -> None:
+    classifier = FakeChild(response=AssistantMessage(content="REASONING"))
+    local = FakeChild()
+    client = _client(local, FakeChild(), classifier, privacy_enabled=True)
+    messages = [{"role": "user", "content": "password=keep-this-local"}]
+
+    response = await client.invoke(messages)
+
+    assert not classifier.invoke_calls
+    assert local.invoke_calls[0][0] is messages
+    assert response.metadata["edge_cloud_router"]["privacy_tier"] == "S3"
+    assert response.metadata["edge_cloud_router"]["target"] == "local"
+    assert response.metadata["edge_cloud_router"]["selected_deployment"] == "local_medium"
+
+
+@pytest.mark.asyncio
+async def test_classifier_failure_uses_original_local_request() -> None:
+    classifier = FakeChild(invoke_error=RuntimeError("classifier failed"))
+    local = FakeChild()
+    client = _client(local, FakeChild(), classifier)
+    messages = [{"role": "user", "content": "Analyze all files"}]
+
+    response = await client.invoke(messages)
+
+    assert local.invoke_calls[0][0] is messages
+    assert response.metadata["edge_cloud_router"]["target"] == "local"
+    assert response.metadata["edge_cloud_router"]["complexity_level"] is None
+
+
+@pytest.mark.asyncio
+async def test_invalid_external_route_plan_fails_closed_to_local() -> None:
+    class InvalidEngine:
+        async def route(self, request, classifier=None):
+            return object()
+
+    local = FakeChild()
+    client = _client(local, FakeChild(), mode="heuristic")
+    client._engine = InvalidEngine()
+    messages = [{"role": "user", "content": "Analyze all files"}]
+
+    response = await client.invoke(messages)
+
+    assert local.invoke_calls[0][0] is messages
+    assert response.metadata["edge_cloud_router"]["target"] == "local"
+    assert response.metadata["edge_cloud_router"]["route_reason"] == "router_failed"
+
+
+@pytest.mark.asyncio
+async def test_explicit_heuristic_mode_runs_without_classifier_child() -> None:
+    local = FakeChild()
+    cloud = FakeChild()
+    client = _client(local, cloud, mode="heuristic")
+
+    local_response = await client.invoke("What is DNS?")
+    cloud_response = await client.invoke("Prove this theorem by induction")
+
+    assert local_response.metadata["edge_cloud_router"]["complexity_source"] == "heuristic"
+    assert cloud_response.metadata["edge_cloud_router"]["selected_model"] == "cloud-reasoning"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("prompt", "deployment_name", "model"),
+    [
+        ("What time is it?", "local_fast", "local-fast"),
+        ("Implement a parser", "local_medium", "local-medium"),
+        ("Analyze this entire codebase end-to-end", "cloud_complex", "cloud-complex"),
+        ("Write a systematic review of clinical trial methods", "cloud_research", "cloud-research"),
+        ("Prove this theorem by induction", "cloud_reasoning", "cloud-reasoning"),
+    ],
+)
+async def test_each_complexity_level_uses_its_own_deployment(
+    prompt: str,
+    deployment_name: str,
+    model: str,
+) -> None:
+    deployment_clients = {
+        name: FakeChild()
+        for name in (
+            "local_fast",
+            "local_medium",
+            "cloud_complex",
+            "cloud_research",
+            "cloud_reasoning",
+        )
+    }
+    client = _client(
+        deployment_clients["local_fast"],
+        deployment_clients["cloud_complex"],
+        mode="heuristic",
+        deployments=deployment_clients,
+    )
+
+    response = await client.invoke(prompt)
+
+    assert len(deployment_clients[deployment_name].invoke_calls) == 1
+    metadata = response.metadata["edge_cloud_router"]
+    assert metadata["selected_deployment"] == deployment_name
+    assert metadata["selected_model"] == model
+
+
+@pytest.mark.asyncio
+async def test_cloud_invoke_failure_falls_back_once_to_local() -> None:
+    local = FakeChild(
+        response=AssistantMessage(
+            content="local answer",
+            usage_metadata=UsageMetadata(total_tokens=12),
+            completion_token_ids=[1, 2],
+            logprobs={"content": [{"token": "x"}]},
+        )
+    )
+    cloud = FakeChild(invoke_error=RuntimeError("cloud unavailable"))
+    client = _client(local, cloud)
+
+    response = await client.invoke("Analyze all files end-to-end")
+
+    assert len(cloud.invoke_calls) == 1
+    assert len(local.invoke_calls) == 1
+    assert response.content == "local answer"
+    assert response.usage_metadata.total_tokens == 12
+    assert response.completion_token_ids == [1, 2]
+    assert response.logprobs == {"content": [{"token": "x"}]}
+    metadata = response.metadata["edge_cloud_router"]
+    assert metadata["target"] == "local"
+    assert metadata["fallback_reason"] == "cloud_invoke_failed"
+
+
+@pytest.mark.asyncio
+async def test_local_failure_propagates_without_cloud_fallback() -> None:
+    local = FakeChild(invoke_error=RuntimeError("local unavailable"))
+    cloud = FakeChild()
+    client = _client(local, cloud, mode="heuristic")
+
+    with pytest.raises(RuntimeError, match="local unavailable"):
+        await client.invoke("What is DNS?")
+
+    assert not cloud.invoke_calls
+
+
+@pytest.mark.asyncio
+async def test_cloud_empty_stream_falls_back_to_local_and_preserves_metadata() -> None:
+    local = FakeChild(chunks=[AssistantMessageChunk(content="local")])
+    cloud = FakeChild(chunks=[])
+    client = _client(local, cloud)
+
+    chunks = [chunk async for chunk in client.stream("Analyze all files end-to-end")]
+
+    assert [chunk.content for chunk in chunks] == ["local"]
+    metadata = chunks[0].metadata["edge_cloud_router"]
+    assert metadata["target"] == "local"
+    assert metadata["fallback_reason"] == "cloud_stream_failed_before_first_chunk"
+
+
+@pytest.mark.asyncio
+async def test_cloud_stream_failure_after_a_chunk_is_propagated_without_splicing() -> None:
+    local = FakeChild(chunks=[AssistantMessageChunk(content="local")])
+    cloud = FakeChild(
+        chunks=[AssistantMessageChunk(content="cloud")],
+        stream_error=RuntimeError("stream failed"),
+        error_after_chunks=True,
+    )
+    client = _client(local, cloud)
+
+    received = []
+    with pytest.raises(RuntimeError, match="stream failed"):
+        async for chunk in client.stream("Analyze all files end-to-end"):
+            received.append(chunk.content)
+
+    assert received == ["cloud"]
+    assert not local.stream_calls
+
+
+@pytest.mark.asyncio
+async def test_answer_argument_precedence_and_cloud_header_isolation() -> None:
+    cloud = FakeChild()
+    model_config = ModelRequestConfig(model="router-name", temperature=0.7)
+    client = _client(FakeChild(), cloud, model_config=model_config)
+
+    await client.invoke(
+        "Analyze all files end-to-end",
+        model="caller-model-is-ignored",
+        max_tokens=55,
+        custom_headers={"Authorization": "local-token"},
+        extra_body={"messages": [{"role": "user", "content": "uninspected"}]},
+        session_id="local-session",
+        uninspected_payload={"private": "must-not-reach-cloud"},
+        reasoning_effort="high",
+    )
+
+    _, kwargs = cloud.invoke_calls[0]
+    assert kwargs["model"] == "cloud-complex"
+    assert kwargs["temperature"] == 0.7
+    assert kwargs["top_p"] is None
+    assert kwargs["max_tokens"] == 55
+    assert kwargs["reasoning_effort"] == "high"
+    assert "custom_headers" not in kwargs
+    assert "extra_body" not in kwargs
+    assert "session_id" not in kwargs
+    assert "uninspected_payload" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_cloud_stream_drops_opaque_extra_body() -> None:
+    cloud = FakeChild()
+    client = _client(FakeChild(), cloud)
+
+    chunks = [
+        chunk
+        async for chunk in client.stream(
+            "Analyze all files end-to-end",
+            extra_body={"messages": [{"role": "user", "content": "uninspected"}]},
+        )
+    ]
+
+    assert chunks
+    _, kwargs = cloud.stream_calls[0]
+    assert "extra_body" not in kwargs
+
+
+@pytest.mark.parametrize("reserved_field", ["messages", "tools", "stream", "extra_body"])
+def test_cloud_request_config_cannot_override_router_owned_fields(reserved_field: str) -> None:
+    try:
+        import agent_xrouter  # noqa: F401
+    except ImportError:
+        pytest.skip("agent-xrouter is not installed")
+
+    config = _router_config(mode="heuristic")
+    value = {"messages": []} if reserved_field == "extra_body" else []
+    if reserved_field == "stream":
+        value = False
+    config.edge_cloud_router["deployments"]["cloud_complex"]["model_request_config"][reserved_field] = value
+
+    with patch.object(EdgeCloudRouterModelClient, "_create_child"):
+        with pytest.raises(Exception, match="model service config error"):
+            EdgeCloudRouterModelClient(ModelRequestConfig(model="router"), config)
+
+
+def test_recursive_router_child_is_rejected() -> None:
+    try:
+        import agent_xrouter  # noqa: F401
+    except ImportError:
+        pytest.skip("agent-xrouter is not installed")
+
+    config = _router_config(mode="heuristic")
+    config.edge_cloud_router["deployments"]["local_fast"]["model_client_config"] = {
+        "client_provider": "EdgeCloudRouter",
+    }
+
+    with patch.object(EdgeCloudRouterModelClient, "_create_child"):
+        with pytest.raises(Exception, match="model service config error"):
+            EdgeCloudRouterModelClient(ModelRequestConfig(model="router"), config)
+
+
+def test_deployment_privacy_scope_must_match_fixed_route() -> None:
+    try:
+        import agent_xrouter  # noqa: F401
+    except ImportError:
+        pytest.skip("agent-xrouter is not installed")
+
+    config = _router_config(mode="heuristic")
+    config.edge_cloud_router["deployments"]["cloud_reasoning"]["privacy_scope"] = "local"
+
+    with patch.object(EdgeCloudRouterModelClient, "_create_child"):
+        with pytest.raises(Exception, match="model service config error"):
+            EdgeCloudRouterModelClient(ModelRequestConfig(model="router"), config)
+
+
+def test_classifier_privacy_scope_must_be_local() -> None:
+    try:
+        import agent_xrouter  # noqa: F401
+    except ImportError:
+        pytest.skip("agent-xrouter is not installed")
+
+    config = _router_config()
+    config.edge_cloud_router["complexity"]["privacy_scope"] = "cloud"
+
+    with patch.object(EdgeCloudRouterModelClient, "_create_child"):
+        with pytest.raises(Exception, match="model service config error"):
+            EdgeCloudRouterModelClient(ModelRequestConfig(model="router"), config)
+
+
+def test_privacy_enforcement_is_disabled_by_default_and_can_be_enabled() -> None:
+    default_config = _router_config(mode="heuristic")
+    del default_config.edge_cloud_router["privacy"]
+    enabled_config = _router_config(mode="heuristic", privacy_enabled=True)
+
+    assert _EdgeCloudRouterConfig.from_model_client_config(default_config).privacy.enabled is False
+    assert _EdgeCloudRouterConfig.from_model_client_config(enabled_config).privacy.enabled is True
+
+
+@pytest.mark.asyncio
+async def test_disabled_privacy_routes_sensitive_content_by_complexity() -> None:
+    private_value = "alice@example.com"
+    classifier = FakeChild(response=AssistantMessage(content="COMPLEX"))
+    cloud = FakeChild()
+    client = _client(FakeChild(), cloud, classifier)
+
+    response = await client.invoke([{"role": "user", "content": f"Analyze all records for {private_value}"}])
+
+    classifier_prompt, _ = classifier.invoke_calls[0]
+    cloud_messages, _ = cloud.invoke_calls[0]
+    assert private_value in classifier_prompt
+    assert private_value in str(cloud_messages)
+    assert response.metadata["edge_cloud_router"]["privacy_enabled"] is False
+    assert response.metadata["edge_cloud_router"]["privacy_tier"] == "S1"
+
+
+def test_missing_optional_package_raises_model_service_config_error() -> None:
+    with patch.dict(sys.modules, {"agent_xrouter": None}):
+        with pytest.raises(BaseError) as error:
+            _load_agent_xrouter()
+
+    assert error.value.code == StatusCode.MODEL_SERVICE_CONFIG_ERROR.code
+    assert "agent-xrouter package is missing or incompatible" in str(error.value)
+
+
+def test_incompatible_optional_package_raises_model_service_config_error() -> None:
+    package = ModuleType("agent_xrouter")
+
+    with patch.dict(sys.modules, {"agent_xrouter": package}):
+        with pytest.raises(BaseError) as error:
+            _load_agent_xrouter()
+
+    assert error.value.code == StatusCode.MODEL_SERVICE_CONFIG_ERROR.code
+    assert "agent-xrouter package is missing or incompatible" in str(error.value)

--- a/tests/unit_tests/core/foundation/llm/test_message_chunk.py
+++ b/tests/unit_tests/core/foundation/llm/test_message_chunk.py
@@ -287,6 +287,22 @@ def test_assistant_add_merges_reasoning_content():
     assert result.reasoning_content == "Thinking step 1Thinking step 2"
 
 
+def test_assistant_add_preserves_and_merges_metadata():
+    chunk1 = AssistantMessageChunk(
+        content="hello",
+        metadata={"edge_cloud_router": {"target": "cloud"}, "first": True},
+    )
+    chunk2 = AssistantMessageChunk(content=" world", metadata={"second": True})
+
+    result = chunk1 + chunk2
+
+    assert result.metadata == {
+        "edge_cloud_router": {"target": "cloud"},
+        "first": True,
+        "second": True,
+    }
+
+
 def test_assistant_add_handles_none_reasoning_content():
     """Test that __add__ handles None reasoning_content."""
     chunk1 = AssistantMessageChunk(

--- a/tests/unit_tests/core/foundation/llm/test_model_client_config.py
+++ b/tests/unit_tests/core/foundation/llm/test_model_client_config.py
@@ -170,6 +170,23 @@ def test_model_client_config_normalizes_intelli_router_enum_name():
     assert cfg.api_base == ""
 
 
+def test_model_client_config_allows_edge_cloud_router_without_top_level_credentials():
+    cfg = ModelClientConfig(
+        client_provider=ProviderType.EdgeCloudRouter,
+        edge_cloud_router={"configuration": "is parsed by the provider"},
+    )
+
+    assert cfg.client_provider == ProviderType.EdgeCloudRouter
+    assert cfg.api_key == ""
+    assert cfg.api_base == ""
+
+
+def test_model_client_config_normalizes_edge_cloud_router_case():
+    cfg = ModelClientConfig(client_provider="edgecloudrouter")
+
+    assert cfg.client_provider == ProviderType.EdgeCloudRouter.value
+
+
 def test_model_client_config_timeout_must_be_positive():
     with pytest.raises(ValidationError) as error:
         ModelClientConfig(


### PR DESCRIPTION
Paired: [GitHub #319](https://github.com/openJiuwen-ai/agent-core/pull/319) ↔ [GitCode !2185](https://gitcode.com/openJiuwen/agent-core/merge_requests/2185)

**What type of PR is this?**

/kind feature


**What does this PR do / why do we need it**:

- Adds an `EdgeCloudRouter` model-client provider backed by the external `agent-edge` routing engine.
- Supports configurable local and cloud deployments across five complexity levels.
- Preserves routing decisions, selected deployment information, token usage, and cost metadata through streaming and agent execution.
- Adds configuration examples, documentation, and focused unit tests.
- This PR uses the external package `agent-edge` for the router engine. See [agent-edge router](https://github.com/shayan-mk/agent-edge/pull/1) for more info.


**Which issue(s) this PR fixes**:

N/A — no linked issue.


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

- Added unit coverage for routing, configuration validation, privacy handling, cloud-to-local fallback, streaming, and routing metadata.
- Verified local and OpenRouter-backed deployments through JiuwenSwarm.
- Completed the PinchBench end-to-end sanity task successfully with a 100% score.


**Self-checklist**:

+ - [ ] **Design**: Solution has been reviewed by a Maintainer.
+ - [ ] **Test**: Relevant unit and system tests have been completed.
+ - [ ] **Verification**: Verification results are documented above.
+ - [ ] **Interface**: External interface changes have been reviewed where applicable.
+ - [ ] **Document**: Required documentation changes have been submitted.