### PR TITLE
fix(llm): translate OpenAI image_url blocks for Anthropic requests

### DIFF
--- a/openjiuwen/core/foundation/llm/model_clients/anthropic_model_client.py
+++ b/openjiuwen/core/foundation/llm/model_clients/anthropic_model_client.py
@@ -16,6 +16,7 @@ Promp caching layout:
   3. messages
 """
 
+import re
 from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, Iterable, List, Mapping, Optional, Tuple, Union
 
 import httpx
@@ -62,6 +63,37 @@ if TYPE_CHECKING:
 # Shape converters: openJiuwen BaseMessage list  <->  Anthropic Messages API payload
 # ---------------------------------------------------------------------------
 
+_DATA_URI_RE = re.compile(r"^data:(?P<media_type>[^;,]+)(?:;charset=[^;,]*)?;base64,(?P<data>.*)$", re.DOTALL)
+
+
+def _image_url_to_anthropic_block(item: dict) -> Optional[dict]:
+    """Translate an OpenAI-shaped ``image_url`` block to an Anthropic ``image`` block.
+
+    Returns None when the URL is unusable (not a base64 data URI and not
+    http/https); the caller drops the block instead of sending a payload the
+    API is guaranteed to reject with a 400.
+    """
+    image_url = item.get("image_url")
+    url = image_url.get("url") if isinstance(image_url, dict) else image_url
+    if not isinstance(url, str) or not url:
+        return None
+    if url.startswith("data:"):
+        match = _DATA_URI_RE.match(url)
+        if match is None:
+            return None
+        return {
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": match.group("media_type"),
+                "data": match.group("data"),
+            },
+        }
+    if url.startswith(("http://", "https://")):
+        return {"type": "image", "source": {"type": "url", "url": url}}
+    return None
+
+
 def _content_to_blocks(content: Any) -> List[dict]:
     """Normalize OJ ``content`` (str | list[str|dict]) to Anthropic block list."""
     if content is None:
@@ -72,6 +104,13 @@ def _content_to_blocks(content: Any) -> List[dict]:
         blocks2: List[dict] = []
         for item in content:
             if isinstance(item, dict):
+                if item.get("type") == "image_url":
+                    block = _image_url_to_anthropic_block(item)
+                    if block is not None:
+                        blocks2.append(block)
+                    else:
+                        llm_logger.warning("Anthropic: dropping untranslatable image_url block.")
+                    continue
                 blocks2.append(dict(item))
             elif isinstance(item, str):
                 if item:

--- a/tests/unit_tests/core/foundation/llm/test_anthropic_model_client.py
+++ b/tests/unit_tests/core/foundation/llm/test_anthropic_model_client.py
@@ -68,6 +68,77 @@ class TestContentToBlocks:
         blocks = _content_to_blocks(42)
         assert blocks == [{"type": "text", "text": "42"}]
 
+    def test_image_url_data_uri_png_translated_to_base64_source(self):
+        blocks = _content_to_blocks([
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+        ])
+        assert blocks == [{
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/png", "data": "AAAA"},
+        }]
+
+    def test_image_url_data_uri_jpeg_translated_to_base64_source(self):
+        blocks = _content_to_blocks([
+            {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,BBBB"}},
+        ])
+        assert blocks[0]["source"]["media_type"] == "image/jpeg"
+        assert blocks[0]["source"]["data"] == "BBBB"
+
+    def test_image_url_http_translated_to_url_source(self):
+        blocks = _content_to_blocks([
+            {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+        ])
+        assert blocks == [{
+            "type": "image",
+            "source": {"type": "url", "url": "https://example.com/cat.png"},
+        }]
+
+    def test_image_url_string_form_translated(self):
+        # Some OpenAI-compatible callers pass image_url as a plain string.
+        blocks = _content_to_blocks([
+            {"type": "image_url", "image_url": "https://example.com/cat.png"},
+        ])
+        assert blocks == [{
+            "type": "image",
+            "source": {"type": "url", "url": "https://example.com/cat.png"},
+        }]
+
+    def test_image_url_detail_field_ignored(self):
+        blocks = _content_to_blocks([
+            {"type": "image_url",
+             "image_url": {"url": "https://example.com/cat.png", "detail": "high"}},
+        ])
+        assert blocks == [{
+            "type": "image",
+            "source": {"type": "url", "url": "https://example.com/cat.png"},
+        }]
+
+    def test_untranslatable_image_url_dropped_others_preserved(self):
+        blocks = _content_to_blocks([
+            {"type": "text", "text": "before"},
+            {"type": "image_url", "image_url": {"url": "/tmp/x.png"}},
+            {"type": "image_url", "image_url": {"url": "data:image/png,notbase64"}},
+            {"type": "image_url", "image_url": {}},
+            {"type": "text", "text": "after"},
+        ])
+        assert blocks == [
+            {"type": "text", "text": "before"},
+            {"type": "text", "text": "after"},
+        ]
+
+    def test_mixed_content_order_preserved(self):
+        blocks = _content_to_blocks([
+            {"type": "text", "text": "look"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            "trailing",
+        ])
+        assert blocks == [
+            {"type": "text", "text": "look"},
+            {"type": "image",
+             "source": {"type": "base64", "media_type": "image/png", "data": "AAAA"}},
+            {"type": "text", "text": "trailing"},
+        ]
+
 
 # ---------------------------------------------------------------------------
 # A. Pure converters: _convert_message_schemas
@@ -156,6 +227,21 @@ class TestConvertMessageSchemas:
             {"role": "developer", "content": "note"},
         ])
         assert messages[0]["role"] == "user"
+
+    def test_tool_result_image_url_content_translated(self):
+        _, messages = _convert_message_schemas([
+            {"role": "tool", "tool_call_id": "t1", "content": [
+                {"type": "text", "text": "screenshot:"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            ]},
+        ])
+        tool_result = messages[0]["content"][0]
+        assert tool_result["type"] == "tool_result"
+        assert tool_result["content"] == [
+            {"type": "text", "text": "screenshot:"},
+            {"type": "image",
+             "source": {"type": "base64", "media_type": "image/png", "data": "AAAA"}},
+        ]
 
     def test_strict_alternation_with_pending_tool_results_flush(self):
         # When a user message lands between tool responses and the next message,


### PR DESCRIPTION
Paired: [GitHub #320](https://github.com/openJiuwen-ai/agent-core/pull/320) ↔ [GitCode !2186](https://gitcode.com/openJiuwen/agent-core/merge_requests/2186)

**What type of PR is this?**
/kind bug


**What does this PR do / why do we need it**:
* Any message carrying an image sent to an Anthropic model currently fails with a `400 invalid_request_error`. All image producers in the repo (e.g. `harness/tools/multimodal/vision.py`) emit OpenAI-shaped `{"type": "image_url", "image_url": {"url": ...}}` blocks, and `_content_to_blocks` in `anthropic_model_client.py` copied dict content through verbatim, so the unsupported block type reached the Anthropic Messages API unchanged.
* This PR adds a small translation step in `_content_to_blocks`: `image_url` blocks are converted to the Anthropic `{"type": "image", "source": {...}}` shape. Data URIs (`data:image/png;base64,...`) become `base64` sources with the parsed media type; `http(s)` URLs become `url` sources. The string form of `image_url` (plain URL instead of `{"url": ...}`) is tolerated, and the OpenAI-only `detail` field is dropped.
* Untranslatable URLs (file paths, malformed data URIs, empty) are dropped with a warning log instead of being forwarded: a dropped image degrades one answer, while a verbatim pass-through 400s the entire request.
* Because `_content_to_blocks` is also used for `tool_result` content, images returned by tools are translated as well (Anthropic supports nested image blocks in `tool_result`).
* Non-image dict blocks keep the existing verbatim pass-through, so already-Anthropic-shaped content keeps working. Backlog task A6 (expose Anthropic in the provider UI) depends on this fix; the typed content-block abstraction (D2) remains the long-term solution.


**Which issue(s) this PR fixes**:
Fixes #373 


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：
* Extended `tests/unit_tests/core/foundation/llm/test_anthropic_model_client.py` with 9 new unit tests covering: data-URI translation (png and jpeg media types), http URL translation, the string form of `image_url`, the `detail` field being ignored, untranslatable URLs being dropped while surrounding blocks are preserved, mixed text/image/string content order, and an `image_url` inside a `role: "tool"` message ending up as a translated `image` block nested in `tool_result`.
* `pytest tests/unit_tests/core/foundation/llm/` - 362 passed, 3 skipped.
* `ruff check` passes on both changed files.


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #373
<!-- /bot1-related-issues -->
