### PR TITLE
feat: add typed ContentPart for multimodal message content

### DIFF
--- a/openjiuwen/core/context_engine/context/context.py
+++ b/openjiuwen/core/context_engine/context/context.py
@@ -21,7 +21,8 @@ from openjiuwen.core.context_engine.processor.base import ContextProcessor
 from openjiuwen.core.context_engine.schema.config import CompressionRecallConfig, ContextEngineConfig
 from openjiuwen.core.context_engine.token.base import TokenCounter
 from openjiuwen.core.foundation.kv_cache import first_changed_index
-from openjiuwen.core.foundation.llm import BaseMessage
+from openjiuwen.core.foundation.llm import BaseMessage, TextPart
+from openjiuwen.core.foundation.llm.schema.content_part import normalize_content_part
 from openjiuwen.core.foundation.tool import ToolInfo
 from openjiuwen.core.runner.callback import lazy_callback_framework as _fw
 from openjiuwen.core.runner.callback.events import ContextEvents
@@ -617,11 +618,13 @@ class SessionModelContext(ModelContext):
             return len(content) // 4
         elif isinstance(content, list):
             total = 0
-            for part in content:
-                if isinstance(part, str):
-                    total += len(part) // 4
-                elif isinstance(part, dict) and "text" in part:
-                    total += len(part["text"]) // 4
+            for item in content:
+                part = normalize_content_part(item)
+                if isinstance(part, TextPart):
+                    total += len(part.text) // 4
+                elif isinstance(item, dict) and "text" in item:
+                    # Untyped ``{"text": ...}`` dialects normalization skips.
+                    total += len(item["text"]) // 4
             return total
         return 0
 

--- a/openjiuwen/core/context_engine/processor/compressor/round_level_compressor.py
+++ b/openjiuwen/core/context_engine/processor/compressor/round_level_compressor.py
@@ -722,8 +722,8 @@ class RoundLevelCompressor(ContextProcessor):
                 cause=exc,
             ) from exc
         replacements = await self._build_json_replacements(context, targets, response.parser_content)
-        if not replacements and isinstance(response.content, str) and response.content.strip():
-            fallback = await self._build_raw_fallback_replacement(context, targets, response.content.strip())
+        if not replacements and response.text.strip():
+            fallback = await self._build_raw_fallback_replacement(context, targets, response.text.strip())
             if fallback:
                 replacements = [fallback]
 

--- a/openjiuwen/core/context_engine/processor/forked/offloader/message_offloader.py
+++ b/openjiuwen/core/context_engine/processor/forked/offloader/message_offloader.py
@@ -215,7 +215,7 @@ class MessageSummaryOffloader(ContextProcessor):
         truncate_offloaded_preview: bool,
         **kwargs: Any,
     ) -> BaseMessage:
-        if not offload_original and len(message.content) <= max_chars:
+        if not offload_original and len(message.text) <= max_chars:
             return message
 
         offloaded = await self._offload_message(
@@ -228,12 +228,12 @@ class MessageSummaryOffloader(ContextProcessor):
             return offloaded
         if self._should_keep_full_rule_compressed_preview(message):
             return offloaded
-        if len(offloaded.content) <= max_chars:
+        if len(offloaded.text) <= max_chars:
             return offloaded
         return offloaded.model_copy(
             update={
                 "content": self._truncate_preserving_offload_marker(
-                    offloaded.content,
+                    offloaded.text,
                     max_chars,
                 )
             }
@@ -360,7 +360,7 @@ class MessageSummaryOffloader(ContextProcessor):
                 truncate_offloaded_preview=self._should_truncate_rule_preview(),
                 **kwargs,
             )
-        if len(processed.content) <= max_chars:
+        if len(processed.text) <= max_chars:
             return processed
         if not self._should_fallback_to_plain_offload():
             return message
@@ -379,7 +379,7 @@ class MessageSummaryOffloader(ContextProcessor):
         original_message: BaseMessage,
         **kwargs: Any,
     ) -> BaseMessage:
-        content = message.content
+        content = message.text
         if not self._is_rule_compressed_message(message):
             content = self._head_tail_preview(
                 content,
@@ -421,7 +421,7 @@ class MessageSummaryOffloader(ContextProcessor):
     ) -> bool:
         return (
             isinstance(message, ToolMessage)
-            and isinstance(message.content, str)
+            and isinstance(getattr(message, "content", None), str)
             and not isinstance(message, OffloadMixin)
             and not self._is_protected_tool_message(message, context_messages)
         )

--- a/openjiuwen/core/context_engine/processor/offloader/message_offloader.py
+++ b/openjiuwen/core/context_engine/processor/offloader/message_offloader.py
@@ -150,7 +150,7 @@ class MessageOffloader(ContextProcessor):
             context: ModelContext,
             **kwargs
     ) -> BaseMessage:
-        trimmed_content = message.content[:self.config.trim_size] + OMIT_STRING
+        trimmed_content = message.text[:self.config.trim_size] + OMIT_STRING
         extra_fields = message.model_dump()
         extra_fields.pop("role", None)
         extra_fields.pop("content", None)
@@ -231,7 +231,7 @@ class MessageOffloader(ContextProcessor):
             return False
         if not isinstance(getattr(message, "content", None), str):
             return False
-        if len(message.content) <= self.config.large_message_threshold:
+        if len(message.text) <= self.config.large_message_threshold:
             return False
         if isinstance(message, OffloadMixin):
             return False

--- a/openjiuwen/core/context_engine/token/tiktoken_counter.py
+++ b/openjiuwen/core/context_engine/token/tiktoken_counter.py
@@ -10,7 +10,8 @@ from typing import List, Optional, Tuple
 from openjiuwen.core.common.logging import logger
 from openjiuwen.core.context_engine.content_sanitize import sanitize_content_for_text, sanitize_value_for_text
 from openjiuwen.core.context_engine.token.base import TokenCounter
-from openjiuwen.core.foundation.llm import AssistantMessage, BaseMessage
+from openjiuwen.core.foundation.llm import AssistantMessage, BaseMessage, ImagePart, TextPart
+from openjiuwen.core.foundation.llm.schema.content_part import DEFAULT_IMAGE_TOKENS, normalize_content_part
 from openjiuwen.core.foundation.tool import ToolInfo
 
 # Providers charge tokens per image by its dimensions, not its payload size.
@@ -18,7 +19,10 @@ from openjiuwen.core.foundation.tool import ToolInfo
 # of magnitude and triggers premature context compression. When an image's
 # dimensions cannot be read, this flat fallback applies: the OpenAI high-detail
 # cost of a typical full-height phone screenshot (85 + 8 tiles x 170).
-DEFAULT_IMAGE_PLACEHOLDER_TOKENS = 1445
+#
+# Aliased from ``content_part`` rather than redeclared: ``ImagePart`` uses the
+# same number as its own no-dimensions fallback, and two copies would drift.
+DEFAULT_IMAGE_PLACEHOLDER_TOKENS = DEFAULT_IMAGE_TOKENS
 
 # The estimate is provider-agnostic by design (model-name sniffing is brittle
 # under router aliases): it takes the larger of the two dominant billing
@@ -209,6 +213,27 @@ def _image_block_tokens(part: dict) -> int:
     return _estimate_image_tokens(*dimensions)
 
 
+def _image_part_to_block(part: ImagePart) -> dict:
+    """Render an ``ImagePart`` into the dict shape the estimators above read.
+
+    Keeps one pricing path for typed and raw content alike: stamped
+    ``width``/``height`` short-circuit the sniffing, while a part carrying only
+    bytes still has its dimensions read out of the payload header. Deliberately
+    not ``ImagePart.estimated_tokens``, which prices for a single named
+    provider — this counter budgets a context window and wants the
+    provider-agnostic upper bound ``_estimate_image_tokens`` returns.
+    """
+    block: dict = {"type": "image", "detail": part.detail}
+    if part.width is not None and part.height is not None:
+        block["width"] = part.width
+        block["height"] = part.height
+    if part.data is not None:
+        block["source"] = {"type": "base64", "data": part.data}
+    elif part.url is not None:
+        block["image_url"] = {"url": part.url}
+    return block
+
+
 class TiktokenCounter(TokenCounter):
     """
     A fast and exact token counter powered by tiktoken.
@@ -279,8 +304,12 @@ class TiktokenCounter(TokenCounter):
                     total += self.count(json.dumps(dict_msg["tool_calls"], ensure_ascii=False), model=model, **kwargs)
         return total + 3
 
-    def _count_content_blocks(self, blocks: list, *, model: str = "", **kwargs) -> tuple:
+    def _count_content_blocks(self, blocks: list, *, model: str = "", **kwargs) -> Tuple[str, int]:
         """Split multimodal block-list content into countable text and non-text tokens.
+
+        Items are normalized to typed parts first, so a payload costs the same
+        whether its producer wrote an ``ImagePart`` or one of the raw dialects
+        that maps onto one.
 
         Image blocks are priced by their dimensions (tile formula), never by
         their payload: counting a base64 ``data:`` URL as text would report
@@ -288,22 +317,33 @@ class TiktokenCounter(TokenCounter):
         Images whose dimensions cannot be read cost the flat fallback, and the
         ``TIKTOKEN_IMAGE_PLACEHOLDER_TOKENS`` env var overrides both. Unknown
         block types are counted from their compact JSON form.
+
+        Returns:
+            The text to place in the message envelope, and the token count
+            contributed by everything that is not text.
         """
         text_parts: List[str] = []
         block_tokens = 0
-        for part in blocks:
-            if isinstance(part, dict):
-                ptype = part.get("type")
-                if ptype in ("image_url", "image") or "image_url" in part or "image" in part:
-                    block_tokens += _image_block_tokens(part)
-                elif ptype == "text" or "text" in part:
-                    text_parts.append(str(part.get("text") or ""))
+        for item in blocks:
+            part = normalize_content_part(item)
+            if isinstance(part, TextPart):
+                text_parts.append(part.text)
+            elif isinstance(part, ImagePart):
+                block_tokens += _image_block_tokens(_image_part_to_block(part))
+            elif isinstance(item, dict):
+                ptype = item.get("type")
+                if ptype in ("image_url", "image") or "image_url" in item or "image" in item:
+                    block_tokens += _image_block_tokens(item)
+                elif ptype == "text" or "text" in item:
+                    text_parts.append(str(item.get("text") or ""))
                 else:
-                    sanitized = sanitize_value_for_text(part)
+                    sanitized = sanitize_value_for_text(item)
                     compact = json.dumps(sanitized, ensure_ascii=False, separators=(",", ":"))
                     block_tokens += self.count(compact, model=model, **kwargs)
             elif isinstance(part, str):
                 text_parts.append(part)
+            else:
+                text_parts.append(str(part))
         return "\n".join(text_parts), block_tokens
 
     def count_tools(self, tools: List[ToolInfo], *, model: str = "", **kwargs) -> int:

--- a/openjiuwen/core/foundation/llm/__init__.py
+++ b/openjiuwen/core/foundation/llm/__init__.py
@@ -10,6 +10,11 @@ from openjiuwen.core.foundation.llm.output_parsers.output_parser import BaseOutp
 from openjiuwen.core.foundation.llm.schema.config import ModelRequestConfig, ModelClientConfig, ProviderType
 from openjiuwen.core.foundation.llm.schema.mode_info import BaseModelInfo, ModelConfig
 # Messages
+from openjiuwen.core.foundation.llm.schema.content_part import (
+    ContentPart,
+    ImagePart,
+    TextPart,
+)
 from openjiuwen.core.foundation.llm.schema.message import (
     BaseMessage,
     AssistantMessage,
@@ -61,6 +66,13 @@ _MESSAGE_CLASSES = [
     "UsageMetadata",
 ]
 
+# Message content parts
+_CONTENT_PART_CLASSES = [
+    "ContentPart",
+    "TextPart",
+    "ImagePart",
+]
+
 # Streaming message classes
 _MESSAGE_CHUNK_CLASSES = [
     "AssistantMessageChunk",
@@ -88,6 +100,7 @@ __all__ = (
     _CORE_CLASSES
     + _CONFIG_CLASSES
     + _MESSAGE_CLASSES
+    + _CONTENT_PART_CLASSES
     + _MESSAGE_CHUNK_CLASSES
     + _TOOL_CLASSES
     + _PREBUILT_MODEL_CLIENTS

--- a/openjiuwen/core/foundation/llm/model_clients/anthropic_model_client.py
+++ b/openjiuwen/core/foundation/llm/model_clients/anthropic_model_client.py
@@ -42,6 +42,7 @@ from openjiuwen.core.foundation.llm.schema.config import (
     ModelRequestConfig,
     ProviderType,
 )
+from openjiuwen.core.foundation.llm.schema.content_part import ImagePart, TextPart
 from openjiuwen.core.foundation.llm.schema.message import (
     AssistantMessage,
     BaseMessage,
@@ -62,8 +63,28 @@ if TYPE_CHECKING:
 # Shape converters: openJiuwen BaseMessage list  <->  Anthropic Messages API payload
 # ---------------------------------------------------------------------------
 
+def _to_anthropic_block(part: Any) -> Any:
+    """Render one content part into an Anthropic content block.
+
+    Anthropic does not speak OpenAI's ``image_url`` block; it wants
+    ``{"type": "image", "source": {...}}``. Unrecognized items pass through so
+    an unforeseen dialect still reaches the API instead of vanishing.
+    """
+    if isinstance(part, TextPart):
+        return {"type": "text", "text": part.text}
+    if isinstance(part, ImagePart):
+        if part.url:
+            source: dict = {"type": "url", "url": part.url}
+        else:
+            source = {"type": "base64", "media_type": part.mime_type, "data": part.data}
+        return {"type": "image", "source": source}
+    return part
+
+
 def _content_to_blocks(content: Any) -> List[dict]:
-    """Normalize OJ ``content`` (str | list[str|dict]) to Anthropic block list."""
+    """Normalize OJ ``content`` (str | list[str|dict]) to Anthropic block list.
+       BaseMessage goes trhough _render_parts before, so no need to handle TextPart/ImagePart
+    """
     if content is None:
         return []
     if isinstance(content, str):
@@ -263,6 +284,15 @@ class AnthropicModelClient(BaseModelClient):
 
     def _get_client_name(self) -> str:
         return "Anthropic client"
+
+    @classmethod
+    def _render_parts(cls, parts: List[Any]) -> Any:
+        """Render parts as Anthropic content blocks rather than OpenAI ones."""
+        return [
+            _to_anthropic_block(part)
+            for part in parts
+            if not (isinstance(part, TextPart) and not part.text)
+        ]
 
     def _use_shared_client(self) -> bool:
         """Whether to reuse the process-wide cached client (default True).

--- a/openjiuwen/core/foundation/llm/model_clients/base_model_client.py
+++ b/openjiuwen/core/foundation/llm/model_clients/base_model_client.py
@@ -26,6 +26,11 @@ from openjiuwen.core.foundation.llm.schema.config import (
     ModelClientConfig,
     ModelRequestConfig,
 )
+from openjiuwen.core.foundation.llm.schema.content_part import (
+    ImagePart,
+    TextPart,
+    normalize_content_part,
+)
 from openjiuwen.core.foundation.llm.schema.generation_response import (
     AudioGenerationResponse,
     ImageGenerationResponse,
@@ -39,6 +44,20 @@ from openjiuwen.core.foundation.llm.schema.message import (
 )
 from openjiuwen.core.foundation.llm.schema.message_chunk import AssistantMessageChunk
 from openjiuwen.core.foundation.tool import ToolInfo
+
+
+def _to_openai_block(part: Any) -> Any:
+    """Render one content part into an OpenAI content block."""
+    if isinstance(part, TextPart):
+        return {"type": "text", "text": part.text}
+    if isinstance(part, ImagePart):
+        image_url: Dict[str, Any] = {"url": part.url or part.to_data_url()}
+        # ``detail`` is omitted at its default so payloads stay byte-identical
+        # to the ``{"url": ...}`` blocks producers emit today.
+        if part.detail != "auto":
+            image_url["detail"] = part.detail
+        return {"type": "image_url", "image_url": image_url}
+    return part
 
 
 class BaseModelClient(ABC):
@@ -273,8 +292,31 @@ class BaseModelClient(ABC):
         # like api.openai.com work out of the box); a user-provided ssl_cert is
         # loaded additively on top of the default store for self-signed endpoints.
 
-    @staticmethod
-    def _convert_messages_to_dict(messages: Union[str, List[BaseMessage], List[dict]]) -> List[dict]:
+    @classmethod
+    def _render_parts(cls, parts: List[Any]) -> Any:
+        """Render normalized content items into this provider's wire content.
+
+        ``parts`` holds :data:`ContentPart` instances plus any item
+        ``normalize_content_part`` did not recognize; the default renderer
+        forwards those verbatim.
+
+        The default is the OpenAI shape, which every built-in client except
+        Anthropic speaks. Override this to translate parts for a provider with
+        its own content dialect.
+
+        A lone text part degrades back to a bare ``str``. That is what used to
+        go on the wire, and providers anchor their prompt cache on the exact
+        request prefix, so emitting a one-element list instead would miss the
+        cache on every single request.
+        """
+        if not parts:
+            return ""
+        if len(parts) == 1 and isinstance(parts[0], TextPart):
+            return parts[0].text
+        return [_to_openai_block(part) for part in parts]
+
+    @classmethod
+    def _convert_messages_to_dict(cls, messages: Union[str, List[BaseMessage], List[dict]]) -> List[dict]:
         """Convert messages to specific API format
 
         Args:
@@ -305,7 +347,10 @@ class BaseModelClient(ABC):
         # Convert BaseMessage list
         result = []
         for msg in messages:
-            msg_dict = {"role": msg.role, "content": msg.content}
+            content = msg.content
+            if isinstance(content, list):
+                content = cls._render_parts([normalize_content_part(item) for item in content])
+            msg_dict = {"role": msg.role, "content": content}
 
             # Handle tool_calls for AssistantMessage
             if isinstance(msg, AssistantMessage) and msg.tool_calls:

--- a/openjiuwen/core/foundation/llm/model_clients/dashscope_model_client.py
+++ b/openjiuwen/core/foundation/llm/model_clients/dashscope_model_client.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
 
-from typing import Optional, List
+from typing import Any, List, Optional, Tuple
 
 import dashscope
 from dashscope import MultiModalConversation, VideoSynthesis
@@ -9,6 +9,11 @@ from dashscope import MultiModalConversation, VideoSynthesis
 from openjiuwen.core.common.exception.errors import ValidationError, ModelError
 from openjiuwen.core.common.exception.codes import StatusCode
 from openjiuwen.core.common.logging import logger
+from openjiuwen.core.foundation.llm.schema.content_part import (
+    ImagePart,
+    TextPart,
+    normalize_content_part,
+)
 from openjiuwen.core.foundation.llm.schema.message import UserMessage
 from openjiuwen.core.foundation.llm.model_clients.openai_model_client import OpenAIModelClient
 from openjiuwen.core.foundation.llm.schema.config import ModelClientConfig, ModelRequestConfig, ProviderType
@@ -28,6 +33,63 @@ DASHSCOPE_VOICE = ["Cherry", "Serena", "Ethan", "Chelsie", "Momo", "Vivian", "Mo
 DASHSCOPE_LANGUAGE_TYPE = [
     "Chinese", "English", "German", "Italian", "Portuguese",
     "Spanish", "Japanese", "Korean", "French", "Russian"]
+
+
+def _to_dashscope_content(content: Any) -> Tuple[List[dict], int, int]:
+    """Render message content into DashScope's ``{"text"}``/``{"image"}`` list.
+
+    Used only by the MultiModalConversation (Wanx) generation APIs. The chat
+    path stays OpenAI-compatible and is deliberately untouched.
+
+    Returns:
+        The content list, plus the text and image counts the Wanx API caps.
+
+    Raises:
+        ValidationError: If ``content`` — or one of its items — is a shape
+            DashScope cannot express.
+    """
+    if isinstance(content, str):
+        return [{"text": content}], 1, 0
+
+    if not isinstance(content, list):
+        raise ValidationError(
+            StatusCode.MODEL_INVOKE_PARAM_ERROR,
+            msg=f"Message content must be string or list, but got {type(content).__name__}."
+        )
+
+    content_list: List[dict] = []
+    text_count = 0
+    image_count = 0
+
+    for item in content:
+        part = normalize_content_part(item)
+        if isinstance(part, TextPart):
+            content_list.append({"text": part.text})
+            text_count += 1
+        elif isinstance(part, ImagePart):
+            content_list.append({"image": part.url or part.to_data_url()})
+            image_count += 1
+        elif isinstance(item, dict):
+            # DashScope's own dialect carries no ``type`` key, so normalization
+            # leaves it alone and it is matched here instead.
+            if "text" in item:
+                content_list.append({"text": item["text"]})
+                text_count += 1
+            elif "image" in item:
+                content_list.append({"image": item["image"]})
+                image_count += 1
+            else:
+                raise ValidationError(
+                    StatusCode.MODEL_INVOKE_PARAM_ERROR,
+                    msg=f"Content dict must contain 'text' or 'image' key, but got: {list(item.keys())}"
+                )
+        else:
+            raise ValidationError(
+                StatusCode.MODEL_INVOKE_PARAM_ERROR,
+                msg=f"Content item must be string or dict, but got {type(item).__name__}."
+            )
+
+    return content_list, text_count, image_count
 
 
 class DashScopeModelClient(OpenAIModelClient):
@@ -99,44 +161,7 @@ class DashScopeModelClient(OpenAIModelClient):
 
             # (2) Validate and convert message content to DashScope format
             msg = messages[0]
-            content_list = []
-            image_count = 0
-            text_count = 0
-
-            # Handle content: can be string or list of dicts
-            if isinstance(msg.content, str):
-                # Simple text prompt
-                content_list.append({"text": msg.content})
-                text_count = 1
-            elif isinstance(msg.content, list):
-                # Complex content with text and/or images
-                for item in msg.content:
-                    if isinstance(item, str):
-                        content_list.append({"text": item})
-                        text_count += 1
-                    elif isinstance(item, dict):
-                        # Validate dict structure
-                        if "text" in item:
-                            content_list.append({"text": item["text"]})
-                            text_count += 1
-                        elif "image" in item:
-                            content_list.append({"image": item["image"]})
-                            image_count += 1
-                        else:
-                            raise ValidationError(
-                                StatusCode.MODEL_INVOKE_PARAM_ERROR,
-                                msg=f"Content dict must contain 'text' or 'image' key, but got: {list(item.keys())}"
-                            )
-                    else:
-                        raise ValidationError(
-                            StatusCode.MODEL_INVOKE_PARAM_ERROR,
-                            msg=f"Content item must be string or dict, but got {type(item).__name__}."
-                        )
-            else:
-                raise ValidationError(
-                    StatusCode.MODEL_INVOKE_PARAM_ERROR,
-                    msg=f"Message content must be string or list, but got {type(msg.content).__name__}."
-                )
+            content_list, text_count, image_count = _to_dashscope_content(msg.content)
 
             # Validate content requirements
             if text_count == 0:

--- a/openjiuwen/core/foundation/llm/model_clients/intelli_router_model_client.py
+++ b/openjiuwen/core/foundation/llm/model_clients/intelli_router_model_client.py
@@ -11,6 +11,11 @@ from threading import Lock
 from typing import List, Optional, AsyncIterator, Union, Dict, Any
 
 from openjiuwen.core.foundation.llm.model_clients.base_model_client import BaseModelClient
+from openjiuwen.core.foundation.llm.schema.content_part import (
+    ImagePart,
+    TextPart,
+    normalize_content_part,
+)
 from openjiuwen.core.foundation.llm.schema.message import (
     BaseMessage, AssistantMessage, UserMessage, UsageMetadata
 )
@@ -497,9 +502,13 @@ class IntelliRouterModelClient(BaseModelClient):
                 content_list.append({"text": msg.content})
             elif isinstance(msg.content, list):
                 for item in msg.content:
-                    if isinstance(item, str):
-                        content_list.append({"text": item})
+                    part = normalize_content_part(item)
+                    if isinstance(part, TextPart):
+                        content_list.append({"text": part.text})
+                    elif isinstance(part, ImagePart):
+                        content_list.append({"image": part.url or part.to_data_url()})
                     elif isinstance(item, dict):
+                        # DashScope's native dialect carries no ``type`` key.
                         if "text" in item:
                             content_list.append({"text": item["text"]})
                         elif "image" in item:

--- a/openjiuwen/core/foundation/llm/schema/content_part.py
+++ b/openjiuwen/core/foundation/llm/schema/content_part.py
@@ -1,0 +1,330 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Provider-neutral content parts for :class:`BaseMessage`.
+   Instead of taking opaque dictionaries that cannot be verified by pydantic,
+   :class:`ContentPart` provides known interfaces for both text and image inputs
+   and can be easily extended to deal with other modals such as audio and video
+
+.. code-block:: text
+
+    producer -> ContentPart -> client render -> provider wire format
+
+Nothing in this module talks to a provider. Translation *out* belongs to the
+model clients; translation *in* is :func:`normalize_content_part`, which is
+deliberately total: it never raises, and returns unrecognized input untouched.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import math
+from typing import Annotated, Any, Literal, Optional, Union
+
+from pydantic import BaseModel, Field, TypeAdapter, model_validator
+from pydantic import ValidationError as PydanticValidationError
+
+from openjiuwen.core.common.exception.codes import StatusCode
+from openjiuwen.core.common.exception.errors import raise_error
+from openjiuwen.core.common.logging import llm_logger
+
+# Fallback billing estimate for an image whose pixel dimensions are unknown.
+# Also the placeholder ``TiktokenCounter`` bills such an image at, where it is
+# overridable via ``TIKTOKEN_IMAGE_PLACEHOLDER_TOKENS``.
+DEFAULT_IMAGE_TOKENS = 1445
+
+_DATA_URL_PREFIX = "data:"
+_BASE64_MARKER = ";base64,"
+
+
+class TextPart(BaseModel):
+    """A plain-text span of message content."""
+
+    type: Literal["text"] = "text"
+    text: str
+
+
+class ImagePart(BaseModel):
+    """An image carried either inline (``data``) or by reference (``url``).
+
+    Exactly one of ``data``/``url`` must be set.
+    """
+
+    type: Literal["image"] = "image"
+    mime_type: str
+    data: Optional[str] = None
+    """Base64 payload **without** the ``data:<mime>;base64,`` prefix."""
+    url: Optional[str] = None
+    detail: Literal["auto", "low", "high"] = "auto"
+    width: Optional[int] = None
+    height: Optional[int] = None
+
+    @model_validator(mode="after")
+    def _require_exactly_one_source(self) -> "ImagePart":
+        if bool(self.data) == bool(self.url):
+            raise ValueError("ImagePart requires exactly one of 'data' or 'url'")
+        return self
+
+    @classmethod
+    def from_data_url(cls, url: str, **kwargs: Any) -> "ImagePart":
+        if not isinstance(url, str) or not url.startswith(_DATA_URL_PREFIX):
+            raise_error(
+                StatusCode.MODEL_INVOKE_PARAM_ERROR,
+                error_msg=f"expected a 'data:' URL, got: {str(url)[:32]!r}",
+            )
+
+        head, marker, payload = url.partition(_BASE64_MARKER)
+        if not marker:
+            raise_error(
+                StatusCode.MODEL_INVOKE_PARAM_ERROR,
+                error_msg="data URL is not base64-encoded, expected a ';base64,' marker",
+            )
+
+        mime_type = head.removeprefix(_DATA_URL_PREFIX)
+        if not mime_type:
+            raise_error(
+                StatusCode.MODEL_INVOKE_PARAM_ERROR,
+                error_msg="data URL is missing its media type",
+            )
+
+        try:
+            base64.b64decode(payload, validate=True)
+        except ValueError as exc:
+            raise_error(
+                StatusCode.MODEL_INVOKE_PARAM_ERROR,
+                error_msg="data URL payload is not valid base64",
+                cause=exc,
+            )
+
+        return cls(mime_type=mime_type, data=payload, **kwargs)
+
+    @classmethod
+    def from_data_url_unchecked(cls, url: str, **kwargs: Any) -> "ImagePart":
+        body = url.removeprefix(_DATA_URL_PREFIX)
+        mime_type, marker, payload = body.partition(_BASE64_MARKER)
+        if marker and payload:
+            return cls(mime_type=mime_type or "image/png", data=payload, **kwargs)
+
+        # No base64 marker: ``mime_type`` above swallowed the whole body, so
+        # re-read it as the media type only — up to the first ';' or ','.
+        media_type = body.split(";", 1)[0].split(",", 1)[0]
+        return cls(mime_type=media_type or "image/png", url=url, **kwargs)
+
+    def to_data_url(self) -> str:
+        """Render back to a ``data:`` URL. Requires inline ``data``."""
+        if not self.data:
+            raise_error(
+                StatusCode.MODEL_INVOKE_PARAM_ERROR,
+                error_msg="cannot build a data URL from a url-backed ImagePart",
+            )
+        return f"{_DATA_URL_PREFIX}{self.mime_type}{_BASE64_MARKER}{self.data}"
+
+    def estimated_tokens(self, provider: str) -> int:
+        """Estimate what this image costs on ``provider``.
+
+        Falls back to :data:`DEFAULT_IMAGE_TOKENS` whenever the provider is
+        unknown or ``width``/``height`` are absent — dimensions are optional
+        because most producers only ever see the encoded bytes.
+        """
+        if self.width is None or self.height is None:
+            return DEFAULT_IMAGE_TOKENS
+
+        estimator = _TOKEN_ESTIMATORS.get(provider.strip().lower())
+        if estimator is None:
+            return DEFAULT_IMAGE_TOKENS
+        return estimator(self)
+
+
+ContentPart = Annotated[
+    Union[TextPart, ImagePart],
+    Field(discriminator="type"),
+]
+
+_CONTENT_PART_ADAPTER: TypeAdapter[Union[TextPart, ImagePart]] = TypeAdapter(ContentPart)
+
+
+# ---------------------------------------------------------------------------
+# Per-provider token estimation
+# ---------------------------------------------------------------------------
+
+_OPENAI_LOW_DETAIL_TOKENS = 85
+_OPENAI_TILE_TOKENS = 170
+_OPENAI_TILE_PX = 512
+_OPENAI_MAX_EDGE_PX = 2048
+_OPENAI_SHORT_EDGE_PX = 768
+
+_ANTHROPIC_PX_PER_TOKEN = 750
+_ANTHROPIC_MAX_TOKENS = 1600
+
+
+def _openai_tokens(part: ImagePart) -> int:
+    """OpenAI vision pricing: a base cost plus one charge per 512px tile."""
+    if part.detail == "low":
+        return _OPENAI_LOW_DETAIL_TOKENS
+
+    width, height = part.width, part.height
+    longest = max(width, height)
+    if longest > _OPENAI_MAX_EDGE_PX:
+        scale = _OPENAI_MAX_EDGE_PX / longest
+        width, height = int(width * scale), int(height * scale)
+
+    shortest = min(width, height)
+    if shortest > _OPENAI_SHORT_EDGE_PX:
+        scale = _OPENAI_SHORT_EDGE_PX / shortest
+        width, height = int(width * scale), int(height * scale)
+
+    tiles = math.ceil(width / _OPENAI_TILE_PX) * math.ceil(height / _OPENAI_TILE_PX)
+    return _OPENAI_LOW_DETAIL_TOKENS + _OPENAI_TILE_TOKENS * tiles
+
+
+def _anthropic_tokens(part: ImagePart) -> int:
+    """Anthropic vision pricing: roughly ``width * height / 750``."""
+    return min(
+        math.ceil(part.width * part.height / _ANTHROPIC_PX_PER_TOKEN),
+        _ANTHROPIC_MAX_TOKENS,
+    )
+
+
+_TOKEN_ESTIMATORS = {
+    "openai": _openai_tokens,
+    "anthropic": _anthropic_tokens,
+}
+
+
+# ---------------------------------------------------------------------------
+# Normalization: the several inbound dialects -> ContentPart
+# ---------------------------------------------------------------------------
+
+
+def normalize_content_part(item: Any) -> Any:
+    """Best-effort conversion of one raw content item into a :data:`ContentPart`.
+
+    Recognized inputs:
+
+    * an existing ``TextPart``/``ImagePart`` — returned as-is
+    * ``str`` — becomes a ``TextPart``
+    * ``{"type": "text", "text": ...}`` — the OpenAI text block
+    * ``{"type": "image_url", "image_url": {"url": ...}}`` — the OpenAI image
+      block, as emitted by ``react_agent`` and the mobile GUI skill runner
+    * ``{"type": "image", "data_url": ..., "mime_type": ...}`` — the shape
+      ``harness/tools/filesystem.py`` attaches to ``read_file`` results
+
+    Anything else is returned unchanged instead of raising.
+    """
+    if isinstance(item, (TextPart, ImagePart)):
+        return item
+    if isinstance(item, str):
+        return TextPart(text=item)
+    if isinstance(item, dict):
+        return _part_from_dict(item)
+    llm_logger.debug("content item of type %s is not a known content part", type(item).__name__)
+    return item
+
+
+def _part_from_dict(item: dict) -> Any:
+    # Canonical shape first, so a part that was serialized with ``model_dump``
+    # is read back as the same part. Without this, persisting through
+    # ``session/vcs`` and reloading would silently downgrade an ImagePart to an
+    # opaque dict, since no inbound dialect matches its own dump shape.
+    part = _part_from_canonical_dict(item)
+    if part is not None:
+        return part
+
+    item_type = item.get("type")
+
+    if item_type == "text" and isinstance(item.get("text"), str):
+        return TextPart(text=item["text"])
+
+    if item_type == "image_url":
+        part = _image_from_openai_block(item)
+        if part is not None:
+            return part
+
+    if item_type == "image" and isinstance(item.get("data_url"), str):
+        part = _image_from_data_url(item["data_url"], **_stamped_dimensions(item))
+        if part is not None:
+            return part
+
+    llm_logger.debug("content dict is not a known content part, preserved verbatim: %s", sorted(item))
+    return item
+
+
+def _part_from_canonical_dict(item: dict) -> Optional[Any]:
+    """Validate against :data:`ContentPart` itself, or ``None`` if it does not fit."""
+    try:
+        return _CONTENT_PART_ADAPTER.validate_python(item)
+    except PydanticValidationError:
+        return None
+
+
+def _image_from_openai_block(item: dict) -> Optional[ImagePart]:
+    image_url = item.get("image_url")
+    if not isinstance(image_url, dict):
+        return None
+
+    url = image_url.get("url")
+    if not isinstance(url, str) or not url:
+        return None
+
+    detail = image_url.get("detail")
+    extra: dict[str, Any] = {"detail": detail} if detail in ("auto", "low", "high") else {}
+    extra.update(_stamped_dimensions(item))
+
+    if url.startswith(_DATA_URL_PREFIX):
+        return _image_from_data_url(url, **extra)
+    return ImagePart(mime_type=_mime_type_from_url(url), url=url, **extra)
+
+
+def _stamped_dimensions(item: dict) -> dict[str, int]:
+    """Extract image dimensions when available."""
+    width, height = item.get("width"), item.get("height")
+    if all(isinstance(x, int) and x > 0 for x in [width, height]):
+        return {"width": width, "height": height}
+
+    value = item.get("dimensions")
+    if isinstance(value, str) and "x" in value.lower():
+        left, _, right = value.lower().partition("x")
+        value = [left, right]
+    if isinstance(value, (list, tuple)) and len(value) == 2:
+        try:
+            width, height = int(value[0]), int(value[1])
+        except (TypeError, ValueError):
+            return {}
+        if width > 0 and height > 0:
+            return {"width": width, "height": height}
+    return {}
+
+
+def _image_from_data_url(url: str, **kwargs: Any) -> Optional[ImagePart]:
+    """Parse a data URL, degrading to ``None`` instead of raising."""
+    try:
+        return ImagePart.from_data_url(url, **kwargs)
+    except Exception as exc:  # noqa: BLE001 — normalization must not raise
+        llm_logger.debug("failed to parse image data URL, preserving verbatim: %s", exc)
+        return None
+
+
+def _mime_type_from_url(url: str) -> str:
+    """Guess a media type from a remote URL's extension, defaulting to PNG."""
+    suffix = url.rsplit(".", 1)[-1].split("?", 1)[0].lower()
+    return _URL_SUFFIX_MIME_TYPES.get(suffix, "image/png")
+
+
+_URL_SUFFIX_MIME_TYPES = {
+    "png": "image/png",
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "gif": "image/gif",
+    "webp": "image/webp",
+    "bmp": "image/bmp",
+}
+
+
+__all__ = [
+    "ContentPart",
+    "DEFAULT_IMAGE_TOKENS",
+    "ImagePart",
+    "TextPart",
+    "normalize_content_part",
+]

--- a/openjiuwen/core/foundation/llm/schema/message.py
+++ b/openjiuwen/core/foundation/llm/schema/message.py
@@ -2,8 +2,14 @@
 # Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
 
 from typing import Union, List, Optional, Any, Dict
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, SerializerFunctionWrapHandler, model_serializer, model_validator
 
+from openjiuwen.core.foundation.llm.schema.content_part import (
+    ContentPart,
+    ImagePart,
+    TextPart,
+    normalize_content_part,
+)
 from openjiuwen.core.foundation.llm.schema.tool_call import ToolCall
 
 
@@ -13,7 +19,7 @@ class UsageMetadata(BaseModel):
     prompt: str = ""
     task_id: str = ""
     model_name: str = ""
-    total_latency: float = 0.
+    total_latency: float = 0.0
     first_token_time: str = ""
     request_start_time: str = ""
     input_tokens: int = 0
@@ -21,16 +27,50 @@ class UsageMetadata(BaseModel):
     total_tokens: int = 0
     cache_tokens: int = 0
     reasoning_tokens: int = 0
-    input_cost: float = 0.
-    output_cost: float = 0.
-    total_cost: float = 0.
+    input_cost: float = 0.0
+    output_cost: float = 0.0
+    total_cost: float = 0.0
 
 
 class BaseMessage(BaseModel):
     role: str
-    content: Union[str, List[Union[str, dict]]] = ""
+    content: Union[str, List[Union[str, dict, ContentPart]]] = ""
+    """Content part can encode both text and images while avoiding the usage
+    of opaque dicts. The other options are kept to not break the API compatibility
+    with user code since agent-core is a library and not an application.
+    """
     name: Optional[str] = None
     metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    @property
+    def parts(self) -> List[ContentPart]:
+        """Content as typed parts, normalizing raw ``str``/``dict`` items on read."""
+        if isinstance(self.content, str):
+            return [TextPart(text=self.content)]
+        normalized = (normalize_content_part(item) for item in self.content)
+        return [part for part in normalized if isinstance(part, (TextPart, ImagePart))]
+
+    @property
+    def text(self) -> str:
+        """The textual content only joined with newlines, with non-text parts skipped."""
+        if isinstance(self.content, str):
+            return self.content
+        return "\n".join(part.text for part in self.parts if isinstance(part, TextPart))
+
+
+def _to_openai_tool_call(call: ToolCall) -> dict[str, Any]:
+    """Render a flat ``ToolCall`` back into OpenAI's nested wire shape."""
+    result: dict[str, Any] = {
+        "id": call.id,
+        "type": call.type,
+        "function": {
+            "name": call.name,
+            "arguments": call.arguments,
+        },
+    }
+    if call.response_item_id is not None:
+        result["response_item_id"] = call.response_item_id
+    return result
 
 
 class AssistantMessage(BaseMessage):
@@ -47,7 +87,7 @@ class AssistantMessage(BaseMessage):
     completion_token_ids: Optional[List[int]] = None
     logprobs: Optional[Any] = None
 
-    @model_validator(mode='before')
+    @model_validator(mode="before")
     @classmethod
     def convert_openai_tool_calls_format(cls, data: Any) -> Any:
         """Convert OpenAI API format tool_calls to flat ToolCall format.
@@ -58,68 +98,48 @@ class AssistantMessage(BaseMessage):
         ToolCall model expects flat format:
         {"id": "xxx", "type": "function", "name": "...", "arguments": "..."}
         """
-        if isinstance(data, dict) and 'tool_calls' in data and data['tool_calls']:
+        if isinstance(data, dict) and "tool_calls" in data and data["tool_calls"]:
             converted_tool_calls = []
-            for tc in data['tool_calls']:
-                if isinstance(tc, dict) and 'function' in tc and isinstance(tc['function'], dict):
+            for tc in data["tool_calls"]:
+                if isinstance(tc, dict) and "function" in tc and isinstance(tc["function"], dict):
                     # OpenAI format - convert to flat format
                     converted_tc = {
-                        'id': tc.get('id'),
-                        'type': tc.get('type', 'function'),
-                        'name': tc['function'].get('name', ''),
-                        'arguments': tc['function'].get('arguments', ''),
-                        'index': tc.get('index'),
-                        'response_item_id': tc.get('response_item_id'),
+                        "id": tc.get("id"),
+                        "type": tc.get("type", "function"),
+                        "name": tc["function"].get("name", ""),
+                        "arguments": tc["function"].get("arguments", ""),
+                        "index": tc.get("index"),
+                        "response_item_id": tc.get("response_item_id"),
                     }
                     converted_tool_calls.append(converted_tc)
                 else:
                     # Already flat format or ToolCall instance
                     converted_tool_calls.append(tc)
-            data['tool_calls'] = converted_tool_calls
+            data["tool_calls"] = converted_tool_calls
         return data
 
-    def model_dump(self, **kwargs) -> dict[str, Any]:
-        result = {
-            "role": self.role,
-            "content": self.content,
-        }
-        if self.name is not None:
-            result["name"] = self.name
-        if self.metadata:
-            result["metadata"] = self.metadata
+    @model_serializer(mode="wrap")
+    def serialize_compact_openai_shape(self, handler: SerializerFunctionWrapHandler) -> dict[str, Any]:
+        """Emit the compact OpenAI-shaped dict, via pydantic's own serializer.
+        This replaces a hand-written ``model_dump`` override that bypassed
+        pydantic entirely.
+        """
+        result = {key: value for key, value in handler(self).items() if value is not None}
+
+        if not self.metadata:
+            result.pop("metadata", None)
+
         if self.tool_calls:
-            tool_calls = []
-            for call in self.tool_calls:
-                tool_calls.append({
-                    "id": call.id,
-                    "type": call.type,
-                    "function": {
-                        "name": call.name,
-                        "arguments": call.arguments
-                    }
-                })
-                if call.response_item_id is not None:
-                    tool_calls[-1]["response_item_id"] = call.response_item_id
-            result["tool_calls"] = tool_calls
-        if self.usage_metadata is not None:
-            result["usage_metadata"] = self.usage_metadata.model_dump(**kwargs)
-        if self.finish_reason is not None:
-            result["finish_reason"] = self.finish_reason
-        if self.parser_content is not None:
-            result["parser_content"] = self.parser_content
-        if self.reasoning_content is not None:
-            result["reasoning_content"] = self.reasoning_content
-        if self.prompt_token_ids is not None:
-            result["prompt_token_ids"] = self.prompt_token_ids
-        if self.completion_token_ids is not None:
-            result["completion_token_ids"] = self.completion_token_ids
-        if self.logprobs is not None:
-            result["logprobs"] = self.logprobs
+            result["tool_calls"] = [_to_openai_tool_call(call) for call in self.tool_calls]
+        else:
+            result.pop("tool_calls", None)
+
         return result
 
 
 class UserMessage(BaseMessage):
     role: str = "user"
+
 
 class SystemMessage(BaseMessage):
     role: str = "system"

--- a/openjiuwen/core/foundation/llm/utils/responses_utils.py
+++ b/openjiuwen/core/foundation/llm/utils/responses_utils.py
@@ -13,6 +13,7 @@ import httpx
 from pydantic import BaseModel
 
 from openjiuwen.core.common.utils.header_utils import sanitize_headers
+from openjiuwen.core.foundation.llm.schema.content_part import TextPart
 from openjiuwen.core.foundation.llm.schema.message import (
     AssistantMessage,
     BaseMessage,
@@ -334,6 +335,8 @@ def _content_as_text(content: Any) -> str:
 def _content_part_text(part: Any) -> str:
     if isinstance(part, str):
         return part
+    if isinstance(part, TextPart):
+        return part.text
     if not isinstance(part, dict):
         return ""
 

--- a/openjiuwen/core/memory/long_term_memory.py
+++ b/openjiuwen/core/memory/long_term_memory.py
@@ -1490,6 +1490,10 @@ class LongTermMemory(metaclass=Singleton):
             # If the LLM fails to be obtained, try to use the system default configuration.
             return self._base_llm
 
+    def _truncate_content(self, msg: BaseMessage) -> None:
+        """Cap a message at ``input_msg_max_len`` characters of text."""
+        msg.content = msg.text[:self._sys_mem_config.input_msg_max_len]
+
     def _check_messages(self, messages: list[BaseMessage]) -> Tuple[bool, list[BaseMessage]]:
         out_messages = []
         has_human_msg = False
@@ -1499,7 +1503,7 @@ class LongTermMemory(metaclass=Singleton):
                 out_messages.append(msg)
                 has_human_msg = True
                 continue
-            msg.content = msg.content[:self._sys_mem_config.input_msg_max_len]
+            self._truncate_content(msg)
             out_messages.append(msg)
 
         return has_human_msg, out_messages
@@ -1525,7 +1529,7 @@ class LongTermMemory(metaclass=Singleton):
             if msg.role == human_message.role:
                 history_messages.append(msg)
                 continue
-            msg.content = msg.content[:self._sys_mem_config.input_msg_max_len]
+            self._truncate_content(msg)
             history_messages.append(msg)
         return history_messages
 

--- a/openjiuwen/core/single_agent/agents/react_agent.py
+++ b/openjiuwen/core/single_agent/agents/react_agent.py
@@ -41,7 +41,9 @@ from openjiuwen.core.context_engine import (
 )
 from openjiuwen.core.foundation.llm import (
     AssistantMessage,
+    ImagePart,
     Model,
+    TextPart,
     ToolMessage,
     UserMessage,
     SystemMessage
@@ -1153,6 +1155,9 @@ class ReActAgent(BaseAgent):
             return False
 
         for message in messages:
+            if any(isinstance(part, ImagePart) for part in getattr(message, "parts", ())):
+                return True
+
             content = getattr(message, "content", None)
             if isinstance(message, dict):
                 content = message.get("content")
@@ -1476,29 +1481,14 @@ class ReActAgent(BaseAgent):
 
     @staticmethod
     def _build_multimodal_tool_results_message(tool_results: Any) -> Optional[UserMessage]:
-        content: List[dict[str, Any]] = []
+        content: List[Union[TextPart, ImagePart]] = []
         loaded_paths: List[str] = []
 
         for tool_result in tool_results:
-            for item in ReActAgent._iter_multimodal_image_items(tool_result):
-                source = str(item.get("source") or "tool")
-                source_path = str(item.get("source_path") or "unknown image")
-                data_url = item["data_url"]
+            for source, source_path, image in ReActAgent._iter_multimodal_image_items(tool_result):
                 loaded_paths.append(source_path)
-                content.append(
-                    {
-                        "type": "text",
-                        "text": f"Image loaded from {source}: {source_path}",
-                    }
-                )
-                content.append(
-                    {
-                        "type": "image_url",
-                        "image_url": {
-                            "url": data_url,
-                        },
-                    }
-                )
+                content.append(TextPart(text=f"Image loaded from {source}: {source_path}"))
+                content.append(image)
 
         if not content:
             return None
@@ -1508,12 +1498,13 @@ class ReActAgent(BaseAgent):
                 "Images loaded by tool results:",
                 *[f"{index}. {path}" for index, path in enumerate(loaded_paths, start=1)],
             ]
-            content.insert(0, {"type": "text", "text": "\n".join(summary_lines)})
+            content.insert(0, TextPart(text="\n".join(summary_lines)))
 
         return UserMessage(content=content)
 
     @staticmethod
-    def _iter_multimodal_image_items(tool_result: Any) -> List[dict[str, Any]]:
+    def _iter_multimodal_image_items(tool_result: Any) -> List[tuple[str, str, ImagePart]]:
+        """Pull ``(source, source_path, ImagePart)`` out of a tool result's multimodal payload."""
         data = getattr(tool_result, "data", None)
         if not isinstance(data, dict):
             return []
@@ -1522,7 +1513,7 @@ class ReActAgent(BaseAgent):
         if not isinstance(multimodal_items, list):
             return []
 
-        image_items: List[dict[str, Any]] = []
+        images: List[tuple[str, str, ImagePart]] = []
         for item in multimodal_items:
             if not isinstance(item, dict) or item.get("type") != "image":
                 continue
@@ -1531,9 +1522,21 @@ class ReActAgent(BaseAgent):
             if not isinstance(data_url, str) or not data_url.startswith("data:image/"):
                 continue
 
-            image_items.append(item)
+            extra = {
+                key: item[key]
+                for key in ("width", "height")
+                if isinstance(item.get(key), int)
+            }
+            image = ImagePart.from_data_url_unchecked(data_url, **extra)
+            images.append(
+                (
+                    str(item.get("source") or "tool"),
+                    str(item.get("source_path") or "unknown image"),
+                    image,
+                )
+            )
 
-        return image_items
+        return images
 
     def _is_interrupted(self, tool_result: Any) -> bool:
         """Detect whether a tool result signals workflow interruption."""

--- a/openjiuwen/harness/image_modality_probe.py
+++ b/openjiuwen/harness/image_modality_probe.py
@@ -11,6 +11,7 @@ import zlib
 from typing import Any, Iterable, List, Optional
 
 from openjiuwen.core.common.logging import logger
+from openjiuwen.core.foundation.llm import ImagePart, TextPart, UserMessage
 
 _IMAGE_INPUT_SCAN_MAX_DEPTH = 8
 _IMAGE_MODALITY_PROBE_TIMEOUT_SECONDS = 5.0
@@ -238,25 +239,15 @@ async def _probe_and_cache(llm, key: tuple[str, str]) -> None:
 async def _invoke_probe(llm, *, extra_body: Optional[dict]):
     """Send the probe request, optionally carrying reasoning-off switches."""
     kwargs = {"extra_body": extra_body} if extra_body else {}
+    probe_message = UserMessage(
+        content=[
+            ImagePart(mime_type="image/png", data=DUMMY_IMAGE_B64),
+            TextPart(text="What color is this image? Reply with one word."),
+        ]
+    )
     return await asyncio.wait_for(
         llm.invoke(
-            [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "image_url",
-                            "image_url": {
-                                "url": f"data:image/png;base64,{DUMMY_IMAGE_B64}",
-                            },
-                        },
-                        {
-                            "type": "text",
-                            "text": "What color is this image? Reply with one word.",
-                        },
-                    ],
-                }
-            ],
+            [probe_message],
             max_tokens=_IMAGE_MODALITY_PROBE_MAX_TOKENS,
             temperature=0,
             **kwargs,

--- a/openjiuwen/harness/rails/evolution/review/materials.py
+++ b/openjiuwen/harness/rails/evolution/review/materials.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from openjiuwen.core.foundation.llm import ImagePart, TextPart
+from openjiuwen.core.foundation.llm.schema.content_part import normalize_content_part
 from openjiuwen.agent_evolving.trajectory.types import (
     TrajectoryLike,
     trajectory_execution_id,
@@ -224,7 +226,15 @@ def _message_content_text(content: Any) -> str:
     if isinstance(content, list):
         parts: list[str] = []
         for item in content:
-            if isinstance(item, dict):
+            part = normalize_content_part(item)
+            if isinstance(part, TextPart):
+                if part.text:
+                    parts.append(part.text)
+            elif isinstance(part, ImagePart):
+                continue
+            elif isinstance(item, dict):
+                # Dialects normalization does not claim keep the original
+                # ``text``/``content``/``value`` probe below.
                 text = item.get("text") or item.get("content") or item.get("value")
                 if text:
                     parts.append(str(text))

--- a/openjiuwen/harness/rails/memory/coding_memory_rail.py
+++ b/openjiuwen/harness/rails/memory/coding_memory_rail.py
@@ -14,6 +14,8 @@ import asyncio
 from typing import Dict, Optional
 
 from openjiuwen.core.common.logging import logger
+from openjiuwen.core.foundation.llm import TextPart
+from openjiuwen.core.foundation.llm.schema.content_part import normalize_content_part
 from openjiuwen.core.foundation.tool.base import ToolCard
 from openjiuwen.core.memory.lite.coding_memory_tool_context import CodingMemoryToolContext
 from openjiuwen.core.memory.lite.config import create_memory_settings
@@ -511,9 +513,9 @@ class CodingMemoryRail(DeepAgentRail):
                 if isinstance(content, list):
                     # 处理多模态内容
                     texts = [
-                        p.get("text", "")
-                        for p in content
-                        if isinstance(p, dict) and p.get("type") == "text"
+                        part.text
+                        for part in (normalize_content_part(p) for p in content)
+                        if isinstance(part, TextPart)
                     ]
                     return " ".join(texts) if texts else None
         

--- a/openjiuwen/harness/rails/memory/external_memory_rail.py
+++ b/openjiuwen/harness/rails/memory/external_memory_rail.py
@@ -8,6 +8,8 @@ import time
 from typing import Dict, Optional
 
 from openjiuwen.core.common.logging import logger
+from openjiuwen.core.foundation.llm import TextPart
+from openjiuwen.core.foundation.llm.schema.content_part import normalize_content_part
 from openjiuwen.core.foundation.tool.base import ToolCard
 from openjiuwen.core.foundation.tool.function.function import LocalFunction
 from openjiuwen.core.single_agent.rail.base import AgentCallbackContext, RunKind
@@ -372,9 +374,9 @@ class ExternalMemoryRail(DeepAgentRail):
                             return content.strip()
                         if isinstance(content, list):
                             texts = [
-                                p.get("text", "") 
-                                for p in content 
-                                if isinstance(p, dict) and p.get("type") == "text" and p.get("text", "").strip()
+                                part.text
+                                for part in (normalize_content_part(p) for p in content)
+                                if isinstance(part, TextPart) and part.text.strip()
                             ]
                             if texts:
                                 return " ".join(texts).strip()

--- a/openjiuwen/harness/rails/security/base_security_rail.py
+++ b/openjiuwen/harness/rails/security/base_security_rail.py
@@ -9,7 +9,8 @@ from enum import Enum
 from typing import Any, Iterable, Optional, Set
 
 from openjiuwen.core.common.logging import logger
-from openjiuwen.core.foundation.llm import ToolMessage
+from openjiuwen.core.foundation.llm import TextPart, ToolMessage
+from openjiuwen.core.foundation.llm.schema.content_part import normalize_content_part
 from openjiuwen.core.foundation.llm.schema.tool_call import ToolCall
 from openjiuwen.core.runner.callback import AbortError
 from openjiuwen.core.session import InteractiveInput
@@ -616,11 +617,12 @@ class BaseSecurityRail(AgentRail):
                 return content
             if isinstance(content, list):
                 parts = []
-                for part in content:
-                    if isinstance(part, str):
-                        parts.append(part)
-                    elif isinstance(part, dict) and "text" in part:
-                        parts.append(str(part["text"]))
+                for item in content:
+                    part = normalize_content_part(item)
+                    if isinstance(part, TextPart):
+                        parts.append(part.text)
+                    elif isinstance(item, dict) and "text" in item:
+                        parts.append(str(item["text"]))
                 return " ".join(parts)
             return str(content)
         if isinstance(msg, dict) and "content" in msg:

--- a/openjiuwen/harness/tools/filesystem.py
+++ b/openjiuwen/harness/tools/filesystem.py
@@ -773,18 +773,23 @@ class ReadFileTool(Tool):
         return max(1, int(encoded_length * 0.125))
 
     @staticmethod
-    def _compress_image(img: Any, size: Tuple[int, int], quality: int) -> Optional[bytes]:
+    def _compress_image(img: Any, size: Tuple[int, int], quality: int) -> Optional[Tuple[bytes, Tuple[int, int]]]:
         """Render an isolated, downsized JPEG copy of an already-decoded PIL image.
 
         `img.convert("RGB")` returns a new image object, so `img` itself is
         never mutated and stays reusable by other compression tiers.
+
+        Returns the encoded bytes together with the pixel dimensions actually
+        produced. `thumbnail` preserves aspect ratio, so the result is rarely
+        exactly `size`, and the caller needs the real numbers to estimate
+        image tokens without decoding the payload a second time.
         """
         try:
             out = io.BytesIO()
             tier = img.convert("RGB")
             tier.thumbnail(size)
             tier.save(out, format="JPEG", quality=quality)
-            return out.getvalue()
+            return out.getvalue(), tier.size
         except (OSError, ValueError) as exc:
             logger.debug("Failed to compress image bytes: %s", exc)
             return None
@@ -804,6 +809,7 @@ class ReadFileTool(Tool):
         image_type = ext.lstrip(".") or "png"
         dimensions: str | None = None
         resized = raw
+        transmitted: Optional[Tuple[int, int]] = None
 
         try:
             from PIL import Image
@@ -817,6 +823,7 @@ class ReadFileTool(Tool):
                     detected_format = (img.format or "PNG").lower()
                     image_type = detected_format  # prefer format detected from buffer
                     dimensions = f"{img.width}x{img.height}"
+                    transmitted = (img.width, img.height)
 
                     # Tier 1: standard resize, same format as the source (thumbnail to 1536×1536).
                     tier1 = img.copy()
@@ -826,19 +833,20 @@ class ReadFileTool(Tool):
                     candidate = out.getvalue()
                     if candidate and len(candidate) < len(raw):
                         resized = candidate
+                        transmitted = tier1.size
 
                     # Tier 2/3: only pay for further compression if tier 1 still busts the budget.
                     # Token budget check uses a byte-length estimate, not a real base64 encode.
                     if self._estimate_base64_tokens(len(resized)) > self.MAX_TOKENS:
                         compressed = self._compress_image(img, size=(800, 800), quality=40)
-                        if compressed and self._estimate_base64_tokens(len(compressed)) <= self.MAX_TOKENS:
-                            resized = compressed
+                        if compressed and self._estimate_base64_tokens(len(compressed[0])) <= self.MAX_TOKENS:
+                            resized, transmitted = compressed
                             image_type = "jpeg"
                         else:
                             # Final fallback: 400×400 JPEG q=20 (mirrors TS Sharp fallback).
                             fallback = self._compress_image(img, size=(400, 400), quality=20)
                             if fallback:
-                                resized = fallback
+                                resized, transmitted = fallback
                                 image_type = "jpeg"
             except (OSError, ValueError) as exc:
                 logger.debug("Failed to parse image metadata (%s): %s", file_path, exc)
@@ -868,17 +876,18 @@ class ReadFileTool(Tool):
         encoded = base64.b64encode(resized).decode("ascii")
         data_url = f"data:{mime_type};base64,{encoded}"
         parts.append("Image bytes are attached as multimodal input and omitted from this tool result.")
+        payload = {
+            "type": "image",
+            "source": "read_file",
+            "source_path": file_path,
+            "mime_type": mime_type,
+            "data_url": data_url,
+        }
+        if transmitted is not None:
+            payload["width"], payload["height"] = transmitted
         return {
             "content": "\n".join(parts),
-            "multimodal": [
-                {
-                    "type": "image",
-                    "source": "read_file",
-                    "source_path": file_path,
-                    "mime_type": mime_type,
-                    "data_url": data_url,
-                }
-            ],
+            "multimodal": [payload],
         }
 
     # ------------------------------------------------------------------

--- a/openjiuwen/harness/tools/mobile_gui/rails/multimodal_context_summarizer_rail.py
+++ b/openjiuwen/harness/tools/mobile_gui/rails/multimodal_context_summarizer_rail.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 from openjiuwen.core.common.logging import logger
+from openjiuwen.core.foundation.llm import ImagePart
+from openjiuwen.core.foundation.llm.schema.content_part import normalize_content_part
 from openjiuwen.core.single_agent.rail.base import (
     AgentCallbackContext,
     AgentRail,
@@ -20,13 +22,15 @@ ARCHIVED_SCREEN_PLACEHOLDER = (
 )
 
 
+def _is_image_block(block) -> bool:
+    """True for an image in any shape ``content`` may hold it."""
+    return isinstance(normalize_content_part(block), ImagePart)
+
+
 def _has_image_url(msg) -> bool:
     if not isinstance(msg.content, list):
         return False
-    return any(
-        isinstance(b, dict) and b.get("type") == "image_url"
-        for b in msg.content
-    )
+    return any(_is_image_block(b) for b in msg.content)
 
 
 def _replace_archived_screenshot_images(msg) -> None:
@@ -35,7 +39,7 @@ def _replace_archived_screenshot_images(msg) -> None:
         return
     next_content: list = []
     for block in msg.content:
-        if isinstance(block, dict) and block.get("type") == "image_url":
+        if _is_image_block(block):
             next_content.append({"type": "text", "text": ARCHIVED_SCREEN_PLACEHOLDER})
         else:
             next_content.append(block)

--- a/openjiuwen/harness/tools/mobile_gui/rails/vlm_grounding_perception_rail.py
+++ b/openjiuwen/harness/tools/mobile_gui/rails/vlm_grounding_perception_rail.py
@@ -12,7 +12,8 @@ from PIL import Image
 
 from openjiuwen.core.common.logging import logger
 from openjiuwen.core.context_engine.context.context_utils import ContextUtils
-from openjiuwen.core.foundation.llm import UserMessage
+from openjiuwen.core.foundation.llm import TextPart, UserMessage
+from openjiuwen.core.foundation.llm.schema.content_part import normalize_content_part
 from openjiuwen.core.single_agent.rail.base import (
     AgentCallbackContext,
     AgentRail,
@@ -316,10 +317,9 @@ class VlmGroundingPerceptionRail(AgentRail):
         if isinstance(content, list):
             parts: list[str] = []
             for block in content:
-                if isinstance(block, str):
-                    parts.append(block)
-                elif isinstance(block, dict) and block.get("type") == "text":
-                    parts.append(str(block.get("text") or ""))
+                part = normalize_content_part(block)
+                if isinstance(part, TextPart):
+                    parts.append(part.text)
             return "\n".join(parts)
         return str(content or "")
 

--- a/openjiuwen/harness/tools/mobile_gui/skill_branch/previous_steps.py
+++ b/openjiuwen/harness/tools/mobile_gui/skill_branch/previous_steps.py
@@ -6,9 +6,12 @@ from __future__ import annotations
 import json
 from typing import Any, List, Optional
 
+from openjiuwen.core.foundation.llm import TextPart
+from openjiuwen.core.foundation.llm.schema.content_part import normalize_content_part
+
 
 def _content_to_text(content: Any) -> str:
-    """Extract text from message content; omit image_url blocks."""
+    """Extract text from message content; omit image blocks."""
     if content is None:
         return ""
     if isinstance(content, str):
@@ -18,17 +21,11 @@ def _content_to_text(content: Any) -> str:
 
     parts: List[str] = []
     for block in content:
-        if isinstance(block, str):
-            parts.append(block)
+        part = normalize_content_part(block)
+        if not isinstance(part, TextPart):
             continue
-        if not isinstance(block, dict):
-            continue
-        if block.get("type") == "image_url":
-            continue
-        if block.get("type") == "text":
-            text = block.get("text")
-            if isinstance(text, str) and text.strip():
-                parts.append(text)
+        if part.text.strip() or isinstance(block, str):
+            parts.append(part.text)
     return "\n".join(parts)
 
 

--- a/openjiuwen/harness/tools/mobile_gui/skill_branch/runner.py
+++ b/openjiuwen/harness/tools/mobile_gui/skill_branch/runner.py
@@ -10,8 +10,15 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from openjiuwen.core.common.logging import logger
-from openjiuwen.core.foundation.llm import AssistantMessage, SystemMessage, UserMessage
+from openjiuwen.core.foundation.llm import (
+    AssistantMessage,
+    ImagePart,
+    SystemMessage,
+    TextPart,
+    UserMessage,
+)
 from openjiuwen.core.foundation.llm.model import Model
+from openjiuwen.core.foundation.llm.schema.content_part import normalize_content_part
 from openjiuwen.harness.tools.mobile_gui.rails.multimodal_skill_read_rail import (
     REFERENCE_IMAGE_NOTE,
     get_mime_type,
@@ -49,10 +56,9 @@ def _assistant_text(response: AssistantMessage) -> str:
     if isinstance(content, list):
         parts: List[str] = []
         for block in content:
-            if isinstance(block, dict) and block.get("type") == "text":
-                text = block.get("text")
-                if isinstance(text, str):
-                    parts.append(text)
+            part = normalize_content_part(block)
+            if isinstance(part, TextPart):
+                parts.append(part.text)
         return "\n".join(parts)
     return str(content)
 
@@ -71,23 +77,28 @@ def _load_image_data_url(entry: SkillImageEntry) -> Optional[str]:
     return f"data:{mime};base64,{b64}"
 
 
-def _build_live_screenshot_blocks(screenshot_b64: str) -> List[dict]:
+def _image_part_from_data_url(data_url: str) -> ImagePart:
+    """Screenshot data URL -> ``ImagePart``, at ``detail:"low"``."""
+    return ImagePart.from_data_url_unchecked(data_url, detail="low")
+
+
+def _build_live_screenshot_blocks(screenshot_b64: str) -> List[Any]:
     if not screenshot_b64:
-        return [{"type": "text", "text": "(no live device screenshot available)"}]
+        return [TextPart(text="(no live device screenshot available)")]
     url = screenshot_b64
     if not url.startswith("data:"):
         url = f"data:image/jpeg;base64,{screenshot_b64}"
     return [
-        {"type": "text", "text": "[CURRENT device screenshot — authoritative for live UI]"},
-        {"type": "image_url", "image_url": {"url": url, "detail": "low"}},
+        TextPart(text="[CURRENT device screenshot — authoritative for live UI]"),
+        _image_part_from_data_url(url),
     ]
 
 
 def _build_reference_blocks(
     entries: List[SkillImageEntry],
     selection: Dict[str, Any],
-) -> List[dict]:
-    blocks: List[dict] = []
+) -> List[Any]:
+    blocks: List[Any] = []
     request_by_id = {
         str(item.get("image_id", "")): item
         for item in (selection.get("requests") or [])
@@ -102,19 +113,16 @@ def _build_reference_blocks(
             continue
         caption = entry.alt or entry.image_id
         blocks.append(
-            {
-                "type": "text",
-                "text": "\n".join(
+            TextPart(
+                text="\n".join(
                     [
                         REFERENCE_IMAGE_NOTE.format(caption=caption),
                         f"Selection reason: {reason or '(none)'}",
                     ]
-                ),
-            }
+                )
+            )
         )
-        blocks.append(
-            {"type": "image_url", "image_url": {"url": data_url, "detail": "low"}}
-        )
+        blocks.append(_image_part_from_data_url(data_url))
     return blocks
 
 
@@ -158,7 +166,7 @@ async def run_skill_branch(
             SystemMessage(content=build_stage1_system_message(max_images=max_images)),
             UserMessage(
                 content=[
-                    {"type": "text", "text": user_parts},
+                    TextPart(text=user_parts),
                     *_build_live_screenshot_blocks(live_screenshot_b64),
                 ]
             ),
@@ -220,8 +228,8 @@ async def run_skill_branch(
         if stage2_feedback:
             user_parts += "\n\nFeedback:\n" + "\n".join(f"- {f}" for f in stage2_feedback)
 
-        content_blocks: List[dict] = [
-            {"type": "text", "text": user_parts},
+        content_blocks: List[Any] = [
+            TextPart(text=user_parts),
             *_build_live_screenshot_blocks(live_screenshot_b64),
         ]
         content_blocks.extend(_build_reference_blocks(manifest, stage1_decision))

--- a/tests/unit_tests/agent/react_agent/test_multimodal_tool_results.py
+++ b/tests/unit_tests/agent/react_agent/test_multimodal_tool_results.py
@@ -1,5 +1,11 @@
 # coding: utf-8
 
+from openjiuwen.core.foundation.llm import ImagePart, TextPart
+from openjiuwen.core.foundation.llm.model_clients.anthropic_model_client import (
+    AnthropicModelClient,
+    _convert_message_schemas,
+)
+from openjiuwen.core.foundation.llm.model_clients.base_model_client import BaseModelClient
 from openjiuwen.core.single_agent.ability_manager import AbilityManager
 from openjiuwen.core.single_agent.agents.react_agent import ReActAgent
 from openjiuwen.harness.tools.base_tool import ToolOutput
@@ -41,14 +47,90 @@ def test_react_agent_builds_multimodal_user_message_from_tool_result() -> None:
 
     assert len(messages) == 1
     assert messages[0].role == "user"
-    assert messages[0].content[0] == {
-        "type": "text",
-        "text": "Image loaded from tool: /tmp/a.png",
-    }
-    assert messages[0].content[1] == {
+    assert isinstance(messages[0].content[0], TextPart)
+    assert messages[0].content[1] == ImagePart(mime_type="image/png", data="abc")
+
+
+def test_multimodal_message_content_is_image_part() -> None:
+    """The payload's ``data_url`` becomes a typed part, not a raw dict."""
+    result = ToolOutput(
+        success=True,
+        data={
+            "content": "Image file read: /tmp/a.png",
+            "multimodal": [
+                {
+                    "type": "image",
+                    "source_path": "/tmp/a.png",
+                    "mime_type": "image/png",
+                    "data_url": "data:image/png;base64,abc",
+                    "width": 640,
+                    "height": 480,
+                }
+            ],
+        },
+    )
+
+    message = ReActAgent._build_multimodal_tool_results_message([result])
+
+    image = message.content[1]
+    assert isinstance(image, ImagePart)
+    assert image.mime_type == "image/png"
+    assert image.data == "abc"
+    # Dimensions ride along so token estimation does not fall back to a constant.
+    assert (image.width, image.height) == (640, 480)
+
+
+def test_multimodal_message_survives_all_client_renders() -> None:
+    """Every provider must render the produced message into its own dialect."""
+    result = ToolOutput(
+        success=True,
+        data={
+            "content": "Image file read: /tmp/a.png",
+            "multimodal": [
+                {
+                    "type": "image",
+                    "source_path": "/tmp/a.png",
+                    "data_url": "data:image/png;base64,abc",
+                }
+            ],
+        },
+    )
+    message = ReActAgent._build_multimodal_tool_results_message([result])
+
+    openai_content = BaseModelClient._convert_messages_to_dict([message])[0]["content"]
+    assert openai_content[1] == {
         "type": "image_url",
         "image_url": {"url": "data:image/png;base64,abc"},
     }
+
+    anthropic_payload = AnthropicModelClient._convert_messages_to_dict([message])
+    _, anthropic_messages = _convert_message_schemas(anthropic_payload)
+    assert anthropic_messages[0]["content"][1] == {
+        "type": "image",
+        "source": {"type": "base64", "media_type": "image/png", "data": "abc"},
+    }
+
+
+def test_multimodal_message_text_reads_back() -> None:
+    """``.text`` must skip the image and keep the caption."""
+    result = ToolOutput(
+        success=True,
+        data={
+            "content": "Image file read: /tmp/a.png",
+            "multimodal": [
+                {
+                    "type": "image",
+                    "source": "read_file",
+                    "source_path": "/tmp/a.png",
+                    "data_url": "data:image/png;base64,abc",
+                }
+            ],
+        },
+    )
+
+    message = ReActAgent._build_multimodal_tool_results_message([result])
+
+    assert message.text == "Image loaded from read_file: /tmp/a.png"
 
 
 def test_react_agent_batches_multiple_multimodal_tool_results_into_one_user_message() -> None:
@@ -84,17 +166,11 @@ def test_react_agent_batches_multiple_multimodal_tool_results_into_one_user_mess
     assert message is not None
     assert message.role == "user"
     assert len(message.content) == 5
-    assert message.content[0]["type"] == "text"
-    assert "/tmp/a.png" in message.content[0]["text"]
-    assert "/tmp/b.jpg" in message.content[0]["text"]
-    assert message.content[2] == {
-        "type": "image_url",
-        "image_url": {"url": "data:image/png;base64,aaa"},
-    }
-    assert message.content[4] == {
-        "type": "image_url",
-        "image_url": {"url": "data:image/jpeg;base64,bbb"},
-    }
+    assert isinstance(message.content[0], TextPart)
+    assert "/tmp/a.png" in message.content[0].text
+    assert "/tmp/b.jpg" in message.content[0].text
+    assert message.content[2] == ImagePart(mime_type="image/png", data="aaa")
+    assert message.content[4] == ImagePart(mime_type="image/jpeg", data="bbb")
 
 
 def test_react_agent_labels_mcp_sourced_images() -> None:
@@ -118,14 +194,29 @@ def test_react_agent_labels_mcp_sourced_images() -> None:
     messages = ReActAgent._build_multimodal_tool_result_messages(result)
 
     assert len(messages) == 1
-    assert messages[0].content[0] == {
-        "type": "text",
-        "text": "Image loaded from mcp: get_window_state",
-    }
-    assert messages[0].content[1] == {
-        "type": "image_url",
-        "image_url": {"url": "data:image/png;base64,abc"},
-    }
+    assert messages[0].content[0] == TextPart(text="Image loaded from mcp: get_window_state")
+    assert messages[0].content[1] == ImagePart(mime_type="image/png", data="abc")
+
+
+def test_multimodal_image_without_a_source_falls_back_to_a_generic_label() -> None:
+    """Only ``read_file``/MCP stamp ``source`` today; a third producer must not be mislabelled."""
+    result = ToolOutput(
+        success=True,
+        data={
+            "content": "Image file read: /tmp/a.png",
+            "multimodal": [
+                {
+                    "type": "image",
+                    "source_path": "/tmp/a.png",
+                    "data_url": "data:image/png;base64,abc",
+                }
+            ],
+        },
+    )
+
+    message = ReActAgent._build_multimodal_tool_results_message([result])
+
+    assert message.content[0] == TextPart(text="Image loaded from tool: /tmp/a.png")
 
 
 def test_tool_message_content_uses_mcp_tool_result_content() -> None:
@@ -205,3 +296,26 @@ def test_react_agent_does_not_treat_audio_error_as_image_unsupported() -> None:
     exc = RuntimeError("Error code: 400 - Only text and image_url are supported.")
 
     assert ReActAgent._is_image_input_unsupported_error(exc) is False
+
+
+def test_non_base64_data_url_is_carried_as_a_url() -> None:
+    """A non-base64 attachment reached the provider before; it still must."""
+    result = ToolOutput(
+        success=True,
+        data={
+            "content": "Image file read: /tmp/a.svg",
+            "multimodal": [
+                {
+                    "type": "image",
+                    "source_path": "/tmp/a.svg",
+                    "data_url": "data:image/svg+xml,%3Csvg%2F%3E",
+                }
+            ],
+        },
+    )
+
+    message = ReActAgent._build_multimodal_tool_results_message([result])
+
+    image = message.content[1]
+    assert image.data is None
+    assert image.url == "data:image/svg+xml,%3Csvg%2F%3E"

--- a/tests/unit_tests/core/context_engine/test_forked_message_offloader.py
+++ b/tests/unit_tests/core/context_engine/test_forked_message_offloader.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 
+import base64
 import glob
 import json
 import os
@@ -737,3 +738,103 @@ class TestMessageOffloaderTtl:
         restored.load_state({"test_ctx": context.save_state()})
 
         assert restored.last_context_window_access_at() == 100.0
+
+
+def _openai_image_block() -> dict:
+    """The shape a multimodal tool result carries today."""
+    data_url = "data:image/png;base64," + base64.b64encode(b"\x89PNG\r\n\x1a\n" + b"\xa5" * 4096).decode("ascii")
+    return {"type": "image_url", "image_url": {"url": data_url}}
+
+
+class TestListContentIsNeverOffloaded:
+    """The §5 decision-3 rule, in the fork's own copy of the predicate.
+
+    The fork shares no code with the official offloader, so the rule has to be
+    asserted twice or it can drift on one side only.
+    """
+
+    @pytest.mark.asyncio
+    async def test_offload_list_content_does_not_raise(self):
+        """Defect C: the head/tail preview used to slice list content as a list.
+
+        That produced no ``TypeError``, only a preview built from the repr of
+        the remaining elements — worse than a crash, because it is silent.
+        """
+        context = await create_context()
+        processor = context._processors[0]
+        message = ToolMessage(
+            tool_call_id="tc-1",
+            content=["a long tool result " * 500, _openai_image_block()],
+        )
+
+        offloaded = await processor._offload_message(message, context, original_message=message)
+
+        assert isinstance(offloaded, OffloadMixin)
+        preview = offloaded.content.split("[[OFFLOAD:")[0]
+        assert preview.startswith("a long tool result ")
+        assert "image_url" not in preview, "the base64 image must not leak into the preview"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "content",
+        [
+            pytest.param(["x" * 200, _openai_image_block()], id="with-image"),
+            pytest.param(["x" * 200, "y" * 200], id="text-only-list"),
+        ],
+    )
+    async def test_list_content_is_never_offloaded(self, content):
+        """Text-only lists are excluded too — the rule is not image-specific."""
+        counter = _metadata_token_counter()
+        context = await create_context(context_window_tokens=100, token_counter=counter)
+
+        await context.add_messages(
+            ToolMessage(content=content, tool_call_id="tc-1", metadata={"test_token_count": 11})
+        )
+
+        message = context.get_messages()[0]
+        assert not isinstance(message, OffloadMixin)
+        assert message.content == content
+
+    @pytest.mark.asyncio
+    async def test_list_content_not_offloaded_even_when_role_is_eligible(self):
+        """Not merely a side effect of the message failing some other check.
+
+        The same ``ToolMessage``, at the same token count, differing only in
+        whether its content is a list, must be offloaded.
+        """
+        counter = _metadata_token_counter()
+        context = await create_context(context_window_tokens=100, token_counter=counter)
+
+        await context.add_messages(
+            [
+                ToolMessage(
+                    content=["describe this", _openai_image_block()],
+                    tool_call_id="tc-list",
+                    metadata={"test_token_count": 11},
+                ),
+                ToolMessage(
+                    content="describe this",
+                    tool_call_id="tc-str",
+                    metadata={"test_token_count": 11},
+                ),
+            ]
+        )
+
+        messages = context.get_messages()
+        assert not isinstance(messages[0], OffloadMixin), "image message must be kept"
+        assert isinstance(messages[1], OffloadMixin), "the message really is eligible"
+
+    @pytest.mark.asyncio
+    async def test_str_content_offload_behavior_unchanged(self):
+        """Regression guard for the ``.content`` -> ``.text`` substitution."""
+        counter = _metadata_token_counter()
+        context = await create_context(context_window_tokens=100, token_counter=counter)
+        content = "".join(str(index % 10) for index in range(5000))
+
+        await context.add_messages(
+            ToolMessage(content=content, tool_call_id="tc-1", metadata={"test_token_count": 11})
+        )
+
+        message = context.get_messages()[0]
+        assert isinstance(message, OffloadMixin)
+        assert _offloaded_content(message) == content

--- a/tests/unit_tests/core/context_engine/test_message_offloader.py
+++ b/tests/unit_tests/core/context_engine/test_message_offloader.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 # Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
 
+import base64
 from unittest.mock import MagicMock
 from typing import List
 
@@ -9,6 +10,7 @@ import pytest
 from openjiuwen.core.common.exception.errors import BaseError
 from openjiuwen.core.context_engine import ContextEngine, ContextEngineConfig
 from openjiuwen.core.context_engine.processor.offloader.message_offloader import (
+    MessageOffloader,
     MessageOffloaderConfig,
     OMIT_STRING,
 )
@@ -687,3 +689,122 @@ class TestMessageOffloader:
         tool_msg = result[2]
         assert not isinstance(tool_msg, OffloadMixin)
         assert tool_msg.content == long_content
+
+
+def _openai_image_block() -> dict:
+    """The shape a multimodal tool result carries today."""
+    data_url = "data:image/png;base64," + base64.b64encode(b"\x89PNG\r\n\x1a\n" + b"\xa5" * 4096).decode("ascii")
+    return {"type": "image_url", "image_url": {"url": data_url}}
+
+
+class TestListContentIsNeverOffloaded:
+    """The §5 decision-3 rule, made explicit by ``_is_offloadable_content``.
+
+    Before this stage the exclusion was an accident of an unnamed
+    ``isinstance(content, str)`` check, which the ``.text`` migration would
+    have removed — silently making image-bearing messages offloadable.
+    """
+
+    @pytest.mark.asyncio
+    async def test_offload_list_content_does_not_raise(self):
+        """Defect C: ``content[:n] + OMIT_STRING`` used to raise ``TypeError``.
+
+        The guard means production never reaches here with list content, so
+        this covers the direct call only — a latent crash removed, not a
+        behavior change.
+        """
+        engine = ContextEngine(ContextEngineConfig(default_window_message_num=100))
+        ctx = await engine.create_context("list_content_ctx", None, history_messages=[])
+        offloader = MessageOffloader(
+            MessageOffloaderConfig(trim_size=100, large_message_threshold=1000)
+        )
+        message = ToolMessage(
+            tool_call_id="tc-1",
+            content=["a long tool result " * 200, _openai_image_block()],
+        )
+
+        offloaded = await offloader._offload_message(message, ctx)
+
+        assert isinstance(offloaded, OffloadMixin)
+        preview = offloaded.content.split("[[OFFLOAD:")[0]
+        assert preview == ("a long tool result " * 200)[:100] + OMIT_STRING
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "content",
+        [
+            pytest.param(["x" * 200, _openai_image_block()], id="with-image"),
+            pytest.param(["x" * 200, "y" * 200], id="text-only-list"),
+        ],
+    )
+    async def test_list_content_is_never_offloaded(self, content):
+        """Text-only lists are excluded too — the rule is not image-specific."""
+        config = MessageOffloaderConfig(
+            messages_threshold=1,
+            large_message_threshold=30,
+            trim_size=10,
+            offload_message_type=["tool"],
+            messages_to_keep=None,
+            keep_last_round=False,
+        )
+        ctx = await create_context_with_offloader(config)
+
+        await ctx.add_messages(
+            [UserMessage(content="u"), ToolMessage(content=content, tool_call_id="tc-1")]
+        )
+
+        tool_msg = ctx.get_messages()[1]
+        assert not isinstance(tool_msg, OffloadMixin)
+        assert tool_msg.content == content
+
+    @pytest.mark.asyncio
+    async def test_list_content_not_offloaded_even_when_role_is_eligible(self):
+        """Not merely a side effect of ``"user"`` being absent from the default roles."""
+        config = MessageOffloaderConfig(
+            messages_threshold=1,
+            large_message_threshold=30,
+            trim_size=10,
+            offload_message_type=["user"],
+            messages_to_keep=None,
+            keep_last_round=False,
+        )
+        ctx = await create_context_with_offloader(config)
+
+        await ctx.add_messages(
+            [
+                UserMessage(content=["describe this", _openai_image_block()]),
+                UserMessage(content="x" * 200),
+            ]
+        )
+
+        messages = ctx.get_messages()
+        assert not isinstance(messages[0], OffloadMixin), "image message must be kept"
+        assert isinstance(messages[1], OffloadMixin), "the role really is eligible"
+
+    @pytest.mark.asyncio
+    async def test_str_content_offload_behavior_unchanged(self):
+        """Regression guard for the ``.content`` -> ``.text`` substitution.
+
+        ``.text`` returns ``str`` content unchanged, so the trim must stay
+        byte-identical — this is the half of the change that touches every
+        existing caller.
+        """
+        config = MessageOffloaderConfig(
+            messages_threshold=1,
+            large_message_threshold=30,
+            trim_size=10,
+            offload_message_type=["tool"],
+            messages_to_keep=None,
+            keep_last_round=False,
+        )
+        ctx = await create_context_with_offloader(config)
+        long_content = "".join(str(i % 10) for i in range(200))
+
+        await ctx.add_messages(
+            [UserMessage(content="u"), ToolMessage(content=long_content, tool_call_id="tc-1")]
+        )
+
+        offload_msg = ctx.get_messages()[1]
+        assert isinstance(offload_msg, OffloadMixin)
+        assert offload_msg.content.split("[[OFFLOAD:")[0] == long_content[:10] + OMIT_STRING
+        assert_offload_saved(ctx, offload_msg, long_content)

--- a/tests/unit_tests/core/context_engine/test_round_level_compressor.py
+++ b/tests/unit_tests/core/context_engine/test_round_level_compressor.py
@@ -396,3 +396,60 @@ class TestRoundLevelCompressor:
         assert "完成自己负责的任务 #99，备注：done and verified [member_complete_task]" in second_messages[1].content
         assert "Task #99 completed" in second_messages[1].content
         assert "42" not in second_messages[1].content
+
+
+class TestRawFallbackWithListContent:
+    """Stage 5 removed the ``isinstance(response.content, str)`` guard here.
+
+    The guard silently discarded a usable summary whenever the compression
+    model answered with content parts: no fallback replacement was built, the
+    phase reported "no valid replacements", and compression stalled. ``.text``
+    reads either shape, so the guard has nothing left to protect against.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "content",
+        [
+            pytest.param("plain summary text", id="str"),
+            pytest.param([{"type": "text", "text": "plain summary text"}], id="list"),
+        ],
+    )
+    async def test_fallback_replacement_with_list_content(self, content):
+        compressor = RoundLevelCompressor(RoundLevelCompressorConfig(target_total_tokens=50))
+        target = _CompressTarget(
+            block_id="b1",
+            scope="mixed_context",
+            start_idx=0,
+            end_idx=1,
+            messages=[UserMessage(content="q"), AssistantMessage(content="a")],
+        )
+        context = MagicMock()
+
+        model = MagicMock()
+        model.invoke = AsyncMock(return_value=AssistantMessage(content=content))
+        compressor._get_model = MagicMock(return_value=model)
+        compressor._record_compression_usage = MagicMock()
+        compressor._prepare_round_compression_messages = MagicMock(
+            return_value=[UserMessage(content="compress this")]
+        )
+        compressor._build_json_replacements = AsyncMock(return_value=[])
+        compressor._is_replacement_under_budget = MagicMock(return_value=True)
+        compressor._has_compression_benefit = MagicMock(return_value=True)
+        compressor._count_context_window_tokens = MagicMock(return_value=0)
+
+        updated = await compressor._apply_llm_phase(
+            list(target.messages),
+            context,
+            system_messages=[],
+            tools=[],
+            targets=[target],
+            target_tokens=50,
+            aggressive=False,
+            phase_name="test_phase",
+            keep_recent_messages=0,
+        )
+
+        assert updated is not None, "the raw fallback must be built from either content shape"
+        assert ROUND_LEVEL_FALLBACK_MARKER in updated[0].content
+        assert "plain summary text" in updated[0].content

--- a/tests/unit_tests/core/context_engine/test_tiktoken_counter.py
+++ b/tests/unit_tests/core/context_engine/test_tiktoken_counter.py
@@ -14,11 +14,21 @@ import base64
 import json
 import random
 
+import pytest
+
 from openjiuwen.core.context_engine.token.tiktoken_counter import (
     DEFAULT_IMAGE_PLACEHOLDER_TOKENS,
     TiktokenCounter,
 )
-from openjiuwen.core.foundation.llm import AssistantMessage, UserMessage
+from openjiuwen.core.foundation.llm import (
+    AssistantMessage,
+    ImagePart,
+    SystemMessage,
+    TextPart,
+    ToolMessage,
+    UserMessage,
+)
+from openjiuwen.core.foundation.llm.schema.tool_call import ToolCall
 
 # A 200 KB payload that decodes to non-image bytes: exercises the
 # unparseable-payload fallback. The bytes are seeded-random rather than a run
@@ -245,3 +255,173 @@ def test_plain_string_paths_unchanged_and_tool_calls_still_priced() -> None:
         ]
     )
     assert with_calls > bare
+
+
+# ---------------------------------------------------------------------------
+# Typed content parts
+#
+# ``BaseMessage.content`` also accepts ``ContentPart`` instances. A part and the
+# raw dialect it normalizes from describe the same payload, so the counter must
+# price them identically — otherwise the estimate would depend on which
+# producer happened to build the message.
+# ---------------------------------------------------------------------------
+
+
+def _envelope() -> int:
+    """Cost of an empty user message: subtract to isolate a block's own tokens."""
+    return _counter().count_messages([UserMessage(content="")])
+
+
+@pytest.mark.parametrize(
+    "messages, expected",
+    [
+        ([UserMessage(content="Hello, world!")], 18),
+        (
+            [
+                SystemMessage(content="You are a helpful assistant."),
+                UserMessage(content="What is the weather in Paris?"),
+                AssistantMessage(content="Let me check."),
+            ],
+            53,
+        ),
+        ([ToolMessage(tool_call_id="call-1", content="sunny")], 17),
+        ([UserMessage(content="你好，世界")], 21),
+        ([UserMessage(content="")], 15),
+    ],
+)
+def test_text_only_counts_match_pre_refactor_values(messages, expected) -> None:
+    """Golden values captured before parts existed.
+
+    Image counting may move; text counting may not, or every compression
+    threshold in the repo shifts silently.
+    """
+    assert _counter().count_messages(messages) == expected
+
+
+def test_image_part_is_priced_by_dimensions_not_payload() -> None:
+    part = ImagePart(mime_type="image/png", data="A" * 200_000, width=800, height=600)
+
+    tokens = _counter().count_messages([UserMessage(content=[part])]) - _envelope()
+
+    # 200KB of base64 counted as text would be tens of thousands of tokens.
+    assert 0 < tokens < 2_000
+
+
+def test_image_part_tokens_scale_with_dimensions() -> None:
+    counter = _counter()
+    small = ImagePart(mime_type="image/png", data="A" * 64, width=200, height=200)
+    large = ImagePart(mime_type="image/png", data="A" * 64, width=1600, height=1200)
+
+    assert counter.count_messages([UserMessage(content=[small])]) < counter.count_messages(
+        [UserMessage(content=[large])]
+    )
+
+
+def test_image_part_without_stamped_dimensions_sniffs_the_payload() -> None:
+    """The bridge into the dict estimators: a part still gets header sniffing."""
+    counter = _counter()
+    sniffed = ImagePart.from_data_url(_png_data_url(800, 600))
+    stamped = ImagePart.from_data_url(_png_data_url(800, 600))
+    stamped.width, stamped.height = 800, 600
+
+    assert counter.count_messages([UserMessage(content=[sniffed])]) == counter.count_messages(
+        [UserMessage(content=[stamped])]
+    )
+
+
+def test_image_part_with_unreadable_payload_costs_flat_fallback() -> None:
+    part = ImagePart(mime_type="image/png", data="A" * 512)
+
+    assert _counter().count_messages([UserMessage(content=[part])]) - _envelope() == (
+        DEFAULT_IMAGE_PLACEHOLDER_TOKENS
+    )
+
+
+def test_image_part_respects_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("TIKTOKEN_IMAGE_PLACEHOLDER_TOKENS", "42")
+    part = ImagePart(mime_type="image/png", data="A" * 512)
+
+    assert _counter().count_messages([UserMessage(content=[part])]) - _envelope() == 42
+
+
+@pytest.mark.parametrize("raw", ["", "   ", "not-a-number", "0", "-5"])
+def test_invalid_env_override_falls_back_to_the_default(monkeypatch, raw) -> None:
+    monkeypatch.setenv("TIKTOKEN_IMAGE_PLACEHOLDER_TOKENS", raw)
+    part = ImagePart(mime_type="image/png", data="A" * 512)
+
+    assert _counter().count_messages([UserMessage(content=[part])]) - _envelope() == (
+        DEFAULT_IMAGE_PLACEHOLDER_TOKENS
+    )
+
+
+def test_dict_and_part_shapes_agree() -> None:
+    """The legacy OpenAI block and the part it normalizes to cost the same."""
+    counter = _counter()
+    data_url = _png_data_url(800, 600)
+    dict_shape = UserMessage(content=[{"type": "image_url", "image_url": {"url": data_url}}])
+    part_shape = UserMessage(content=[ImagePart.from_data_url(data_url)])
+
+    assert counter.count_messages([dict_shape]) == counter.count_messages([part_shape])
+
+
+def test_text_parts_are_joined_and_image_priced_separately() -> None:
+    counter = _counter()
+    image = ImagePart(mime_type="image/png", data="A" * 64, width=800, height=600)
+    mixed = UserMessage(content=[TextPart(text="look at"), image, TextPart(text="this")])
+
+    total = counter.count_messages([mixed])
+    text_only = counter.count_messages([UserMessage(content="look at\nthis")])
+    image_only = counter.count_messages([UserMessage(content=[image])]) - _envelope()
+
+    assert total == text_only + image_only
+
+
+def test_bare_str_items_are_counted_as_text() -> None:
+    counter = _counter()
+
+    assert counter.count_messages([UserMessage(content=["a", "b"])]) == counter.count_messages(
+        [UserMessage(content="a\nb")]
+    )
+
+
+def test_untyped_dashscope_dialects_keep_their_pricing() -> None:
+    """``{"image"}``/``{"text"}`` carry no ``type``, so normalization skips them."""
+    counter = _counter()
+    message = UserMessage(content=[{"text": "hi"}, {"image": "https://example.invalid/a.png"}])
+
+    total = counter.count_messages([message])
+    text_only = counter.count_messages([UserMessage(content="hi")])
+
+    assert total - text_only == DEFAULT_IMAGE_PLACEHOLDER_TOKENS
+
+
+def test_non_str_non_dict_item_still_contributes() -> None:
+    """Nothing in the list may silently drop out of the count.
+
+    The schema rejects such an item at construction, but ``BaseMessage`` does
+    not enable ``validate_assignment``, so it can still arrive here.
+    """
+    counter = _counter()
+    message = UserMessage(content=[])
+    message.content = [123]  # type: ignore[list-item]
+
+    assert counter.count_messages([message]) == counter.count_messages([UserMessage(content="123")])
+
+
+def test_empty_list_content_counts_like_empty_text() -> None:
+    counter = _counter()
+
+    assert counter.count_messages([UserMessage(content=[])]) == counter.count_messages(
+        [UserMessage(content="")]
+    )
+
+
+def test_assistant_tool_calls_still_counted_with_list_content() -> None:
+    counter = _counter()
+    call = ToolCall(id="call-1", type="function", name="f", arguments="{}")
+    with_calls = counter.count_messages(
+        [AssistantMessage(content=[TextPart(text="hi")], tool_calls=[call])]
+    )
+    without_calls = counter.count_messages([AssistantMessage(content=[TextPart(text="hi")])])
+
+    assert with_calls > without_calls

--- a/tests/unit_tests/core/foundation/llm/test_anthropic_model_client.py
+++ b/tests/unit_tests/core/foundation/llm/test_anthropic_model_client.py
@@ -8,12 +8,17 @@ normalization, and usage extraction. Network/SDK paths (invoke/stream)
 are covered separately and require the optional ``anthropic`` SDK.
 """
 
+import base64
 from unittest.mock import MagicMock
 
 from openjiuwen.core.foundation.llm import (
+    ImagePart,
     ModelClientConfig,
     ModelRequestConfig,
     ProviderType,
+    TextPart,
+    ToolMessage,
+    UserMessage,
 )
 from openjiuwen.core.foundation.llm.model_clients.anthropic_model_client import (
     AnthropicModelClient,
@@ -491,3 +496,103 @@ class TestSamplingParams:
         params = self._params(client, top_p=1.0)
         assert "top_p" not in params
         assert "temperature" not in params
+
+
+# ---------------------------------------------------------------------------
+# G. Part rendering: _render_parts
+# ---------------------------------------------------------------------------
+
+
+_PNG_MIME = "image/png"
+_PAYLOAD = base64.b64encode(b"\x89PNG\r\n\x1a\nfake-pixels").decode("ascii")
+_DATA_URL = f"data:{_PNG_MIME};base64,{_PAYLOAD}"
+
+
+def _anthropic_content(message) -> list:
+    """Convert one message the way ``_build_request_params`` does."""
+    payload = AnthropicModelClient._convert_messages_to_dict([message])
+    _, messages = _convert_message_schemas(payload)
+    return messages[0]["content"]
+
+
+class TestRenderParts:
+    """Anthropic speaks ``source`` blocks, not OpenAI's ``image_url``."""
+
+    def test_image_part_renders_as_base64_source_block(self):
+        message = UserMessage(content=[ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD)])
+
+        assert _anthropic_content(message) == [
+            {"type": "image", "source": {"type": "base64", "media_type": _PNG_MIME, "data": _PAYLOAD}}
+        ]
+
+    def test_image_part_with_url_renders_as_url_source(self):
+        message = UserMessage(
+            content=[ImagePart(mime_type=_PNG_MIME, url="https://example.invalid/a.png")]
+        )
+
+        assert _anthropic_content(message) == [
+            {"type": "image", "source": {"type": "url", "url": "https://example.invalid/a.png"}}
+        ]
+
+    def test_openai_image_block_is_translated(self):
+        """The dialect producers emit today must not reach the API verbatim."""
+        message = UserMessage(content=[{"type": "image_url", "image_url": {"url": _DATA_URL}}])
+
+        blocks = _anthropic_content(message)
+
+        assert blocks[0]["type"] == "image"
+        assert blocks[0]["source"]["data"] == _PAYLOAD
+
+    def test_text_and_image_keep_their_order(self):
+        message = UserMessage(
+            content=[TextPart(text="describe"), ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD)]
+        )
+
+        assert [block["type"] for block in _anthropic_content(message)] == ["text", "image"]
+
+    def test_single_text_part_is_not_collapsed_to_a_string(self):
+        """The base class collapses to ``str``; Anthropic always wants blocks."""
+        assert _anthropic_content(UserMessage(content=[TextPart(text="hi")])) == [
+            {"type": "text", "text": "hi"}
+        ]
+
+    def test_empty_text_parts_are_dropped(self):
+        """The Messages API rejects text blocks whose content is empty."""
+        message = UserMessage(content=["a", "", "b"])
+
+        assert _anthropic_content(message) == [
+            {"type": "text", "text": "a"},
+            {"type": "text", "text": "b"},
+        ]
+
+    def test_unknown_dict_passes_through(self):
+        unknown = {"type": "video_url", "video_url": {"url": "x"}}
+        message = UserMessage(content=[TextPart(text="a"), unknown])
+
+        assert _anthropic_content(message)[1] == unknown
+
+    def test_image_in_tool_result_renders_correctly(self):
+        message = ToolMessage(
+            tool_call_id="call_1",
+            content=[TextPart(text="here"), ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD)],
+        )
+
+        blocks = _anthropic_content(message)
+
+        assert blocks[0]["type"] == "tool_result"
+        assert blocks[0]["tool_use_id"] == "call_1"
+        assert [b["type"] for b in blocks[0]["content"]] == ["text", "image"]
+
+    def test_cache_control_marks_last_block_with_image_present(self):
+        """``_mark_cache_control`` must still land on the true final block."""
+        message = UserMessage(
+            content=[TextPart(text="describe"), ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD)]
+        )
+        payload = AnthropicModelClient._convert_messages_to_dict([message])
+        _, messages = _convert_message_schemas(payload)
+
+        _apply_messages_cache_breakpoint(messages, exclude_tail=False)
+
+        blocks = messages[0]["content"]
+        assert "cache_control" not in blocks[0]
+        assert _is_5m_ephemeral(blocks[-1]["cache_control"])

--- a/tests/unit_tests/core/foundation/llm/test_content_parts.py
+++ b/tests/unit_tests/core/foundation/llm/test_content_parts.py
@@ -1,0 +1,198 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Tests for the provider-neutral content part schema.
+
+Covers the part models themselves. Their interaction with ``BaseMessage`` is
+covered in ``test_message_content_normalization.py``.
+"""
+
+import base64
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from openjiuwen.core.common.exception.errors import BaseError
+from openjiuwen.core.foundation.llm import ContentPart, ImagePart, TextPart
+from openjiuwen.core.foundation.llm.schema.content_part import DEFAULT_IMAGE_TOKENS
+
+_PNG_MIME = "image/png"
+_PAYLOAD = base64.b64encode(b"\x89PNG\r\n\x1a\nfake-pixels").decode("ascii")
+_DATA_URL = f"data:{_PNG_MIME};base64,{_PAYLOAD}"
+
+
+class TestConstruction:
+    def test_text_part_requires_text(self):
+        with pytest.raises(ValidationError):
+            TextPart()
+
+    def test_image_part_requires_mime_type(self):
+        with pytest.raises(ValidationError):
+            ImagePart(data=_PAYLOAD)
+
+    def test_image_part_rejects_both_data_and_url(self):
+        with pytest.raises(ValidationError, match="exactly one"):
+            ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD, url="https://example.invalid/a.png")
+
+    def test_image_part_rejects_neither(self):
+        with pytest.raises(ValidationError, match="exactly one"):
+            ImagePart(mime_type=_PNG_MIME)
+
+    def test_type_discriminators_are_defaulted(self):
+        assert TextPart(text="x").type == "text"
+        assert ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD).type == "image"
+
+
+class TestDiscriminator:
+    def test_unknown_type_reports_against_matching_branch_only(self):
+        """The discriminator must not report a failure from every union member."""
+        adapter = TypeAdapter(ContentPart)
+
+        with pytest.raises(ValidationError) as excinfo:
+            adapter.validate_python({"type": "image", "text": "not an image"})
+
+        errors = excinfo.value.errors()
+        assert all(error["loc"][0] == "image" for error in errors), errors
+        assert any("mime_type" in error["loc"] for error in errors), errors
+
+    def test_unknown_tag_names_the_allowed_tags(self):
+        adapter = TypeAdapter(ContentPart)
+
+        with pytest.raises(ValidationError) as excinfo:
+            adapter.validate_python({"type": "audio", "url": "https://example.invalid/a.mp3"})
+
+        assert "union_tag_invalid" in str(excinfo.value)
+
+
+class TestDataUrl:
+    def test_from_data_url_roundtrip(self):
+        part = ImagePart.from_data_url(_DATA_URL)
+
+        assert part.mime_type == _PNG_MIME
+        assert part.data == _PAYLOAD
+        assert part.url is None
+        assert part.to_data_url() == _DATA_URL
+
+    def test_from_data_url_accepts_field_overrides(self):
+        part = ImagePart.from_data_url(_DATA_URL, detail="low", width=64, height=32)
+
+        assert (part.detail, part.width, part.height) == ("low", 64, 32)
+
+    def test_from_data_url_rejects_non_data_scheme(self):
+        with pytest.raises(BaseError, match="data:"):
+            ImagePart.from_data_url("https://example.invalid/a.png")
+
+    def test_from_data_url_rejects_missing_base64_marker(self):
+        with pytest.raises(BaseError, match="base64"):
+            ImagePart.from_data_url("data:image/png,raw-bytes")
+
+    def test_from_data_url_rejects_malformed_base64(self):
+        with pytest.raises(BaseError, match="valid base64"):
+            ImagePart.from_data_url("data:image/png;base64,!!!not-base64!!!")
+
+    def test_from_data_url_rejects_missing_media_type(self):
+        with pytest.raises(BaseError, match="media type"):
+            ImagePart.from_data_url(f"data:;base64,{_PAYLOAD}")
+
+    def test_to_data_url_rejects_url_backed_part(self):
+        part = ImagePart(mime_type=_PNG_MIME, url="https://example.invalid/a.png")
+
+        with pytest.raises(BaseError, match="url-backed"):
+            part.to_data_url()
+
+
+class TestDataUrlUnchecked:
+    """The lenient counterpart, for pipelines that forwarded bytes unvalidated.
+
+    Every case here is one that :meth:`from_data_url` rejects. Dropping such a
+    payload would silently lose an image the model is meant to see, so these
+    must degrade rather than raise.
+    """
+
+    def test_well_formed_url_matches_the_strict_parser(self):
+        assert ImagePart.from_data_url_unchecked(_DATA_URL) == ImagePart.from_data_url(_DATA_URL)
+
+    def test_accepts_field_overrides(self):
+        part = ImagePart.from_data_url_unchecked(_DATA_URL, detail="low", width=8, height=4)
+
+        assert (part.detail, part.width, part.height) == ("low", 8, 4)
+
+    def test_malformed_base64_is_kept_as_data(self):
+        part = ImagePart.from_data_url_unchecked("data:image/png;base64,!!!not-base64!!!")
+
+        assert part.data == "!!!not-base64!!!"
+        assert part.mime_type == _PNG_MIME
+
+    def test_unpadded_base64_is_kept_as_data(self):
+        assert ImagePart.from_data_url_unchecked("data:image/png;base64,abc").data == "abc"
+
+    def test_missing_media_type_falls_back_to_png(self):
+        assert ImagePart.from_data_url_unchecked(f"data:;base64,{_PAYLOAD}").mime_type == _PNG_MIME
+
+    def test_non_base64_payload_becomes_a_url(self):
+        """``ImagePart`` demands exactly one of data/url, so an empty ``data``
+        would raise rather than degrade."""
+        part = ImagePart.from_data_url_unchecked("data:image/svg+xml,%3Csvg%2F%3E")
+
+        assert part.data is None
+        assert part.url == "data:image/svg+xml,%3Csvg%2F%3E"
+
+    def test_non_base64_payload_reads_only_the_media_type(self):
+        """The payload must not be swallowed into ``mime_type`` by the split."""
+        part = ImagePart.from_data_url_unchecked("data:image/svg+xml,%3Csvg%2F%3E")
+
+        assert part.mime_type == "image/svg+xml"
+
+    def test_media_type_parameters_are_stripped(self):
+        part = ImagePart.from_data_url_unchecked("data:image/svg+xml;charset=utf-8,%3Csvg%2F%3E")
+
+        assert part.mime_type == "image/svg+xml"
+
+    def test_never_raises_on_any_of_the_strict_parser_rejections(self):
+        for url in (
+            "data:image/png,raw-bytes",
+            "data:image/png;base64,!!!",
+            f"data:;base64,{_PAYLOAD}",
+            "data:",
+        ):
+            assert isinstance(ImagePart.from_data_url_unchecked(url), ImagePart)
+
+
+class TestEstimatedTokens:
+    def test_estimated_tokens_scales_with_dimensions(self):
+        small = ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD, width=256, height=256)
+        large = ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD, width=2048, height=2048)
+
+        assert small.estimated_tokens("openai") < large.estimated_tokens("openai")
+
+    def test_estimated_tokens_differs_by_provider(self):
+        part = ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD, width=1024, height=1024)
+
+        assert part.estimated_tokens("openai") != part.estimated_tokens("anthropic")
+
+    def test_estimated_tokens_falls_back_without_dimensions(self):
+        part = ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD)
+
+        assert part.estimated_tokens("openai") == DEFAULT_IMAGE_TOKENS
+
+    def test_estimated_tokens_falls_back_for_unknown_provider(self):
+        part = ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD, width=1024, height=1024)
+
+        assert part.estimated_tokens("some-local-vllm") == DEFAULT_IMAGE_TOKENS
+
+    def test_provider_matching_is_case_insensitive(self):
+        part = ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD, width=1024, height=1024)
+
+        assert part.estimated_tokens("OpenAI") == part.estimated_tokens("openai")
+
+    def test_low_detail_is_charged_a_flat_rate_on_openai(self):
+        """OpenAI bills low-detail images at the base rate regardless of size."""
+        small = ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD, width=256, height=256, detail="low")
+        large = ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD, width=4096, height=4096, detail="low")
+
+        assert small.estimated_tokens("openai") == large.estimated_tokens("openai") == 85
+
+    def test_oversized_image_is_capped_on_anthropic(self):
+        part = ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD, width=8000, height=8000)
+
+        assert part.estimated_tokens("anthropic") == 1600

--- a/tests/unit_tests/core/foundation/llm/test_dashscope_model_client.py
+++ b/tests/unit_tests/core/foundation/llm/test_dashscope_model_client.py
@@ -1,0 +1,136 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Unit tests for the DashScope content conversion.
+
+Only the MultiModalConversation (Wanx) generation APIs use DashScope's
+``{"text"}``/``{"image"}`` dialect. The chat path is OpenAI-compatible and
+inherits ``BaseModelClient._render_parts`` unchanged — asserted here so a
+future override does not silently break it.
+"""
+
+import base64
+
+import pytest
+
+from openjiuwen.core.common.exception.errors import ValidationError
+from openjiuwen.core.foundation.llm import (
+    ImagePart,
+    ModelClientConfig,
+    ModelRequestConfig,
+    TextPart,
+    UserMessage,
+)
+from openjiuwen.core.foundation.llm.model_clients.dashscope_model_client import (
+    DashScopeModelClient,
+    _to_dashscope_content,
+)
+
+_PNG_MIME = "image/png"
+_PAYLOAD = base64.b64encode(b"\x89PNG\r\n\x1a\nfake-pixels").decode("ascii")
+_DATA_URL = f"data:{_PNG_MIME};base64,{_PAYLOAD}"
+
+
+def _content(content) -> list:
+    return _to_dashscope_content(content)[0]
+
+
+class TestToDashScopeContent:
+    def test_str_content_becomes_one_text_entry(self):
+        assert _to_dashscope_content("draw a cat") == ([{"text": "draw a cat"}], 1, 0)
+
+    def test_text_part_renders_as_text_key(self):
+        assert _content([TextPart(text="draw a cat")]) == [{"text": "draw a cat"}]
+
+    def test_str_item_renders_as_text_key(self):
+        assert _content(["draw a cat"]) == [{"text": "draw a cat"}]
+
+    def test_image_part_renders_as_image_key(self):
+        assert _content([ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD)]) == [{"image": _DATA_URL}]
+
+    def test_url_backed_image_part_keeps_the_url(self):
+        part = ImagePart(mime_type=_PNG_MIME, url="https://example.invalid/a.png")
+
+        assert _content([part]) == [{"image": "https://example.invalid/a.png"}]
+
+    def test_openai_image_block_is_translated(self):
+        """The Stage-0 defect: this used to raise ``ValidationError``."""
+        block = {"type": "image_url", "image_url": {"url": _DATA_URL}}
+
+        assert _content(["draw", block]) == [{"text": "draw"}, {"image": _DATA_URL}]
+
+    def test_native_dialect_still_accepted(self):
+        """DashScope's own shape carries no ``type`` key; normalization skips it."""
+        native = [{"text": "draw"}, {"image": "https://example.invalid/a.png"}]
+
+        assert _content(native) == native
+
+    def test_counts_text_and_images(self):
+        content = ["draw", ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD), "in blue"]
+
+        _, text_count, image_count = _to_dashscope_content(content)
+
+        assert (text_count, image_count) == (2, 1)
+
+    def test_order_is_preserved(self):
+        content = [ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD), "then text"]
+
+        assert list(_content(content)[0]) == ["image"]
+        assert list(_content(content)[1]) == ["text"]
+
+    def test_unknown_dict_still_raises(self):
+        with pytest.raises(ValidationError, match="must contain 'text' or 'image' key"):
+            _to_dashscope_content([{"caption": "x"}])
+
+    def test_non_str_non_dict_item_still_raises(self):
+        with pytest.raises(ValidationError, match="must be string or dict"):
+            _to_dashscope_content([42])
+
+    def test_non_str_non_list_content_still_raises(self):
+        with pytest.raises(ValidationError, match="must be string or list"):
+            _to_dashscope_content(42)
+
+
+class TestChatPathIsUnchanged:
+    """DashScope chat is OpenAI-compatible; only the Wanx path is special."""
+
+    def test_render_parts_is_inherited_from_the_openai_default(self):
+        message = UserMessage(content=[TextPart(text="hi"), ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD)])
+
+        converted = DashScopeModelClient._convert_messages_to_dict([message])[0]
+
+        assert converted["content"] == [
+            {"type": "text", "text": "hi"},
+            {"type": "image_url", "image_url": {"url": _DATA_URL}},
+        ]
+
+
+@pytest.mark.asyncio
+async def test_image_message_does_not_raise_validation_error(monkeypatch):
+    """End to end through ``generate_image``: an image input is now accepted."""
+    from unittest.mock import MagicMock, patch
+
+    client = DashScopeModelClient(
+        ModelRequestConfig(model="qwen-image-max"),
+        ModelClientConfig(
+            client_provider="DashScope",
+            api_key="mock-api-key",
+            api_base="https://dashscope.example.invalid/api/v1",
+        ),
+    )
+
+    response = MagicMock()
+    response.status_code = 200
+    response.output = {"choices": [{"message": {"content": [{"image": "https://example.invalid/out.png"}]}}]}
+
+    message = UserMessage(content=["draw a cat like this", {"type": "image_url", "image_url": {"url": _DATA_URL}}])
+
+    with patch(
+        "openjiuwen.core.foundation.llm.model_clients.dashscope_model_client.MultiModalConversation"
+    ) as mock_conversation:
+        mock_conversation.call.return_value = response
+        result = await client.generate_image([message])
+
+    assert result.images == ["https://example.invalid/out.png"]
+    sent = mock_conversation.call.call_args.kwargs["messages"][0]["content"]
+    assert sent == [{"text": "draw a cat like this"}, {"image": _DATA_URL}]

--- a/tests/unit_tests/core/foundation/llm/test_message_content_normalization.py
+++ b/tests/unit_tests/core/foundation/llm/test_message_content_normalization.py
@@ -1,0 +1,282 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Tests for reading ``BaseMessage.content`` as typed parts.
+
+The central invariant here is that normalization is **lazy**: ``content`` keeps
+whatever the caller supplied, and only ``.parts``/``.text`` present it as
+``ContentPart``. Every existing consumer type-tests ``content`` items for
+``dict``/``str``, so coercing on construction would break all of them at once
+(see ``docs/dev/message-content-parts-refactor.md`` §3, Stage 1).
+"""
+
+import base64
+import json
+from unittest.mock import patch
+
+from openjiuwen.core.foundation.llm import (
+    AssistantMessage,
+    ImagePart,
+    TextPart,
+    ToolMessage,
+    UserMessage,
+)
+from openjiuwen.core.foundation.llm.schema import content_part as content_part_module
+from openjiuwen.core.foundation.llm.schema.tool_call import ToolCall
+
+_PNG_MIME = "image/png"
+_PAYLOAD = base64.b64encode(b"\x89PNG\r\n\x1a\nfake-pixels").decode("ascii")
+_DATA_URL = f"data:{_PNG_MIME};base64,{_PAYLOAD}"
+
+
+def _openai_image_block(url: str = _DATA_URL) -> dict:
+    """The block ``react_agent`` and the mobile GUI skill runner emit."""
+    return {"type": "image_url", "image_url": {"url": url}}
+
+
+def _filesystem_image_item() -> dict:
+    """The block ``harness/tools/filesystem.py`` attaches to ``read_file`` output."""
+    return {
+        "type": "image",
+        "source": "read_file",
+        "source_path": "/tmp/shot.png",
+        "mime_type": _PNG_MIME,
+        "data_url": _DATA_URL,
+    }
+
+
+class TestStorageIsNotCoerced:
+    """Stage 1 is additive: nothing about how ``content`` is stored changes."""
+
+    def test_str_content_unchanged(self):
+        assert UserMessage(content="hi").content == "hi"
+
+    def test_str_elements_stay_str(self):
+        message = UserMessage(content=["a", "b"])
+
+        assert message.content == ["a", "b"]
+        assert all(isinstance(item, str) for item in message.content)
+
+    def test_known_dicts_stay_dicts(self):
+        """A recognized dialect must not be silently rewritten in place."""
+        block = _openai_image_block()
+        message = UserMessage(content=[block])
+
+        assert message.content == [block]
+        assert isinstance(message.content[0], dict)
+
+    def test_part_instances_pass_through(self):
+        part = TextPart(text="q")
+        message = UserMessage(content=[part])
+
+        assert message.content == [part]
+        assert isinstance(message.content[0], TextPart)
+
+
+class TestPartsProperty:
+    def test_str_element_becomes_text_part(self):
+        assert UserMessage(content=["a"]).parts == [TextPart(text="a")]
+
+    def test_openai_text_dict_becomes_text_part(self):
+        message = UserMessage(content=[{"type": "text", "text": "hello"}])
+
+        assert message.parts == [TextPart(text="hello")]
+
+    def test_openai_image_url_dict_becomes_image_part(self):
+        message = UserMessage(content=[_openai_image_block()])
+
+        part = message.parts[0]
+        assert isinstance(part, ImagePart)
+        assert part.mime_type == _PNG_MIME
+        assert part.data == _PAYLOAD
+        assert part.url is None
+
+    def test_openai_remote_image_url_keeps_the_url(self):
+        message = UserMessage(content=[_openai_image_block("https://example.invalid/a.jpg")])
+
+        part = message.parts[0]
+        assert isinstance(part, ImagePart)
+        assert part.url == "https://example.invalid/a.jpg"
+        assert part.mime_type == "image/jpeg"
+        assert part.data is None
+
+    def test_openai_image_detail_is_preserved(self):
+        block = {"type": "image_url", "image_url": {"url": _DATA_URL, "detail": "low"}}
+
+        assert UserMessage(content=[block]).parts[0].detail == "low"
+
+    def test_filesystem_data_url_dict_becomes_image_part(self):
+        message = UserMessage(content=[_filesystem_image_item()])
+
+        part = message.parts[0]
+        assert isinstance(part, ImagePart)
+        assert part.mime_type == _PNG_MIME
+        assert part.data == _PAYLOAD
+
+    def test_parts_property_on_str_content(self):
+        assert UserMessage(content="hi").parts == [TextPart(text="hi")]
+
+    def test_part_instances_are_not_rewrapped(self):
+        part = ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD)
+
+        assert UserMessage(content=[part]).parts[0] is part
+
+    def test_dumped_parts_are_read_back_as_parts(self):
+        """Normalization must close over its own serialized shape.
+
+        Persistence stores ``model_dump()`` output, so a part that cannot be
+        recognized from its own dump silently downgrades to an opaque dict on
+        reload.
+        """
+        original = UserMessage(
+            content=[TextPart(text="q"), ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD, width=8, height=8)]
+        )
+
+        restored = UserMessage.model_validate(original.model_dump())
+
+        assert restored.parts == original.parts
+
+    def test_unknown_dict_is_dropped_from_parts(self):
+        message = UserMessage(content=[{"type": "video_url", "video_url": {"url": "x"}}])
+
+        assert message.parts == []
+
+    def test_mixed_content_preserves_order(self):
+        message = UserMessage(content=["intro", _openai_image_block(), {"type": "text", "text": "outro"}])
+
+        assert [part.type for part in message.parts] == ["text", "image", "text"]
+
+
+class TestUnknownDicts:
+    def test_unknown_dict_preserved_verbatim(self):
+        """Normalization must never raise or mutate an unrecognized dialect."""
+        unknown = {"type": "video_url", "video_url": {"url": "https://example.invalid/v.mp4"}}
+        message = UserMessage(content=[unknown])
+
+        # Still a plain dict, key for key. (Pydantic copies dicts on validation,
+        # as it always has, so this is equality rather than identity.)
+        assert message.content == [unknown]
+        assert isinstance(message.content[0], dict)
+
+    def test_malformed_image_url_is_preserved(self):
+        malformed = {"type": "image_url", "image_url": {"url": "data:image/png;base64,!!!"}}
+        message = UserMessage(content=[malformed])
+
+        assert message.content == [malformed]
+        assert message.parts == []
+
+    def test_unknown_dict_logs_debug(self):
+        message = UserMessage(content=[{"type": "video_url"}])
+
+        with patch.object(content_part_module.llm_logger, "debug") as mock_debug:
+            message.parts
+
+        mock_debug.assert_called_once()
+
+    def test_known_dict_does_not_log(self):
+        message = UserMessage(content=[{"type": "text", "text": "hi"}])
+
+        with patch.object(content_part_module.llm_logger, "debug") as mock_debug:
+            message.parts
+
+        mock_debug.assert_not_called()
+
+
+class TestTextProperty:
+    def test_text_property_on_str_content(self):
+        assert UserMessage(content="hello").text == "hello"
+
+    def test_text_property_concatenates_text_parts(self):
+        message = UserMessage(content=["a", _openai_image_block(), {"type": "text", "text": "b"}])
+
+        assert message.text == "a\nb"
+
+    def test_text_property_ignores_unknown_dicts(self):
+        message = UserMessage(content=[{"type": "video_url"}, "kept"])
+
+        assert message.text == "kept"
+
+    def test_text_property_on_image_only_content(self):
+        assert UserMessage(content=[_openai_image_block()]).text == ""
+
+    def test_text_property_on_empty_content(self):
+        assert UserMessage().text == ""
+
+
+class TestSerialization:
+    def test_model_dump_serializes_parts(self):
+        message = UserMessage(content=[TextPart(text="q"), ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD)])
+
+        dumped = message.model_dump()
+
+        assert dumped["content"][0] == {"type": "text", "text": "q"}
+        assert dumped["content"][1]["type"] == "image"
+        assert dumped["content"][1]["mime_type"] == _PNG_MIME
+
+    def test_model_dump_json_is_serializable_with_parts(self):
+        """``session/vcs`` calls ``json.dumps`` with no ``default=``."""
+        message = AssistantMessage(content=[TextPart(text="q")])
+
+        assert json.loads(json.dumps(message.model_dump(mode="json")))["content"] == [{"type": "text", "text": "q"}]
+
+    def test_model_dump_json_matches_model_dump(self):
+        """The two output paths diverged while ``model_dump`` was hand-written."""
+        message = AssistantMessage(
+            content="answer",
+            tool_calls=[ToolCall(id="call_1", type="function", name="search", arguments='{"q": "x"}')],
+            reasoning_content="because",
+        )
+
+        assert json.loads(message.model_dump_json()) == message.model_dump(mode="json")
+
+    def test_assistant_message_dump_preserves_tool_calls(self):
+        """Regression guard on the shape the old hand-written override emitted."""
+        message = AssistantMessage(
+            content="",
+            tool_calls=[ToolCall(id="call_1", type="function", name="search", arguments='{"q": "x"}')],
+        )
+
+        assert message.model_dump()["tool_calls"] == [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "search", "arguments": '{"q": "x"}'},
+            }
+        ]
+
+    def test_assistant_message_dump_keeps_response_item_id(self):
+        message = AssistantMessage(
+            content="",
+            tool_calls=[ToolCall(id="c1", type="function", name="f", arguments="{}", response_item_id="resp_1")],
+        )
+
+        assert message.model_dump()["tool_calls"][0]["response_item_id"] == "resp_1"
+
+    def test_assistant_message_dump_stays_compact(self):
+        """Empty and ``None`` fields are dropped, as they always have been."""
+        dumped = AssistantMessage(content="hi").model_dump()
+
+        assert dumped == {"role": "assistant", "content": "hi", "finish_reason": "null"}
+
+    def test_assistant_message_dump_roundtrips(self):
+        message = AssistantMessage(
+            content="answer",
+            tool_calls=[ToolCall(id="call_1", type="function", name="search", arguments="{}")],
+        )
+
+        restored = AssistantMessage.model_validate(message.model_dump())
+
+        assert restored.tool_calls[0].name == "search"
+        assert restored.model_dump() == message.model_dump()
+
+    def test_assistant_message_dump_honors_exclude(self):
+        """``exclude`` was silently ignored by the old override."""
+        message = AssistantMessage(content="hi", reasoning_content="because")
+
+        assert "reasoning_content" not in message.model_dump(exclude={"reasoning_content"})
+
+    def test_tool_message_dump_is_unchanged(self):
+        dumped = ToolMessage(content="result", tool_call_id="call_1").model_dump()
+
+        assert dumped["content"] == "result"
+        assert dumped["tool_call_id"] == "call_1"

--- a/tests/unit_tests/core/foundation/llm/test_part_aware_consumers.py
+++ b/tests/unit_tests/core/foundation/llm/test_part_aware_consumers.py
@@ -1,0 +1,174 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Consumers of ``BaseMessage.content`` must read Parts as well as raw dicts.
+
+Stage 3 landed in two steps: consumers first (this file), producers second.
+Every test here is written as a pair — the legacy dict shape and the Part
+shape must give the *same* answer — because the migration is only correct if
+it is behavior-preserving for the dialects already in flight.
+
+See ``docs/dev/message-content-parts-refactor.md`` §3, Stage 3.
+"""
+
+import base64
+
+from openjiuwen.core.foundation.llm import (
+    AssistantMessage,
+    ImagePart,
+    TextPart,
+    UserMessage,
+)
+
+_PNG_MIME = "image/png"
+_PAYLOAD = base64.b64encode(b"\x89PNG\r\n\x1a\nfake-pixels").decode("ascii")
+_DATA_URL = f"data:{_PNG_MIME};base64,{_PAYLOAD}"
+
+
+def _openai_image_block() -> dict:
+    return {"type": "image_url", "image_url": {"url": _DATA_URL}}
+
+
+def _image_part() -> ImagePart:
+    return ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD)
+
+
+class TestTiktokenCounter:
+    """Image tokens must stay bounded whichever shape the image arrives in.
+
+    Stage 4 folded this into ``TiktokenCounter`` itself and deleted the
+    mobile-GUI monkey-patch these tests used to target.
+    """
+
+    def _count(self, content) -> int:
+        from openjiuwen.core.context_engine.token.tiktoken_counter import TiktokenCounter
+
+        return TiktokenCounter().count_messages([UserMessage(content=content)])
+
+    def test_image_part_counts_as_placeholder_like_the_dict_shape(self):
+        assert self._count([_image_part()]) == self._count([_openai_image_block()])
+
+    def test_image_part_is_not_billed_as_base64_text(self):
+        assert self._count([_image_part()]) < 5000
+
+    def test_text_part_counts_like_a_text_dict(self):
+        assert self._count([TextPart(text="hello")]) == self._count([{"type": "text", "text": "hello"}])
+
+
+class TestMultimodalContextSummarizerRail:
+    def test_image_part_is_detected(self):
+        from openjiuwen.harness.tools.mobile_gui.rails.multimodal_context_summarizer_rail import (
+            _has_image_url,
+        )
+
+        assert _has_image_url(UserMessage(content=[_image_part()])) is True
+        assert _has_image_url(UserMessage(content=[_openai_image_block()])) is True
+
+    def test_text_only_content_is_not_detected(self):
+        from openjiuwen.harness.tools.mobile_gui.rails.multimodal_context_summarizer_rail import (
+            _has_image_url,
+        )
+
+        assert _has_image_url(UserMessage(content=[TextPart(text="no image")])) is False
+
+    def test_image_part_is_replaced_by_the_placeholder(self):
+        from openjiuwen.harness.tools.mobile_gui.rails.multimodal_context_summarizer_rail import (
+            ARCHIVED_SCREEN_PLACEHOLDER,
+            _replace_archived_screenshot_images,
+        )
+
+        message = UserMessage(content=[TextPart(text="before"), _image_part()])
+
+        _replace_archived_screenshot_images(message)
+
+        assert message.content[1] == {"type": "text", "text": ARCHIVED_SCREEN_PLACEHOLDER}
+
+
+class TestTextExtraction:
+    """Every text extractor must see through both shapes identically."""
+
+    @staticmethod
+    def _pair(fn):
+        """Run ``fn`` over the dict shape and the Part shape."""
+        dict_shape = [{"type": "text", "text": "a"}, _openai_image_block(), {"type": "text", "text": "b"}]
+        part_shape = [TextPart(text="a"), _image_part(), TextPart(text="b")]
+        return fn(dict_shape), fn(part_shape)
+
+    def test_previous_steps_content_to_text(self):
+        from openjiuwen.harness.tools.mobile_gui.skill_branch.previous_steps import _content_to_text
+
+        legacy, parts = self._pair(_content_to_text)
+
+        assert legacy == parts == "a\nb"
+
+    def test_skill_branch_assistant_text(self):
+        from openjiuwen.harness.tools.mobile_gui.skill_branch.runner import _assistant_text
+
+        legacy, parts = self._pair(lambda c: _assistant_text(AssistantMessage(content=c)))
+
+        assert legacy == parts == "a\nb"
+
+    def test_vlm_grounding_flatten_message_text(self):
+        from openjiuwen.harness.tools.mobile_gui.rails.vlm_grounding_perception_rail import (
+            VlmGroundingPerceptionRail,
+        )
+
+        legacy, parts = self._pair(lambda c: VlmGroundingPerceptionRail._flatten_message_text(UserMessage(content=c)))
+
+        assert legacy == parts == "a\nb"
+
+    def test_security_rail_text_extraction(self):
+        """Prompt-injection scanning must not go blind on Part-based content."""
+        from openjiuwen.harness.rails.security.base_security_rail import BaseSecurityRail
+
+        rail = BaseSecurityRail.__new__(BaseSecurityRail)
+        legacy, parts = self._pair(lambda c: rail._extract_message_content(UserMessage(content=c)))
+
+        assert legacy == parts == "a b"
+
+    def test_evolution_review_materials(self):
+        from openjiuwen.harness.rails.evolution.review.materials import _message_content_text
+
+        legacy, parts = self._pair(_message_content_text)
+
+        assert legacy == parts == "a\nb"
+
+    def test_no_extractor_splices_a_part_repr_into_its_output(self):
+        """Regression: an ImagePart is truthy and is not a dict.
+
+        Any extractor with a ``str(item)`` fallback tail will stringify the
+        whole model unless images are matched explicitly first.
+        """
+        from openjiuwen.harness.rails.evolution.review.materials import _message_content_text
+        from openjiuwen.harness.tools.mobile_gui.skill_branch.previous_steps import _content_to_text
+
+        for extract in (_message_content_text, _content_to_text):
+            assert "mime_type" not in extract([TextPart(text="a"), _image_part()])
+
+
+class TestIntelliRouterDashScopeContent:
+    """The second DashScope conversion site, found while landing Stage 2."""
+
+    def test_image_part_is_no_longer_dropped(self):
+        message = UserMessage(content=[TextPart(text="draw"), _image_part()])
+
+        content_list = []
+        for item in message.content:
+            if isinstance(item, TextPart):
+                content_list.append({"text": item.text})
+            elif isinstance(item, ImagePart):
+                content_list.append({"image": item.url or item.to_data_url()})
+
+        assert content_list == [{"text": "draw"}, {"image": _DATA_URL}]
+
+
+class TestResponsesUtils:
+    def test_text_part_contributes_its_text(self):
+        from openjiuwen.core.foundation.llm.utils.responses_utils import _content_part_text
+
+        assert _content_part_text(TextPart(text="hi")) == "hi"
+
+    def test_image_part_contributes_nothing(self):
+        from openjiuwen.core.foundation.llm.utils.responses_utils import _content_part_text
+
+        assert _content_part_text(_image_part()) == ""

--- a/tests/unit_tests/core/foundation/llm/test_render_parts.py
+++ b/tests/unit_tests/core/foundation/llm/test_render_parts.py
@@ -1,0 +1,177 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Tests for ``BaseModelClient._render_parts``, the provider conversion seam.
+
+``_convert_messages_to_dict`` normalizes each item of list content and hands
+the result to ``_render_parts``, which every client may override to speak its
+own content dialect. The default is the OpenAI shape.
+
+The load-bearing assertion in this module is
+``test_single_text_part_renders_as_bare_string``: providers key their prompt
+cache on the exact request prefix, so a lone text part must go on the wire as a
+bare ``str``, exactly as it did before this seam existed.
+"""
+
+import base64
+
+import pytest
+
+from openjiuwen.core.foundation.llm import (
+    AssistantMessage,
+    ImagePart,
+    SystemMessage,
+    TextPart,
+    ToolMessage,
+    UserMessage,
+)
+from openjiuwen.core.foundation.llm.model_clients.base_model_client import BaseModelClient
+from openjiuwen.core.foundation.llm.schema.tool_call import ToolCall
+
+_PNG_MIME = "image/png"
+_PAYLOAD = base64.b64encode(b"\x89PNG\r\n\x1a\nfake-pixels").decode("ascii")
+_DATA_URL = f"data:{_PNG_MIME};base64,{_PAYLOAD}"
+
+
+def _render(message) -> object:
+    """Convert one message and return just its rendered ``content``."""
+    return BaseModelClient._convert_messages_to_dict([message])[0]["content"]
+
+
+class TestSingleTextCollapse:
+    """A lone text part must never become a one-element list."""
+
+    def test_single_text_part_renders_as_bare_string(self):
+        assert _render(UserMessage(content=[TextPart(text="x")])) == "x"
+
+    def test_single_str_item_renders_as_bare_string(self):
+        assert _render(UserMessage(content=["x"])) == "x"
+
+    def test_single_openai_text_block_renders_as_bare_string(self):
+        assert _render(UserMessage(content=[{"type": "text", "text": "x"}])) == "x"
+
+    def test_str_content_is_untouched(self):
+        """Plain ``str`` content never reaches ``_render_parts`` at all."""
+        assert _render(UserMessage(content="x")) == "x"
+
+    def test_empty_parts_renders_as_empty_string(self):
+        assert _render(UserMessage(content=[])) == ""
+
+    def test_single_image_part_stays_a_list(self):
+        """The collapse is text-only; an image has no bare-string form."""
+        rendered = _render(UserMessage(content=[ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD)]))
+
+        assert isinstance(rendered, list)
+        assert len(rendered) == 1
+
+
+class TestDefaultOpenAIShape:
+    def test_multiple_parts_render_as_list(self):
+        rendered = _render(UserMessage(content=[TextPart(text="a"), TextPart(text="b")]))
+
+        assert rendered == [
+            {"type": "text", "text": "a"},
+            {"type": "text", "text": "b"},
+        ]
+
+    def test_image_part_renders_as_image_url_block(self):
+        message = UserMessage(content=[TextPart(text="look"), ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD)])
+
+        assert _render(message)[1] == {"type": "image_url", "image_url": {"url": _DATA_URL}}
+
+    def test_url_backed_image_keeps_the_url(self):
+        message = UserMessage(
+            content=[
+                TextPart(text="look"),
+                ImagePart(mime_type="image/jpeg", url="https://example.invalid/a.jpg"),
+            ]
+        )
+
+        assert _render(message)[1]["image_url"] == {"url": "https://example.invalid/a.jpg"}
+
+    def test_default_detail_is_omitted(self):
+        """Emitting ``detail: "auto"`` would change payloads that omit it today."""
+        message = UserMessage(content=[TextPart(text="look"), ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD)])
+
+        assert "detail" not in _render(message)[1]["image_url"]
+
+    def test_non_default_detail_is_emitted(self):
+        message = UserMessage(
+            content=[
+                TextPart(text="look"),
+                ImagePart(mime_type=_PNG_MIME, data=_PAYLOAD, detail="low"),
+            ]
+        )
+
+        assert _render(message)[1]["image_url"]["detail"] == "low"
+
+    def test_default_render_is_openai_shape(self):
+        """An OpenAI-shaped payload survives the round trip byte for byte."""
+        blocks = [
+            {"type": "text", "text": "describe this"},
+            {"type": "image_url", "image_url": {"url": _DATA_URL}},
+        ]
+
+        assert _render(UserMessage(content=blocks)) == blocks
+
+    def test_unknown_dict_passes_through_default_render(self):
+        """An unrecognized dialect must reach the wire, not be dropped."""
+        unknown = {"type": "video_url", "video_url": {"url": "https://example.invalid/v.mp4"}}
+
+        assert _render(UserMessage(content=[TextPart(text="a"), unknown])) == [
+            {"type": "text", "text": "a"},
+            unknown,
+        ]
+
+    def test_lone_unknown_dict_is_not_collapsed(self):
+        unknown = {"type": "video_url"}
+
+        assert _render(UserMessage(content=[unknown])) == [unknown]
+
+
+class TestOtherMessageFields:
+    """Rendering must not disturb anything else ``_convert_messages_to_dict`` emits."""
+
+    def test_roles_are_preserved(self):
+        messages = [
+            SystemMessage(content="sys"),
+            UserMessage(content=["hi"]),
+            AssistantMessage(content="yo"),
+        ]
+
+        converted = BaseModelClient._convert_messages_to_dict(messages)
+
+        assert [m["role"] for m in converted] == ["system", "user", "assistant"]
+
+    def test_tool_calls_still_convert(self):
+        message = AssistantMessage(
+            content=[TextPart(text="calling")],
+            tool_calls=[ToolCall(id="c1", type="function", name="search", arguments="{}")],
+        )
+
+        converted = BaseModelClient._convert_messages_to_dict([message])[0]
+
+        assert converted["content"] == "calling"
+        assert converted["tool_calls"] == [
+            {"id": "c1", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+        ]
+
+    def test_tool_message_keeps_tool_call_id(self):
+        message = ToolMessage(content=[TextPart(text="result")], tool_call_id="c1")
+
+        converted = BaseModelClient._convert_messages_to_dict([message])[0]
+
+        assert converted == {"role": "tool", "content": "result", "tool_call_id": "c1"}
+
+    def test_raw_dict_messages_bypass_rendering(self):
+        """Pre-built dict messages are forwarded verbatim, as they always were."""
+        raw = [{"role": "user", "content": [{"type": "text", "text": "a"}]}]
+
+        assert BaseModelClient._convert_messages_to_dict(raw) == raw
+
+    def test_str_messages_still_become_a_user_message(self):
+        assert BaseModelClient._convert_messages_to_dict("hi") == [{"role": "user", "content": "hi"}]
+
+    def test_empty_messages_still_raise(self):
+        with pytest.raises(Exception):
+            BaseModelClient._convert_messages_to_dict([])

--- a/tests/unit_tests/core/memory/test_long_term_memory_content_truncation.py
+++ b/tests/unit_tests/core/memory/test_long_term_memory_content_truncation.py
@@ -1,0 +1,117 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Input truncation in :class:`LongTermMemory`, first unit coverage.
+
+Stage 5 of the typed content-parts refactor. ``long_term_memory`` capped a
+message by slicing ``content`` directly, which on list content truncates by
+*element count* instead of length — dropping whole parts while leaving a
+single oversized one untouched. See
+``docs/dev/message-content-parts-refactor.md`` §3, Stage 5.
+
+Only system tests existed for this module before, so the ``str`` cases here
+are as much of the point as the list ones.
+"""
+
+import base64
+
+import pytest
+
+from openjiuwen.core.foundation.llm import AssistantMessage, BaseMessage, ToolMessage, UserMessage
+from openjiuwen.core.memory.config.config import MemoryEngineConfig
+from openjiuwen.core.memory.long_term_memory import LongTermMemory
+
+_MAX_LEN = 32
+
+
+def _image_block() -> dict:
+    data_url = "data:image/png;base64," + base64.b64encode(b"\x89PNG\r\n\x1a\n" + b"\xa5" * 4096).decode("ascii")
+    return {"type": "image_url", "image_url": {"url": data_url}}
+
+
+@pytest.fixture
+def memory():
+    """``LongTermMemory`` is a process-wide singleton — restore what we change."""
+    instance = LongTermMemory()
+    previous = instance._sys_mem_config
+    instance._sys_mem_config = MemoryEngineConfig(input_msg_max_len=_MAX_LEN)
+    yield instance
+    instance._sys_mem_config = previous
+
+
+class TestContentTruncation:
+    def test_truncation_on_str_content(self, memory):
+        """The common path must stay a plain character-count truncation."""
+        message = AssistantMessage(content="a" * 100)
+
+        memory._truncate_content(message)
+
+        assert message.content == "a" * _MAX_LEN
+
+    def test_short_str_content_is_untouched(self, memory):
+        message = AssistantMessage(content="short")
+
+        memory._truncate_content(message)
+
+        assert message.content == "short"
+
+    def test_truncation_on_list_content_does_not_corrupt(self, memory):
+        """Slicing a list keeps ``_MAX_LEN`` *elements*, not characters.
+
+        With two parts the old code was a no-op — the oversized text survived
+        whole, and an image survived with it, defeating the cap entirely.
+        """
+        message = AssistantMessage(content=["b" * 100, _image_block()])
+
+        memory._truncate_content(message)
+
+        assert message.content == "b" * _MAX_LEN
+
+    def test_truncation_joins_multiple_text_parts(self, memory):
+        message = AssistantMessage(content=["one", "two"])
+
+        memory._truncate_content(message)
+
+        assert message.content == "one\ntwo"
+
+    def test_truncation_preserves_message_validity(self, memory):
+        """The result must still round-trip as a ``BaseMessage``."""
+        message = ToolMessage(tool_call_id="tc-1", content=["c" * 100, _image_block()])
+
+        memory._truncate_content(message)
+
+        restored = ToolMessage.model_validate(message.model_dump())
+        assert isinstance(restored, BaseMessage)
+        assert restored.content == "c" * _MAX_LEN
+        assert restored.tool_call_id == "tc-1"
+
+
+class TestCheckMessages:
+    """``_check_messages`` is the caller that applies the cap."""
+
+    def test_user_messages_are_reported_and_left_intact(self, memory):
+        user = UserMessage(content="u" * 100)
+
+        has_human_msg, out_messages = memory._check_messages([user])
+
+        assert has_human_msg is True
+        assert out_messages[0].content == "u" * 100, "user messages are exempt from the cap"
+
+    def test_non_user_messages_are_truncated(self, memory):
+        messages = [
+            UserMessage(content="hello"),
+            AssistantMessage(content="a" * 100),
+            ToolMessage(tool_call_id="tc-1", content=["b" * 100, _image_block()]),
+        ]
+
+        has_human_msg, out_messages = memory._check_messages(messages)
+
+        assert has_human_msg is True
+        assert out_messages[1].content == "a" * _MAX_LEN
+        assert out_messages[2].content == "b" * _MAX_LEN
+
+    def test_reports_absent_human_message(self, memory):
+        has_human_msg, out_messages = memory._check_messages([AssistantMessage(content="a")])
+
+        assert has_human_msg is False
+        assert len(out_messages) == 1

--- a/tests/unit_tests/core/session/vcs/test_codec.py
+++ b/tests/unit_tests/core/session/vcs/test_codec.py
@@ -1,6 +1,9 @@
 # coding: utf-8
 # Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
 """Tests for the vcs message codec (BaseMessage <-> json dict, by role)."""
+import json
+
+from openjiuwen.core.foundation.llm.schema.content_part import ImagePart, TextPart
 from openjiuwen.core.foundation.llm.schema.message import (
     AssistantMessage,
     SystemMessage,
@@ -67,3 +70,28 @@ def test_context_state_roundtrip():
     assert isinstance(decoded["messages"][0], UserMessage)
     assert decoded["messages"][1].content == "yo"
     assert decoded["offload_messages"]["h1"][0].content == "big"
+
+
+def test_content_part_content_survives_json_dumps():
+    """``vcs/backend.py`` calls ``json.dumps`` with no ``default=``.
+
+    ``AssistantMessage`` used to override ``model_dump`` by hand, ignoring
+    ``mode="json"``, so a ``ContentPart`` in ``content`` would have reached
+    ``json.dumps`` as a pydantic model and raised ``TypeError``.
+    """
+    message = AssistantMessage(content=[TextPart(text="answer")])
+
+    encoded = encode_message(message)
+
+    assert json.loads(json.dumps(encoded))["content"] == [{"type": "text", "text": "answer"}]
+
+
+def test_content_part_content_roundtrips():
+    message = UserMessage(
+        content=[TextPart(text="look"), ImagePart(mime_type="image/png", data="Zm9v")],
+    )
+
+    decoded = decode_message(encode_message(message))
+
+    assert isinstance(decoded, UserMessage)
+    assert decoded.parts == message.parts

--- a/tests/unit_tests/harness/test_image_modality_probe.py
+++ b/tests/unit_tests/harness/test_image_modality_probe.py
@@ -9,6 +9,12 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from openjiuwen.core.foundation.llm import ImagePart, TextPart, UserMessage
+from openjiuwen.core.foundation.llm.model_clients.anthropic_model_client import (
+    AnthropicModelClient,
+    _convert_message_schemas,
+)
+from openjiuwen.core.foundation.llm.model_clients.base_model_client import BaseModelClient
 from openjiuwen.harness import image_modality_probe
 from openjiuwen.harness.image_modality_probe import (
     get_cached_image_support,
@@ -192,3 +198,57 @@ async def test_scheduled_probe_skips_cached_endpoint() -> None:
 
     assert not image_modality_probe._probe_tasks
     invoke.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Stage 3: the probe is built from Parts, not an OpenAI-shaped dict
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_probe_message_uses_parts():
+    invoke = AsyncMock(return_value=_FakeResponse("blue"))
+    llm = _make_llm(invoke=invoke)
+
+    await probe_image_support(llm)
+
+    message = invoke.await_args.args[0][0]
+    assert isinstance(message, UserMessage)
+    assert isinstance(message.content[0], ImagePart)
+    assert isinstance(message.content[1], TextPart)
+
+
+@pytest.mark.asyncio
+async def test_probe_renders_for_anthropic():
+    """Before Stage 3 the probe only meant anything against OpenAI endpoints."""
+    invoke = AsyncMock(return_value=_FakeResponse("blue"))
+    llm = _make_llm(invoke=invoke)
+
+    await probe_image_support(llm)
+
+    message = invoke.await_args.args[0][0]
+    payload = AnthropicModelClient._convert_messages_to_dict([message])
+    _, anthropic_messages = _convert_message_schemas(payload)
+
+    blocks = anthropic_messages[0]["content"]
+    assert blocks[0]["type"] == "image"
+    assert blocks[0]["source"]["type"] == "base64"
+    assert blocks[0]["source"]["media_type"] == "image/png"
+
+
+@pytest.mark.asyncio
+async def test_probe_still_renders_the_openai_shape():
+    invoke = AsyncMock(return_value=_FakeResponse("blue"))
+    llm = _make_llm(invoke=invoke)
+
+    await probe_image_support(llm)
+
+    message = invoke.await_args.args[0][0]
+    content = BaseModelClient._convert_messages_to_dict([message])[0]["content"]
+
+    assert content[0]["type"] == "image_url"
+    assert content[0]["image_url"]["url"].startswith("data:image/png;base64,")
+    assert content[1] == {
+        "type": "text",
+        "text": "What color is this image? Reply with one word.",
+    }

--- a/tests/unit_tests/harness/tools/mobile_gui/test_skill_branch_blocks.py
+++ b/tests/unit_tests/harness/tools/mobile_gui/test_skill_branch_blocks.py
@@ -1,0 +1,87 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""The skill-branch producers emit typed parts (Stage 3, commit 2)."""
+
+import base64
+
+from openjiuwen.core.foundation.llm import ImagePart, TextPart, UserMessage
+from openjiuwen.core.foundation.llm.model_clients.anthropic_model_client import (
+    AnthropicModelClient,
+    _convert_message_schemas,
+)
+from openjiuwen.core.foundation.llm.model_clients.base_model_client import BaseModelClient
+from openjiuwen.harness.tools.mobile_gui.skill_branch.runner import (
+    _build_live_screenshot_blocks,
+    _image_part_from_data_url,
+)
+
+_JPEG_B64 = base64.b64encode(b"\xff\xd8\xff\xe0fake-jpeg").decode("ascii")
+
+
+class TestLiveScreenshotBlocks:
+    def test_bare_base64_becomes_an_image_part(self):
+        blocks = _build_live_screenshot_blocks(_JPEG_B64)
+
+        assert isinstance(blocks[0], TextPart)
+        assert isinstance(blocks[1], ImagePart)
+        assert blocks[1].mime_type == "image/jpeg"
+        assert blocks[1].data == _JPEG_B64
+
+    def test_detail_is_low_to_keep_screenshots_cheap(self):
+        assert _build_live_screenshot_blocks(_JPEG_B64)[1].detail == "low"
+
+    def test_data_url_input_keeps_its_declared_mime_type(self):
+        blocks = _build_live_screenshot_blocks(f"data:image/png;base64,{_JPEG_B64}")
+
+        assert blocks[1].mime_type == "image/png"
+
+    def test_missing_screenshot_yields_a_text_part_only(self):
+        blocks = _build_live_screenshot_blocks("")
+
+        assert len(blocks) == 1
+        assert isinstance(blocks[0], TextPart)
+
+
+class TestLenientParsing:
+    """Screenshots must survive payloads that strict base64 would reject."""
+
+    def test_unpadded_payload_is_not_dropped(self):
+        part = _image_part_from_data_url("data:image/png;base64,abc")
+
+        assert part.data == "abc"
+
+    def test_missing_mime_type_falls_back(self):
+        assert _image_part_from_data_url("data:;base64,abc").mime_type == "image/png"
+
+    def test_non_base64_data_url_degrades_to_a_url(self):
+        """``ImagePart`` requires exactly one of data/url, so an empty ``data``
+        would raise. A percent-encoded payload becomes a ``url`` instead."""
+        part = _image_part_from_data_url("data:image/svg+xml,%3Csvg%2F%3E")
+
+        assert part.data is None
+        assert part.url == "data:image/svg+xml,%3Csvg%2F%3E"
+        assert part.mime_type == "image/svg+xml"
+
+
+class TestRendering:
+    """``detail:"low"`` must reach OpenAI, and the image must reach Anthropic."""
+
+    def test_openai_render_carries_detail_low(self):
+        message = UserMessage(content=_build_live_screenshot_blocks(_JPEG_B64))
+
+        content = BaseModelClient._convert_messages_to_dict([message])[0]["content"]
+
+        assert content[1]["image_url"]["detail"] == "low"
+        assert content[1]["image_url"]["url"] == f"data:image/jpeg;base64,{_JPEG_B64}"
+
+    def test_anthropic_render_is_a_source_block(self):
+        message = UserMessage(content=_build_live_screenshot_blocks(_JPEG_B64))
+
+        payload = AnthropicModelClient._convert_messages_to_dict([message])
+        _, messages = _convert_message_schemas(payload)
+
+        assert messages[0]["content"][1] == {
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/jpeg", "data": _JPEG_B64},
+        }

--- a/tests/unit_tests/harness/tools/test_filesystem_tools.py
+++ b/tests/unit_tests/harness/tools/test_filesystem_tools.py
@@ -2,6 +2,7 @@
 # Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
 
 import asyncio
+import io
 import os
 import base64
 import json
@@ -14,6 +15,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 import pytest_asyncio
 from PIL import Image
+
+from openjiuwen.core.foundation.llm import ImagePart
 
 from openjiuwen.core.runner import Runner
 from openjiuwen.core.sys_operation import SysOperationCard, OperationMode, LocalWorkConfig
@@ -1322,3 +1325,71 @@ async def test_write_file_small_file_single_full_read_allows_overwrite(sys_op, t
 
     res = await write_tool.invoke({"file_path": file_path, "content": "x\ny\nz"})
     assert res.success is True
+
+
+@pytest.mark.asyncio
+async def test_read_image_emits_dimensions_in_multimodal_payload(sys_op, temp_dir):
+    """Dimensions let ``ImagePart.estimated_tokens`` bill the real image."""
+    read_tool = ReadFileTool(sys_op)
+    file_path = os.path.join(temp_dir, "sized.png")
+    Image.new("RGB", (37, 19), color=(10, 20, 30)).save(file_path, format="PNG")
+
+    read_res = await read_tool.invoke({"file_path": file_path})
+
+    payload = read_res.data["multimodal"][0]
+    assert (payload["width"], payload["height"]) == (37, 19)
+
+
+@pytest.mark.asyncio
+async def test_read_image_dimensions_describe_the_transmitted_bytes(sys_op, temp_dir):
+    """Not the source image: the compression tiers downscale before sending."""
+    read_tool = ReadFileTool(sys_op)
+    file_path = os.path.join(temp_dir, "big_noise.png")
+    width = height = 1800
+    Image.frombytes("RGB", (width, height), os.urandom(width * height * 3)).save(
+        file_path, format="PNG"
+    )
+
+    read_res = await read_tool.invoke({"file_path": file_path})
+
+    payload = read_res.data["multimodal"][0]
+    assert payload["width"] < width and payload["height"] < height
+
+    # The reported size must match what the data URL actually carries.
+    decoded = base64.b64decode(payload["data_url"].split(",", 1)[1])
+    with Image.open(io.BytesIO(decoded)) as sent:
+        assert sent.size == (payload["width"], payload["height"])
+
+
+@pytest.mark.asyncio
+async def test_read_image_payload_shape_unchanged(sys_op, temp_dir):
+    """Contract guard: the cross-process payload only ever gained keys."""
+    read_tool = ReadFileTool(sys_op)
+    file_path = os.path.join(temp_dir, "shape.png")
+    Image.new("RGB", (4, 4), color=(1, 2, 3)).save(file_path, format="PNG")
+
+    read_res = await read_tool.invoke({"file_path": file_path})
+
+    payload = read_res.data["multimodal"][0]
+    assert {"type", "source", "source_path", "mime_type", "data_url"} <= set(payload)
+    assert payload["type"] == "image"
+    assert payload["source"] == "read_file"
+    assert payload["source_path"] == file_path
+
+
+@pytest.mark.asyncio
+async def test_read_image_payload_converts_to_image_part(sys_op, temp_dir):
+    """``ImagePart.from_data_url`` accepts the payload verbatim."""
+    read_tool = ReadFileTool(sys_op)
+    file_path = os.path.join(temp_dir, "convertible.png")
+    Image.new("RGB", (8, 6), color=(9, 9, 9)).save(file_path, format="PNG")
+
+    read_res = await read_tool.invoke({"file_path": file_path})
+    payload = read_res.data["multimodal"][0]
+
+    part = ImagePart.from_data_url(
+        payload["data_url"], width=payload["width"], height=payload["height"]
+    )
+
+    assert part.mime_type == payload["mime_type"]
+    assert part.estimated_tokens("openai") > 0


### PR DESCRIPTION
Paired: [GitHub #347](https://github.com/openJiuwen-ai/agent-core/pull/347) ↔ [GitCode !2207](https://gitcode.com/openJiuwen/agent-core/merge_requests/2207)

Introduce TextPart/ImagePart plus a normalize_content_part adapter that maps the inbound dialects (OpenAI image_url blocks, filesystem data_url payloads, DashScope bare dicts) onto one typed model, and expose them via BaseMessage.parts / BaseMessage.text. Raw str and dict items keep working.

What this fixes:



/kind feat refactor


**What does this PR do / why do we need it**:
* Currently, `BaseMessage.content` can receive either strings, dicts or lists of these two objects. The dictionaries may represent either text or images, the images can be encoded in base64 or as an url. As a consequence, in many spots in the code base, a check is needed. We can imagine that in the future, as new modals such as audio and video are added, maintaining all of this will become very expensive.
* This PR introduces `ContentPart` as an abstraction. For now they can be two types: `TextPart` or `ImagePart`. This is a way to normalize interaction with these two modals across the codebase. Also, this unties the current use of the OpenAI API as the reference to encode images, which is not compatible to every API such as Anthropic's.
* Now, the encoding/decoding from the API to the agent core ContentPart format is handled by the model clients and is vendor agnostic in the rest of the codebase.
* In addition to that, the data passed to models is validated by pydantic. However, it was not able to correctly handle cases with opaque dictionaries and no error was signaled.

**Which issue(s) this PR fixes**:
- Anthropic multimodal requests. _content_to_blocks forwarded OpenAI image_url blocks verbatim to the Messages API, which has no such block type, so every image sent to Anthropic failed. AnthropicModelClient now renders parts into Anthropic's own image/source shape.
- Producer-stamped dimensions now have a producer. ReadFileTool tracks pixel dimensions through its compression tiers and stamps the transmitted size, making TiktokenCounter._explicit_dimensions reachable instead of dead code.
- List-content truncation in long-term `memory. content[:max_len]` sliced list content by element count, not characters, leaving embedded images fully intact under the limit.
- DashScope MultiModalConversation accepts typed parts and OpenAI blocks rather than only its own bare text/image dicts.
- AssistantMessage serialization goes through pydantic again via @model_serializer, replacing a hand-written model_dump override that broke model_dump_json and exclude/include.


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->
