### PR TITLE
fix(context_evolver): add offline memory storage, prompts, and role-t…

### DIFF
--- a/openjiuwen/extensions/context_evolver/offline_memory/bank_io.py
+++ b/openjiuwen/extensions/context_evolver/offline_memory/bank_io.py
@@ -1,0 +1,136 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Small filesystem helpers for the L2/L3 offline-memory bank.
+
+Nothing here talks to an LLM or knows about any particular trace-log
+format — it only knows how to read/write the memory-bank files on disk
+(YAML profiles, markdown correlation notes, JSONL append logs, and the
+"already processed" ledgers that keep offline extraction idempotent
+across re-runs).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Plain text / YAML
+
+def load_text(path: Path) -> str:
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8").strip()
+
+
+def save_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content.strip() + "\n", encoding="utf-8")
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return data or {}
+
+
+def save_yaml(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump(data, allow_unicode=True, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# JSONL (used for the L3 append-only stores: team_compositions /
+# role_suggestions / anti_patterns)
+
+def load_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            rows.append(json.loads(line))
+    return rows
+
+
+def append_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Plain JSON (used for the L3 playbook's outcome_stats rolling window —
+# a flat dict + list of floats, a more natural fit than YAML)
+
+def load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def save_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def new_item_id(existing: dict[str, Any] | None = None) -> str:
+    """Short stable id for a new playbook item, regenerated on the
+    astronomically unlikely collision against ``existing``'s keys."""
+    existing = existing or {}
+    while True:
+        candidate = uuid.uuid4().hex[:8]
+        if candidate not in existing:
+            return candidate
+
+
+# ---------------------------------------------------------------------------
+# Processed-episode ledgers (idempotency across re-runs)
+
+def load_ledger(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    return set(json.loads(path.read_text(encoding="utf-8")))
+
+
+def save_ledger(path: Path, sample_ids: set[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(sorted(sample_ids), ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Teammate-profile merge — L2 rule: profiles are merged, not replaced. List
+# fields are unioned and capped, scalar fields are overwritten by the newer
+# observation.
+
+def merge_profile(old: dict[str, Any], new: dict[str, Any], list_cap: int = 5) -> dict[str, Any]:
+    merged = dict(old)
+    for key, value in new.items():
+        old_value = merged.get(key)
+        if isinstance(old_value, list) and isinstance(value, list):
+            seen = set(old_value)
+            combined = list(old_value)
+            for item in value:
+                if item not in seen:
+                    combined.append(item)
+                    seen.add(item)
+            merged[key] = combined[:list_cap]
+        else:
+            merged[key] = value
+    return merged

--- a/openjiuwen/extensions/context_evolver/offline_memory/bank_io.py
+++ b/openjiuwen/extensions/context_evolver/offline_memory/bank_io.py
@@ -89,7 +89,8 @@ def save_json(path: Path, data: dict[str, Any]) -> None:
 
 def new_item_id(existing: dict[str, Any] | None = None) -> str:
     """Short stable id for a new playbook item, regenerated on the
-    astronomically unlikely collision against ``existing``'s keys."""
+    astronomically unlikely collision against ``existing``'s keys.
+    """
     existing = existing or {}
     while True:
         candidate = uuid.uuid4().hex[:8]

--- a/openjiuwen/extensions/context_evolver/offline_memory/prompts.py
+++ b/openjiuwen/extensions/context_evolver/offline_memory/prompts.py
@@ -1,0 +1,242 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""L2 and L3 prompt bodies.
+
+The reframing for both: a live team member would normally *call a tool*
+(``update_correlation``, ``suggest_team_improvement``, ...) to record a
+reflection as it happens; these prompts instruct an offline observer to
+*emit the JSON that call would have produced*, given trace evidence instead
+of lived experience. All of the substantive judgment rules (evidence-based,
+reusable patterns not one-off events, word/item caps, category definitions)
+are what actually determine memory quality, and are kept intact regardless
+of which trace format supplied the evidence.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# L2 — pairwise collaboration reflection
+
+L2_SYSTEM_PROMPT = """You are reconstructing L2 collaboration reflection for a multi-agent team, \
+after the fact, from a trace log — standing in for the live process where each agent reflects on \
+its own interactions with one teammate at the end of a task.
+
+You are reflecting AS the member named in "Reflecting member", about ONE specific partner named in \
+"Partner". You are given the actual message exchange between them plus nearby task-status events as \
+evidence (claim/completion timestamps).
+
+You produce TWO outputs with DIFFERENT rules, matching how the live system treats them differently:
+
+1. correlation_notes — you ARE shown the member's previous correlation notes about this same partner \
+(if any) below, under "PREVIOUS correlation notes". CURATE them: keep observations that still hold, \
+drop stale single-task details, fold in what this new evidence adds. Do not just concatenate — rewrite \
+into one coherent, current note.
+
+2. profile — you are NOT shown the previous profile, and must NOT try to restate or reproduce it. \
+Emit ONLY the new observations this episode's evidence supports. The merge with prior profile data \
+happens automatically afterwards, outside this call — if you restate an old observation in slightly \
+different words, it will be recorded as a second, separate item instead of being recognized as the \
+same one, silently bloating the list over time. Only emit something for a field if this episode's \
+evidence actually supports it; leave a field out (empty list / omit) rather than guessing or repeating \
+what you'd expect to already be there.
+
+Rules (same standard the live agents follow):
+- Be evidence-based — every claim must trace back to something in the given exchange, not a guess.
+- Record PATTERNS worth remembering for future collaboration with this partner, not a diary of this \
+one task. A single task's specific error or event is not useful on its own unless it reveals a \
+recurring style (e.g. "follows instructions literally but does not independently verify them" is a \
+pattern; "missed one setting on 2026-07-25" is not).
+- MANDATORY: correlation_notes and every profile field MUST NOT mention specific file names, class \
+names, module names, PR numbers, or other task-specific identifiers — those belong to this one task, \
+not to a reusable collaboration pattern. If a detail only makes sense in the context of this exact \
+task, leave it out.
+- Keep correlation_notes concise — 200 to 500 words total, this is a collaboration protocol, not a diary.
+- Be constructive — the goal is improving future collaboration, not grading the partner.
+- If nothing notable happened (collaboration was routine and smooth), it is fine to say so briefly \
+rather than manufacture a pattern.
+
+Respond with a JSON object of exactly this shape:
+{
+  "correlation_notes": "<200-500 words, prose, curated>",
+  "profile": {
+    "reliability": "high" | "medium" | "low",
+    "strengths": ["<NEW pattern this episode supports>", "... up to 5"],
+    "weaknesses": ["<NEW pattern this episode supports>", "... up to 5"],
+    "communication_style": "<one sentence, only if this episode gives evidence for it>",
+    "notes": ["<brief NEW general observation>", "... up to 3"]
+  }
+}
+Any profile list with nothing new to add this episode should be an empty list, not a restatement.
+"""
+
+
+def build_l2_user_prompt(
+    *,
+    reflecting_role: str,
+    partner_role: str,
+    evidence_block: str,
+    existing_notes: str,
+) -> str:
+    parts = [
+        f"Reflecting member (role_type): {reflecting_role}",
+        f"Partner (role_type): {partner_role}",
+        "",
+        "## Evidence: message exchange and nearby task events",
+        evidence_block or "(no direct messages found — should not normally happen)",
+    ]
+    if existing_notes:
+        parts += ["", "## This member's PREVIOUS correlation notes about this partner", existing_notes]
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# L3 — structural / team-composition reflection (ACE-style incremental: one
+# episode at a time, matched against a persistent playbook — see
+# ``l3.propose_actions``'s docstring for the Generator/Reflector/Curator
+# mapping this implements).
+
+L3_SYSTEM_PROMPT = """You are reconstructing L3 structural reflection for a multi-agent team, after \
+the fact, from ONE completed trace log.
+
+In this system, the LEADER is responsible for breaking the task into subtasks and deciding who to \
+spawn/assign to each one — that decomposition and that spawning choice are the two decisions this \
+whole exercise exists to learn from. You are not writing a retrospective summary of "what happened" \
+— you are extracting reusable DECISION-TIME GUIDANCE for a FUTURE leader who is about to face a \
+similar task and has to make the same two decisions: how to break it down, and who to spawn/assign.
+
+You are shown this ONE episode's evidence, and the team's CURRENT playbook of structural insights \
+accumulated from previous episodes (each with a stable id, category, description, and how many prior \
+episodes have reinforced vs. contradicted it). Your job is to decide, for each insight this episode's \
+evidence supports, whether it MATCHES something already in the playbook or is genuinely NEW.
+
+The evidence below is split into TWO kinds, and you must not blur them together:
+
+1. PROCESS EVIDENCE — what the team actually did (roles spawned, task breakdown, cost, timeline, \
+delegation timing, communication). This is what you're extracting decomposition/spawning guidance \
+FROM.
+2. GROUND TRUTH — the deliverable's graded quality (outcome label, compliance, not-satisfied rubric \
+criteria). This came from an INDEPENDENT grader that only ever read the final document — it has ZERO \
+visibility into the team's process, roles, or coordination. It tells you WHAT was wrong, never WHY.
+
+Your job is to find DEFENSIBLE causal bridges between the two — not to assume that anything in the \
+process evidence explains anything in the ground truth just because they're both shown to you. Two \
+things being true about the same episode does not mean one caused the other. Only draw a connection \
+you could justify by a specific mechanism (e.g. "no task in the breakdown covered cross-checking \
+sections against each other, and the gap is specifically about cross-section consistency, so the \
+missing task plausibly explains it"). Most rubric gaps reflect single-writer execution quality \
+(formatting, missing content elements, technical errors, things that would exist even with a solo \
+writer) and have NOTHING to do with team structure — that's an L1 self-improvement concern, not \
+yours. It is common and CORRECT to find that none of the shown gaps have a defensible structural \
+cause, even when several are shown. Also note: the outcome label (success/failure) reflects OVERALL \
+compliance across ALL graded criteria, most of which are satisfied and not shown — a "success" \
+episode can still have some listed gaps below; that is normal and does not by itself need a \
+structural explanation.
+
+Evaluate the leader's decomposition and spawning choices, each tied to specific PROCESS evidence:
+- Team size and coverage — "Roles spawned" (with counts) and "Task breakdown": did the number/mix of \
+roles the leader spawned match the number/shape of subtasks it created?
+- Bottlenecks — "Cost share by role" and "Timeline by role": did one role consume a disproportionate \
+share of cost or time given how many members held that role (a role with 5x members splitting cost 5 \
+ways is different from 1 member consuming that share alone)?
+- Verification gaps — "Task breakdown" and "Roles spawned": did any role's output get reviewed by \
+another before the deliverable was finalized, or did the roster/breakdown lack any review or \
+integration step at all?
+- Parallelism — "Timeline by role": for a role with multiple members, compare its wall-clock active \
+window against its average individual member span — a span close to the wall window suggests genuine \
+overlap, a span much shorter suggests staggering when overlap was available.
+- Delegation efficiency — "Delegation timing": how much of the episode elapsed before the leader had \
+reached every teammate it directly assigned work to?
+- Communication — "Communication": message volume/length by role-pair, and whether broadcasts vs. \
+targeted messages were used appropriately for the coordination need.
+- Idle/unused roles — a role with no timeline entry, or a trivial cost/message share.
+- Prefer STRUCTURAL changes (new/removed roles, or a changed decomposition pattern) over rule changes \
+when the same failure recurs despite instructions already covering it — a dedicated role or a \
+changed breakdown is more durable than another paragraph of instructions.
+
+For EACH insight this episode's evidence supports:
+- If it MATCHES an existing playbook item (same underlying claim, even if this episode's specific \
+details differ from what created it) — output {"item_id": "<that id>", "verdict": "reinforce", \
+"evidence_note": "..."}.
+- If this episode's evidence actively CONTRADICTS an existing item — output {"item_id": "<that id>", \
+"verdict": "contradict", "evidence_note": "..."}. Do NOT decide to remove, deprecate, or rewrite the \
+item yourself — that judgment happens later, in a separate review pass, once enough episodes have \
+weighed in. Your only job here is to record that this one episode pushed against it.
+- If it is genuinely NEW — not covered by anything in the current playbook shown below — output \
+{"verdict": "new", "category": ..., "description": ..., ...}.
+
+Rules:
+- ONLY use an item_id that literally appears in "Current playbook" below. Never invent one.
+- Be evidence-based — every action must trace back to something in this episode's evidence.
+- Most episodes support NOTHING new or notable. An empty actions list is the normal, expected result \
+— do not manufacture an insight just to produce output.
+- MANDATORY phrasing for a "new" item's description: it must be DECISION-TIME GUIDANCE a future \
+leader could apply BEFORE spawning/delegating — "<when a task looks like X>, <do Y>" — not a \
+generic retrospective observation. "Communication could be improved" is not acceptable; \
+"when N roles each produce an independent section of one document, assign an explicit integration/\
+consistency pass before finalizing" is the right shape. It must describe a REUSABLE pattern (would \
+this guidance matter for a future, different task?), not a one-off detail specific to this task.
+- MANDATORY: descriptions and evidence_notes MUST NOT mention specific file names, class names, or \
+other task-specific identifiers.
+
+Categories (use exactly these strings):
+- "agent_change": a SPAWNING-STRATEGY heuristic — trigger_condition (what the task looks like) -> \
+recommended_role_type (a short, generic, reusable role label, e.g. "integration_reviewer" — NEVER an \
+ephemeral persona name like "attention-expert", those don't persist to future tasks). This is NOT an \
+instruction to literally add/remove a permanent team member — neither mode has a persistent \
+roster the leader could act on that way: predefined's roster is fixed by the harness (the leader has \
+no power to change it at all), and dynamic's spawned personas are invented fresh every task (there is \
+no roster to permanently add to). What's actually useful is a rule the leader's own reasoning can \
+apply the NEXT time it decomposes a similar task. ONLY propose "agent_change" items when Team mode \
+(shown below) is "dynamic" — in "predefined" mode there is no spawning decision to give guidance \
+about; use "workflow" there instead for decomposition/delegation guidance. Fields: "action" \
+("include" — recommend spawning this role type when the trigger applies, or "avoid" — recommend NOT \
+spawning it, e.g. because evidence shows it's consistently redundant), "recommended_role_type", \
+"trigger_condition", "expertise".
+- "workflow": how the team coordinates — handoffs, task decomposition, delegation timing, and \
+especially integration/consistency steps for multi-part deliverables. Use this (not "agent_change") \
+for predefined-mode decomposition/delegation guidance, since predefined's roster can't change.
+- "constitution": team-wide principles/standards that should change.
+- "communication": message format, reporting content, information-sharing patterns.
+
+Respond with a JSON object of exactly this shape:
+{
+  "actions": [
+    {
+      "item_id": "<existing id, only for reinforce/contradict>",
+      "verdict": "reinforce" | "contradict" | "new",
+      "evidence_note": "<what in this episode supports this action>",
+      "category": "agent_change" | "workflow" | "constitution" | "communication",
+      "description": "<specific, reusable — only for verdict=\\"new\\">",
+      "action": "<only for agent_change + new: \\"include\\" | \\"avoid\\">",
+      "recommended_role_type": "<only for agent_change + new: short, generic, reusable label>",
+      "trigger_condition": "<only for agent_change + new: what the task looks like when this applies>",
+      "expertise": "<only for agent_change + new>"
+    }
+  ]
+}
+"""
+
+
+def format_playbook_for_prompt(items: dict) -> str:
+    active = {k: v for k, v in items.items() if v.get("status", "active") == "active"}
+    if not active:
+        return "(playbook is currently empty for this task_category — everything you find is \"new\")"
+    ranked = sorted(active.items(), key=lambda kv: -kv[1].get("support_count", 0))
+    lines = [
+        f"- id={item_id} [{item.get('category', '')}] "
+        f"support={item.get('support_count', 0)} contradict={item.get('contradict_count', 0)}: "
+        f"{item.get('description', '')}"
+        for item_id, item in ranked
+    ]
+    return "\n".join(lines)
+
+
+def build_l3_user_prompt(*, task_category: str, mode: str, episode_evidence_block: str, playbook_block: str) -> str:
+    return (
+        f"Task category: {task_category}\n"
+        f"Team mode: {mode}\n\n"
+        "## This episode's evidence\n"
+        f"{episode_evidence_block}\n\n"
+        "## Current playbook (accumulated from previous episodes)\n"
+        f"{playbook_block}"
+    )

--- a/openjiuwen/extensions/context_evolver/offline_memory/role_normalizer.py
+++ b/openjiuwen/extensions/context_evolver/offline_memory/role_normalizer.py
@@ -62,7 +62,8 @@ Respond with a JSON object:
 
 class RosterMemberLike(Protocol):
     """Structural type for whatever roster-member record a caller has —
-    decouples this module from any one trace-format's roster dataclass."""
+    decouples this module from any one trace-format's roster dataclass.
+    """
 
     member_name: str
     display_name: str

--- a/openjiuwen/extensions/context_evolver/offline_memory/role_normalizer.py
+++ b/openjiuwen/extensions/context_evolver/offline_memory/role_normalizer.py
@@ -1,0 +1,178 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Resolve a roster member to a stable ``role_type`` for memory-bank keying.
+
+Predefined and dynamic mode are never mixed — an instance is always
+constructed for one mode, and a dynamic-mode taxonomy is never consulted
+for a predefined-mode run or vice versa.
+
+- ``predefined`` mode: a fixed roster with already-stable member names
+  (e.g. ``team_leader`` / ``researcher`` / ``skeptic`` / ``writer``) —
+  identity mapping, no LLM call, no taxonomy file.
+- ``dynamic`` mode: the leader invents member names per task (e.g.
+  ``edtech-designer``, ``moe-expert``) — these must be classified into a
+  small, persisted taxonomy of canonical role types, or L2/L3 memory keyed
+  by raw member_name fragments into near-duplicates forever. Classification
+  uses a cheap model tier: this is a low-stakes routing call, not a
+  judgment call, and it is easy to re-derive if wrong.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Protocol
+
+from pydantic import BaseModel, Field, ValidationError, field_validator
+
+from openjiuwen.core.common.exception.codes import StatusCode
+from openjiuwen.core.common.exception.errors import raise_error
+from openjiuwen.core.common.logging import memory_logger
+from openjiuwen.core.foundation.llm import JsonOutputParser, Model, SystemMessage, UserMessage
+from openjiuwen.extensions.context_evolver.offline_memory import bank_io
+
+SEED_TAXONOMY: dict[str, str] = {
+    "leader": "Coordinates the team, assigns and tracks tasks, synthesizes the final call.",
+    "researcher": "Gathers supporting evidence and background for a question.",
+    "skeptic": "Independently reviews a design for gaps, contradictions, or weak claims.",
+    "writer": "Synthesizes team input into the final deliverable document.",
+    "domain_specialist": "Provides deep expertise in one specific technical sub-domain.",
+    "architect": "Designs system/infrastructure structure (architecture, data flow, deployment).",
+    "reviewer": "Verifies correctness or completeness of another member's work.",
+}
+
+_CLASSIFY_SYSTEM_PROMPT = """You classify a multi-agent teammate into a canonical role type for a \
+memory system that accumulates collaboration notes across many tasks. The team roster changes \
+every task (member names and personas are invented per-task), so notes must be keyed by a small, \
+stable set of role types rather than by the raw invented name — otherwise every task creates a new \
+role and nothing ever accumulates.
+
+Given the member's display name and description, and the CURRENT taxonomy of canonical role types, \
+decide:
+- If an existing role type is a reasonable fit (same core function, even if the specific domain \
+differs — e.g. "moe-expert" and "attention-expert" are both "domain_specialist"), return it.
+- If no existing type fits without being misleading, propose ONE new canonical role type: a short \
+lowercase_snake_case name plus a one-sentence, domain-agnostic description (describe the FUNCTION, \
+not the specific subject matter, so it generalizes to future tasks).
+
+Respond with a JSON object:
+{"role_type": "<chosen or new type name>", "is_new": true|false, "new_description": "<only if is_new>"}
+"""
+
+
+class RosterMemberLike(Protocol):
+    """Structural type for whatever roster-member record a caller has —
+    decouples this module from any one trace-format's roster dataclass."""
+
+    member_name: str
+    display_name: str
+    desc: str
+
+
+class RoleClassificationResult(BaseModel):
+    role_type: str = Field(default="")
+    is_new: bool = Field(default=False)
+    new_description: str = Field(default="")
+
+    @field_validator("new_description", mode="before")
+    @classmethod
+    def _null_to_empty(cls, value: str | None) -> str:
+        # The prompt documents new_description as "only if is_new" -- the
+        # model correctly omits it (JSON null) whenever is_new is false.
+        return value or ""
+
+
+def _format_taxonomy(taxonomy: dict[str, str]) -> str:
+    return "\n".join(f"- {name}: {desc}" for name, desc in sorted(taxonomy.items()))
+
+
+class RoleNormalizer:
+    def __init__(
+        self,
+        mode: str,
+        taxonomy_path: Path | None = None,
+        *,
+        model: Model | None = None,
+        retries: int = 3,
+    ):
+        if mode not in ("predefined", "dynamic"):
+            raise ValueError(f"mode must be 'predefined' or 'dynamic', got {mode!r}")
+        self.mode = mode
+        self.taxonomy_path = taxonomy_path
+        self._model = model
+        self._retries = retries
+        self._taxonomy: dict[str, str] = {}
+        self._cache: dict[tuple[str, str], str] = {}  # (display_name, desc) -> role_type
+
+        # predefined mode never reaches here — self._taxonomy stays {} and
+        # unused, since resolve() short-circuits to identity below.
+        if mode == "dynamic":
+            if taxonomy_path is None:
+                raise ValueError("dynamic mode requires taxonomy_path")
+            if model is None:
+                raise ValueError("dynamic mode requires a model for role classification")
+            self._taxonomy = bank_io.load_yaml(taxonomy_path)
+            if not self._taxonomy:
+                self._taxonomy = dict(SEED_TAXONOMY)
+                bank_io.save_yaml(self.taxonomy_path, self._taxonomy)
+
+    async def resolve(self, member: RosterMemberLike) -> str:
+        # predefined: roster names are already stable, identity is exact.
+        if self.mode == "predefined":
+            return member.member_name
+
+        # dynamic: classify against the taxonomy, cached per (display_name, desc)
+        # so the same invented persona seen across many episodes in one run
+        # only costs one LLM call.
+        cache_key = (member.display_name, member.desc)
+        if cache_key in self._cache:
+            return self._cache[cache_key]
+
+        result = await self._classify(member)
+
+        role_type = result.role_type.strip().lower().replace(" ", "_")
+        if not role_type:
+            role_type = "domain_specialist"  # safe fallback, never leave a member unkeyed
+
+        if result.is_new and role_type not in self._taxonomy:
+            self._taxonomy[role_type] = result.new_description.strip() or member.desc
+            bank_io.save_yaml(self.taxonomy_path, self._taxonomy)
+
+        self._cache[cache_key] = role_type
+        return role_type
+
+    async def _classify(self, member: RosterMemberLike) -> RoleClassificationResult:
+        messages = [
+            SystemMessage(content=_CLASSIFY_SYSTEM_PROMPT),
+            UserMessage(
+                content=(
+                    f"Current taxonomy:\n{_format_taxonomy(self._taxonomy)}\n\n"
+                    f"Member to classify:\n"
+                    f"display_name: {member.display_name}\n"
+                    f"desc: {member.desc}"
+                )
+            ),
+        ]
+        parser = JsonOutputParser()
+        last_err: Exception | None = None
+        for attempt in range(self._retries):
+            try:
+                response = await self._model.invoke(messages=messages)
+                res = await parser.parse(response.content)
+                return RoleClassificationResult.model_validate(res)
+            except (json.JSONDecodeError, ValidationError) as exc:
+                last_err = exc
+                memory_logger.warning(
+                    "role classification call failed on attempt %d/%d: %s", attempt + 1, self._retries, exc
+                )
+        raise_error(
+            StatusCode.TOOLCHAIN_EVOLVING_MEMORY_LLM_GENERATION_EXECUTION_ERROR,
+            reason=f"role classification failed after {self._retries} attempts: {last_err}",
+        )
+
+    async def resolve_roster(self, roster: list[RosterMemberLike]) -> dict[str, str]:
+        """Return {member_name: role_type} for every member in the roster."""
+        mapping: dict[str, str] = {}
+        for member in roster:
+            mapping[member.member_name] = await self.resolve(member)
+        return mapping


### PR DESCRIPTION
Paired: [GitHub #356](https://github.com/openJiuwen-ai/agent-core/pull/356) ↔ [GitCode !2213](https://gitcode.com/openJiuwen/agent-core/merge_requests/2213)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openJiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
Choose one label from `bug`, `task`, `feature` and `refactor`, and replace `<label>` below the comment block. 

If this pr is not only bugfix/task/feature and also a refactor, you can append `/kind refactor` label after `/kind bug`, `/kind task` and `/kind feature`.
-->
/kind bug


**What does this PR do / why do we need it**:
Adds the storage, prompt, and role-taxonomy infrastructure for offline L2/L3
memory (post-hoc reflection on completed multi-agent team trace logs), under
`openjiuwen/extensions/context_evolver/offline_memory/`:

- `bank_io.py` — filesystem helpers for the memory bank (YAML profiles,
  markdown correlation notes, JSONL append logs, processed-episode ledgers).
- `prompts.py` — L2 (pairwise collaboration reflection) and L3 (structural
  team-composition reflection) system prompt bodies.
- `role_normalizer.py` — classifies a dynamically-spawned teammate persona
  into a stable, reusable `role_type` for memory-bank keying, via a cheap
  LLM classification call cached per (display_name, desc).

This is infrastructure only — no L2/L3 extraction logic, rendering, or
public API surface yet (follow-up PRs), and no wiring into any running
team (rail integration is a separate, later PR; this package has no
automatic callers yet).


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/openJiuwen-ai/agent-core/issues/354


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：
- `import openjiuwen.extensions.context_evolver.offline_memory.role_normalizer`
  succeeds cleanly against both `upstream/develop` and `upstream/main`.
- No automated test coverage in *this* commit — `test_bank_io.py` and
  `test_role_normalizer.py` are staged as a follow-up commit on this branch.


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [ ] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [ ] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #354
<!-- /bot1-related-issues -->
