### PR TITLE
fix(evolving): stop staging sandbox payloads at predictable temp paths

### DIFF
--- a/openjiuwen/agent_evolving/evaluator/evaluator_pipeline/adapters/agents/jiuwenswarm.py
+++ b/openjiuwen/agent_evolving/evaluator/evaluator_pipeline/adapters/agents/jiuwenswarm.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -13,6 +17,64 @@ from ...base import BaseAgentAdapter, register_agent
 from ...docker_env import DockerEnvironment
 from ...models import AgentContext, AgentRunResult, SkillDelta, Task
 from ...skill_manager import extract_specific_errors
+
+
+@contextmanager
+def _staged_file(content: str, suffix: str = "") -> Iterator[Path]:
+    """Materialise ``content`` on the host just long enough to copy it into a sandbox.
+
+    Files handed to the sandbox are written to the shared temporary directory,
+    which on a multi-user host is world-writable and world-readable. Writing
+    them at a fixed, caller-derived path there is unsafe twice over: any local
+    account can read the content while the copy is in flight, and any local
+    account can pre-create the path as a symlink so the write lands somewhere
+    of its choosing.
+
+    ``tempfile.mkstemp`` closes both holes in one atomic step. It picks an
+    unpredictable name, refuses to follow an existing path, and creates the
+    file readable and writable by its owner only. The file is removed when the
+    block exits, including when the block raises, so a failed copy cannot leave
+    the content behind.
+    """
+    fd, raw_path = tempfile.mkstemp(prefix="jiuwenswarm_", suffix=suffix)
+    path = Path(raw_path)
+    try:
+        try:
+            handle = os.fdopen(fd, "w", encoding="utf-8")
+        except BaseException:
+            # The descriptor is only owned by the file object once ``fdopen``
+            # has returned one, so a failure here has to close it by hand.
+            os.close(fd)
+            raise
+        with handle:
+            handle.write(content)
+        yield path
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def _debug_dir() -> Path:
+    """Create a fresh directory for one run's debug output.
+
+    ``mkdtemp`` creates the directory with mode 0700 and a name nobody else can
+    guess, so an existing path in the shared temporary directory can neither be
+    adopted nor followed as a symlink. The directory is deliberately left in
+    place after the run; its location is logged so it can be found.
+    """
+    return Path(tempfile.mkdtemp(prefix="jiuwenswarm_debug_"))
+
+
+def _write_private(path: Path, content: str) -> None:
+    """Write ``content`` to ``path``, refusing to follow an existing symlink.
+
+    ``O_NOFOLLOW`` makes the open fail rather than write through a symlink
+    someone else planted, and the explicit mode keeps the umask from widening
+    the result.
+    """
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW
+    fd = os.open(path, flags, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write(content)
 
 
 @register_agent("jiuwenswarm")
@@ -138,11 +200,8 @@ PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple
 PIP_TIMEOUT=120
 PIP_DEFAULT_TIMEOUT=120
 """
-        env_path = Path("/tmp/jiuwenswarm_env")
-        env_path.write_text(env_content, encoding="utf-8")
-        await env.copy_to(env_path, f"{self.CONFIG_DIR}/.env")
-        if env_path.exists():
-            env_path.unlink()
+        with _staged_file(env_content, suffix=".env") as env_path:
+            await env.copy_to(env_path, f"{self.CONFIG_DIR}/.env")
         logger.info(f"  ✓ Created .env file (evolution={'enabled' if evolution_enabled else 'disabled'})")
 
         config_yaml = f"""preferred_language: en
@@ -172,11 +231,8 @@ react:
 memory:
   engine: none
 """
-        config_path = Path("/tmp/jiuwenswarm_config.yaml")
-        config_path.write_text(config_yaml, encoding="utf-8")
-        await env.copy_to(config_path, f"{self.CONFIG_DIR}/config.yaml")
-        if config_path.exists():
-            config_path.unlink()
+        with _staged_file(config_yaml, suffix=".yaml") as config_path:
+            await env.copy_to(config_path, f"{self.CONFIG_DIR}/config.yaml")
         logger.info(f"  ✓ Created config.yaml (evolution={'enabled' if evolution_enabled else 'disabled'})")
 
         return True
@@ -219,11 +275,8 @@ memory:
         skill_dir = f"{self.SKILL_DIR}/{skill_name}"
         await env.exec(f"mkdir -p {skill_dir}", timeout=10)
 
-        skill_path = Path(f"/tmp/skill_{skill_name}.md")
-        skill_path.write_text(skill_content, encoding="utf-8")
-        success = await env.copy_to(skill_path, f"{skill_dir}/SKILL.md")
-        if skill_path.exists():
-            skill_path.unlink()
+        with _staged_file(skill_content, suffix=".md") as skill_path:
+            success = await env.copy_to(skill_path, f"{skill_dir}/SKILL.md")
 
         if not success:
             logger.error(f"  Failed to load skill: {skill_name}")
@@ -232,25 +285,19 @@ memory:
         logger.info(f"  Skill loaded: {skill_dir}/SKILL.md")
 
         if evo_content:
-            evo_path = Path(f"/tmp/evolutions_{skill_name}.json")
-            evo_path.write_text(evo_content, encoding="utf-8")
-            evo_success = await env.copy_to(evo_path, f"{skill_dir}/evolutions.json")
+            with _staged_file(evo_content, suffix=".json") as evo_path:
+                evo_success = await env.copy_to(evo_path, f"{skill_dir}/evolutions.json")
             if evo_success:
                 logger.info(f"  Evolutions loaded: {skill_dir}/evolutions.json ({len(evo_content)} chars)")
-            if evo_path.exists():
-                evo_path.unlink()
 
         if evo_files:
             evolution_dir = f"{skill_dir}/evolution"
             await env.exec(f"mkdir -p {evolution_dir}", timeout=10)
             for filename, file_content in evo_files.items():
-                file_path = Path(f"/tmp/evolution_{skill_name}_{filename}")
-                file_path.write_text(file_content, encoding="utf-8")
-                file_success = await env.copy_to(file_path, f"{evolution_dir}/{filename}")
+                with _staged_file(file_content) as file_path:
+                    file_success = await env.copy_to(file_path, f"{evolution_dir}/{filename}")
                 if file_success:
                     logger.info(f"  Evolution file loaded: {evolution_dir}/{filename}")
-                if file_path.exists():
-                    file_path.unlink()
 
         return True
 
@@ -275,11 +322,9 @@ memory:
             container_skill_dir = f"{self.SKILL_DIR}/{skill_name}"
             await env.exec(f"mkdir -p {container_skill_dir}", timeout=10)
 
-            tmp_path = Path(f"/tmp/skill_{skill_name}.md")
-            tmp_path.write_text(skill_md.read_text(encoding="utf-8"), encoding="utf-8")
-            success = await env.copy_to(tmp_path, f"{container_skill_dir}/SKILL.md")
-            if tmp_path.exists():
-                tmp_path.unlink()
+            skill_content = skill_md.read_text(encoding="utf-8")
+            with _staged_file(skill_content, suffix=".md") as tmp_path:
+                success = await env.copy_to(tmp_path, f"{container_skill_dir}/SKILL.md")
 
             if success:
                 loaded_skills.append(skill_name)
@@ -287,11 +332,9 @@ memory:
 
             for extra in skill_subdir.iterdir():
                 if extra.is_file() and extra.name != "SKILL.md":
-                    tmp_extra = Path(f"/tmp/skill_{skill_name}_{extra.name}")
-                    tmp_extra.write_text(extra.read_text(encoding="utf-8"), encoding="utf-8")
-                    await env.copy_to(tmp_extra, f"{container_skill_dir}/{extra.name}")
-                    if tmp_extra.exists():
-                        tmp_extra.unlink()
+                    extra_content = extra.read_text(encoding="utf-8")
+                    with _staged_file(extra_content) as tmp_extra:
+                        await env.copy_to(tmp_extra, f"{container_skill_dir}/{extra.name}")
 
         self._all_skill_names = loaded_skills
         if loaded_skills:
@@ -321,29 +364,19 @@ memory:
             else:
                 logger.info(f"  Single-run mode: executing task without skill evolution")
 
-        instruction_path = Path("/tmp/instruction.txt")
-        instruction_path.write_text(task.instruction, encoding="utf-8")
-        await env.copy_to(instruction_path, "/tmp/jiuwenswarm_instruction.txt")
+        with _staged_file(task.instruction, suffix=".txt") as instruction_path:
+            await env.copy_to(instruction_path, "/tmp/jiuwenswarm_instruction.txt")
 
         system_message = self._build_system_message(
             iteration, has_skill, evolution_suggestions, previous_result
         )
         if system_message:
-            system_path = Path("/tmp/system_message.txt")
-            system_path.write_text(system_message, encoding="utf-8")
-            await env.copy_to(system_path, "/tmp/jiuwenswarm_system_message.txt")
-            if system_path.exists():
-                system_path.unlink()
+            with _staged_file(system_message, suffix=".txt") as system_path:
+                await env.copy_to(system_path, "/tmp/jiuwenswarm_system_message.txt")
 
         runner_script = _get_runner_script()
-        runner_path = Path("/tmp/jiuwenswarm_runner.py")
-        runner_path.write_text(runner_script, encoding="utf-8")
-        await env.copy_to(runner_path, "/tmp/jiuwenswarm_runner.py")
-
-        if runner_path.exists():
-            runner_path.unlink()
-        if instruction_path.exists():
-            instruction_path.unlink()
+        with _staged_file(runner_script, suffix=".py") as runner_path:
+            await env.copy_to(runner_path, "/tmp/jiuwenswarm_runner.py")
 
         start_time = time.time()
         evolution_wait = self._config.get("evolution_wait_time", 60) if has_skill else 0
@@ -360,11 +393,11 @@ memory:
         raw_output = result.stdout
         stderr = result.stderr
 
-        debug_dir = Path("/tmp/jiuwenswarm_debug")
-        debug_dir.mkdir(parents=True, exist_ok=True)
-        (debug_dir / "raw_output.txt").write_text(raw_output, encoding="utf-8")
+        debug_dir = _debug_dir()
+        _write_private(debug_dir / "raw_output.txt", raw_output)
         if stderr:
-            (debug_dir / "stderr.txt").write_text(stderr, encoding="utf-8")
+            _write_private(debug_dir / "stderr.txt", stderr)
+        logger.info(f"  Debug output written to {debug_dir}")
 
         trajectory = []
         final_response = ""

--- a/tests/unit_tests/agent_evolving/evaluator/evaluator_pipeline/adapters/agents/test_jiuwenswarm.py
+++ b/tests/unit_tests/agent_evolving/evaluator/evaluator_pipeline/adapters/agents/test_jiuwenswarm.py
@@ -2,6 +2,9 @@
 # Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
 """Tests for JiuWenSwarm agent adapter."""
 
+import os
+import stat
+import tempfile
 from pathlib import Path
 from unittest.mock import patch, MagicMock, AsyncMock
 
@@ -10,8 +13,15 @@ import yaml
 
 from openjiuwen.agent_evolving.evaluator.evaluator_pipeline.adapters.agents.jiuwenswarm import (
     JiuWenSwarmAgent,
+    _debug_dir,
+    _staged_file,
+    _write_private,
 )
-from openjiuwen.agent_evolving.evaluator.evaluator_pipeline.models import ExecResult
+from openjiuwen.agent_evolving.evaluator.evaluator_pipeline.models import (
+    AgentContext,
+    ExecResult,
+    Task,
+)
 
 
 class TestJiuWenSwarmAgentInit:
@@ -82,6 +92,316 @@ class TestJiuWenSwarmAgentValidateConfig:
         errors = agent.validate_config()
         
         assert len(errors) == 0
+
+
+class TestStagedFile:
+    """The staging helper must not expose its content to other local accounts."""
+
+    @staticmethod
+    def test_staged_file_is_private_to_its_owner():
+        with _staged_file("payload") as path:
+            assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+    @staticmethod
+    def test_staged_file_holds_the_content():
+        with _staged_file("payload", suffix=".env") as path:
+            assert path.read_text(encoding="utf-8") == "payload"
+            assert path.suffix == ".env"
+
+    @staticmethod
+    def test_staged_file_lives_in_the_configured_temp_dir():
+        with _staged_file("payload") as path:
+            assert path.parent == Path(tempfile.gettempdir())
+
+    @staticmethod
+    def test_staged_names_are_not_reused():
+        with _staged_file("payload") as first, _staged_file("payload") as second:
+            assert first != second
+
+    @staticmethod
+    def test_staged_file_is_removed_on_success():
+        with _staged_file("payload") as path:
+            assert path.exists()
+        assert not path.exists()
+
+    @staticmethod
+    def test_staged_file_is_removed_when_the_body_raises():
+        captured: list[Path] = []
+        with pytest.raises(RuntimeError):
+            with _staged_file("payload") as path:
+                captured.append(path)
+                raise RuntimeError("copy failed")
+
+        assert captured and not captured[0].exists()
+
+    @staticmethod
+    def test_staged_file_is_removed_when_the_write_fails():
+        """A failed write must not strand the partially staged content."""
+        staged: list[Path] = []
+        real_mkstemp = tempfile.mkstemp
+        real_fdopen = os.fdopen
+
+        def recording_mkstemp(*args, **kwargs):
+            fd, raw_path = real_mkstemp(*args, **kwargs)
+            staged.append(Path(raw_path))
+            return fd, raw_path
+
+        class FailingHandle:
+            def __init__(self, handle):
+                self._handle = handle
+
+            def write(self, _content):
+                raise OSError("no space left on device")
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_exc_info):
+                self._handle.close()
+                return False
+
+        def failing_fdopen(fd, *args, **kwargs):
+            return FailingHandle(real_fdopen(fd, *args, **kwargs))
+
+        with patch.object(tempfile, "mkstemp", recording_mkstemp):
+            with patch("os.fdopen", failing_fdopen):
+                with pytest.raises(OSError):
+                    with _staged_file("payload"):
+                        pass
+
+        assert staged and not staged[0].exists()
+
+    @staticmethod
+    def test_staged_file_closes_the_descriptor_it_cannot_wrap():
+        """``mkstemp`` hands over a descriptor that must not outlive a failed wrap."""
+        staged: list[Path] = []
+        descriptors: list[int] = []
+        real_mkstemp = tempfile.mkstemp
+
+        def recording_mkstemp(*args, **kwargs):
+            fd, raw_path = real_mkstemp(*args, **kwargs)
+            descriptors.append(fd)
+            staged.append(Path(raw_path))
+            return fd, raw_path
+
+        def failing_fdopen(*_args, **_kwargs):
+            raise MemoryError("cannot allocate the file object")
+
+        with patch.object(tempfile, "mkstemp", recording_mkstemp):
+            with patch("os.fdopen", failing_fdopen):
+                with pytest.raises(MemoryError):
+                    with _staged_file("payload"):
+                        pass
+
+        with pytest.raises(OSError):
+            os.fstat(descriptors[0])
+        assert staged and not staged[0].exists()
+
+
+class TestDebugOutput:
+    """Debug output must not be writable, or readable, by other local accounts."""
+
+    @staticmethod
+    def test_debug_dir_is_private_and_unpredictable():
+        first = _debug_dir()
+        second = _debug_dir()
+        try:
+            assert stat.S_IMODE(first.stat().st_mode) == 0o700
+            assert first.parent == Path(tempfile.gettempdir())
+            assert first != second
+        finally:
+            first.rmdir()
+            second.rmdir()
+
+    @staticmethod
+    def test_write_private_creates_an_owner_only_file(tmp_path):
+        target = tmp_path / "raw_output.txt"
+        _write_private(target, "transcript")
+
+        assert target.read_text(encoding="utf-8") == "transcript"
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+    @staticmethod
+    def test_write_private_truncates_an_existing_file(tmp_path):
+        target = tmp_path / "raw_output.txt"
+        _write_private(target, "long previous transcript")
+        _write_private(target, "short")
+
+        assert target.read_text(encoding="utf-8") == "short"
+
+    @staticmethod
+    def test_write_private_refuses_to_follow_a_symlink(tmp_path):
+        victim = tmp_path / "victim.txt"
+        victim.write_text("untouched", encoding="utf-8")
+        planted = tmp_path / "raw_output.txt"
+        planted.symlink_to(victim)
+
+        with pytest.raises(OSError):
+            _write_private(planted, "attacker-chosen content")
+
+        assert victim.read_text(encoding="utf-8") == "untouched"
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_run_sends_its_output_through_the_private_helpers(tmp_path):
+        """The run path itself must not fall back to a fixed, shared directory."""
+        env = MagicMock()
+        env.exec = AsyncMock(
+            return_value=ExecResult(stdout="transcript", stderr="diagnostics", returncode=0)
+        )
+        env.copy_to = AsyncMock(return_value=True)
+        agent = JiuWenSwarmAgent(
+            {
+                "api_key": "not-a-real-key-0123456789",
+                "api_base": "https://api.example.invalid",
+            }
+        )
+
+        real_mkdtemp = tempfile.mkdtemp
+
+        def redirected_mkdtemp(prefix="", **_kwargs):
+            return real_mkdtemp(prefix=prefix, dir=tmp_path)
+
+        with patch.object(tempfile, "mkdtemp", redirected_mkdtemp):
+            await agent.run(
+                env,
+                Task(task_id="task-1", instruction="do the thing"),
+                AgentContext(iteration=1, has_skill=False),
+            )
+
+        created = [entry for entry in tmp_path.iterdir() if entry.is_dir()]
+        assert len(created) == 1
+        assert stat.S_IMODE(created[0].stat().st_mode) == 0o700
+        for name in ("raw_output.txt", "stderr.txt"):
+            written = created[0] / name
+            assert stat.S_IMODE(written.stat().st_mode) == 0o600
+
+
+class TestJiuWenSwarmAgentCredentialStaging:
+    """The API key must never rest at a guessable path in the shared temp dir."""
+
+    API_KEY = "not-a-real-key-0123456789"
+
+    def _agent_and_env(self, copy_to):
+        async def exec_command(command: str, timeout: int) -> ExecResult:
+            stdout = "OK" if "import jiuwenswarm" in command else ""
+            return ExecResult(stdout=stdout, returncode=0)
+
+        env = MagicMock()
+        env.exec = AsyncMock(side_effect=exec_command)
+        env.copy_to = AsyncMock(side_effect=copy_to)
+        agent = JiuWenSwarmAgent(
+            {
+                "api_key": self.API_KEY,
+                "api_base": "https://api.example.invalid",
+                "model_name": "example-model",
+            }
+        )
+        return agent, env
+
+    @pytest.mark.asyncio
+    async def test_env_file_is_staged_privately_and_unpredictably(self):
+        staged: dict[str, tuple[Path, int]] = {}
+
+        async def copy_to(source: Path, destination: str) -> bool:
+            source = Path(source)
+            staged[destination] = (source, stat.S_IMODE(source.stat().st_mode))
+            return True
+
+        agent, env = self._agent_and_env(copy_to)
+        assert await agent.setup(env) is True
+
+        env_path, mode = staged[f"{agent.CONFIG_DIR}/.env"]
+
+        # Readable and writable by the owner only, for the whole copy window.
+        assert mode == 0o600
+
+        # The name must not be derivable from the configuration, so it cannot be
+        # pre-created as a symlink pointing somewhere else.
+        assert "jiuwenswarm_env" not in env_path.name
+        assert self.API_KEY not in env_path.name
+        assert "example-model" not in env_path.name
+
+        # And it must not survive the copy.
+        assert not env_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_env_file_is_removed_when_the_copy_fails(self):
+        staged: list[Path] = []
+
+        async def copy_to(source: Path, destination: str) -> bool:
+            staged.append(Path(source))
+            raise OSError("docker cp failed")
+
+        agent, env = self._agent_and_env(copy_to)
+        with pytest.raises(OSError):
+            await agent.setup(env)
+
+        assert staged, "the .env file was never staged"
+        assert not staged[0].exists()
+
+
+class TestJiuWenSwarmAgentSkillStaging:
+    """Skill payloads must not be staged at names the caller can influence."""
+
+    @staticmethod
+    def _env(copy_to):
+        env = MagicMock()
+        env.exec = AsyncMock(return_value=ExecResult(stdout="", returncode=0))
+        env.copy_to = AsyncMock(side_effect=copy_to)
+        return env
+
+    @pytest.mark.asyncio
+    async def test_skill_payloads_are_staged_privately(self):
+        staged: list[tuple[Path, int]] = []
+
+        async def copy_to(source: Path, destination: str) -> bool:
+            source = Path(source)
+            staged.append((source, stat.S_IMODE(source.stat().st_mode)))
+            return True
+
+        agent = JiuWenSwarmAgent()
+        loaded = await agent.load_skills(
+            self._env(copy_to),
+            {"alpha": "skill body"},
+            evolutions={"alpha": "{}"},
+            evolution_files={"alpha": {"notes.md": "extra body"}},
+        )
+
+        assert loaded == 1
+        assert len(staged) == 3
+        for path, mode in staged:
+            assert mode == 0o600
+            assert not path.exists()
+
+    @pytest.mark.asyncio
+    async def test_skill_name_does_not_reach_the_host_path(self):
+        staged: list[Path] = []
+
+        async def copy_to(source: Path, destination: str) -> bool:
+            staged.append(Path(source))
+            return True
+
+        agent = JiuWenSwarmAgent()
+        await agent.load_skills(self._env(copy_to), {"../escape": "skill body"})
+
+        assert staged
+        assert staged[0].parent == Path(tempfile.gettempdir())
+        assert "escape" not in staged[0].name
+
+    @pytest.mark.asyncio
+    async def test_skill_payload_is_removed_when_the_copy_fails(self):
+        staged: list[Path] = []
+
+        async def copy_to(source: Path, destination: str) -> bool:
+            staged.append(Path(source))
+            raise OSError("docker cp failed")
+
+        agent = JiuWenSwarmAgent()
+        with pytest.raises(OSError):
+            await agent.load_skills(self._env(copy_to), {"alpha": "skill body"})
+
+        assert staged and not staged[0].exists()
 
 
 class TestJiuWenSwarmAgentSetup:


### PR DESCRIPTION
Paired: [GitHub #365](https://github.com/openJiuwen-ai/agent-core/pull/365) ↔ [GitCode !2219](https://gitcode.com/openJiuwen/agent-core/merge_requests/2219)

**What type of PR is this?**

/kind bug

**Which issue(s) this PR fixes**:

Fixes #364

Same mechanism as #282 — a fixed name in a shared temporary directory — but a different consequence and a different fix, so the two do not overlap.

**What does this PR do / why do we need it**:

The jiuwenswarm evaluator adapter materialises files on the host before copying them into a sandbox, at fixed paths under `/tmp`. One of them contains a live API key, written at the default umask in a world-readable directory.

Three exposures, closed here:

- **Disclosure.** `Path.write_text` creates the file 0644, so any local account can read the credential while the copy runs.
- **Attacker-controlled write.** The path is fixed, so another local account can pre-create it as a symlink and redirect the write.
- **Persistence after failure.** `unlink` ran only after `copy_to` returned, and `copy_to` shells out, so an exception left the credential on disk indefinitely. One further site had no cleanup at all on the raising path.

A fourth defect found while fixing these is a path traversal rather than a permission problem: `Path(f"/tmp/skill_{skill_name}.md")` interpolates a caller-supplied name, so a name containing a separator escapes the temporary directory.

A per-user directory at 0700 — the fix in #283 and #367 — would close the disclosure and the symlink pre-registration for these paths too. The reason to go further is **capability**, not sufficiency: what the code needs from the name. #283's lock directory has to be shared between the processes of one user, because `get_lock_file()` hashes the target path. #367's output directory has to survive a restart, because the filenames are content hashes and the paths it has already emitted must still resolve. Both are held to a stable name and pay for it. Nothing here is: a staged file is written, copied once and removed by the same call, and nothing reads it by path from outside the adapter — so the strongest primitive is available for free.

Taking it also closes two things per-user naming cannot: the caller-supplied skill name interpolated into the path, and a fixed directory name that `mkdir(exist_ok=True)` adopts from whoever created it first.

---

### The credential file

A `_staged_file` context manager built on `tempfile.mkstemp`, which in one atomic step picks an unpredictable name, refuses to follow an existing path, and creates the file readable and writable by its owner only. The file is removed on block exit including when the block raises, so a failed copy cannot leave the content behind.

The adapter also hardcoded `/tmp`; going through `tempfile` means `TMPDIR` is now honoured.

### The remaining sandbox payloads

The remaining host-side writes routed through the same helper: the config, the skill and evolution payloads, the instruction and system-message files, and the runner script. The runner script is the sharpest of them — it is copied into the sandbox and executed there, so an attacker able to substitute it before the copy chooses what runs inside the container. This is also where the traversal is closed: the staged name no longer derives from the skill name at all.

### Host-side debug output

Debug output went to a fixed `/tmp/jiuwenswarm_debug`, created with `mkdir(exist_ok=True)`, which silently adopts whatever already sits at that path — another account's directory, or a symlink to one. `Path.write_text` then created through the umask and followed any symlink it found, so planting `raw_output.txt` as a symlink had the evaluator truncate and overwrite a file of the attacker's choosing. Now a `mkdtemp` directory per run, mode 0700, and an explicit `O_NOFOLLOW` open at 0600 for the writes.

---

### Behaviour changes

- Staged files are 0600 and unpredictably named. Nothing reads them by path from outside the adapter, so no caller is affected.
- Staged files are removed on failure paths as well as success.
- Debug output goes to a fresh directory per run rather than a single reused one. The path is logged, so diagnostics stay discoverable, but directories accumulate instead of being overwritten. Routing them to the pipeline's configured `output_dir` would be better; that config is not plumbed to adapters, so it is left for a separate change.
- `TMPDIR` is now honoured, where the hardcoded `/tmp` ignored it.

**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

`pytest tests/unit_tests/agent_evolving/evaluator/evaluator_pipeline/adapters/agents/test_jiuwenswarm.py`
— **33 passed** (15 pre-existing, 18 new).

`pytest tests/unit_tests/agent_evolving/evaluator/evaluator_pipeline/` — **145 passed**.

The adapter is exercisable with light mock fixtures, so `setup()` and `load_skills()` are tested end to end rather than through extracted helpers. New coverage asserts:

- the staged file is mode 0600 at the moment `copy_to` sees it;
- its name is not derivable from the configuration;
- it is removed on the success path **and** on the path where the copy raises;
- a skill name containing a path separator cannot reach the host path;
- debug output is not readable or writable by other accounts;
- `run` still routes its debug output through those helpers, so reverting the call site to the fixed directory fails the suite.

**Negative control.** With the helper present but the `.env` site reverted to the old write, the two credential tests fail and the rest pass. With the debug call site reverted to `/tmp/jiuwenswarm_debug`, the run-path test fails on its assertion — not on collection — and the rest pass. The tests exercise the change rather than passing vacuously.

Test fixtures use invented values; no real credential appears anywhere in the diff.

Full suite: **15844 passed, 37 failed** on this branch against **15825 passed, 38 failed** on `develop` alone, plus four collection errors on both sides from an optional dependency absent in the test environment. The failure sets were compared test by test rather than by count: every failure on this branch also fails on `develop`, and the one extra `develop` failure is a lock-database timing flake that passes when run on its own. None of the 37 are in the files this PR touches — they are in workflow visualisation, the message-queue extension, the `sys_operation` local tests, `rsi/auto_harness` and `agent_rl/online`.

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #282
- Fixes #364
<!-- /bot1-related-issues -->

