### PR TITLE
fix(llm): read provider usage.cost from dict and model_extra

### DIFF
--- a/openjiuwen/core/foundation/llm/model_clients/base_model_client.py
+++ b/openjiuwen/core/foundation/llm/model_clients/base_model_client.py
@@ -206,41 +206,97 @@ class BaseModelClient(ABC):
 
     @staticmethod
     def _extract_cost_info(obj: Any) -> tuple:
-        """Extract cost information from a response or chunk object.
-        Supports three formats:
-        1. ``cost`` as a simple numeric value (int/float)
-        2. ``cost`` / ``usage_cost`` as an object with input/output/total cost attributes
+        """Extract cost information from a response or chunk usage object.
+
+        Supports:
+        1. ``cost`` as a simple numeric value (OpenRouter)
+        2. ``cost`` / ``usage_cost`` as an object/dict with input/output/total
         3. ``cost_details`` with upstream_inference_*_cost fields as fallback
+
+        The OpenAI SDK often strips unknown fields from typed ``Usage`` models.
+        Providers like OpenRouter still put ``cost`` on the wire; it may land in
+        ``model_extra`` / ``__pydantic_extra__``, or the usage object may be a
+        plain dict. Look in all three places.
+
         Returns:
             tuple: (input_cost, output_cost, total_cost)
         """
-        input_cost = 0.
-        output_cost = 0.
-        total_cost = 0.
-        cost_info = getattr(obj, 'cost', None) or getattr(obj, 'usage_cost', None)
-        cost_details = getattr(obj, 'cost_details', None)
-        if cost_info:
-            if isinstance(cost_info, (int, float)):
-                total_cost = float(cost_info)
-            else:
-                input_cost = float(getattr(cost_info, 'input_cost', 0) or
-                                   getattr(cost_info, 'prompt_cost', 0) or 0)
-                output_cost = float(getattr(cost_info, 'output_cost', 0) or
-                                    getattr(cost_info, 'completion_cost', 0) or 0)
-                total_cost = float(getattr(cost_info, 'total_cost', 0) or 0)
+
+        def _get(source: Any, key: str) -> Any:
+            if source is None:
+                return None
+            if isinstance(source, dict):
+                return source.get(key)
+            value = getattr(source, key, None)
+            if value is not None:
+                return value
+            extra = getattr(source, "model_extra", None) or getattr(
+                source, "__pydantic_extra__", None
+            )
+            if isinstance(extra, dict):
+                return extra.get(key)
+            return None
+
+        def _to_float(value: Any) -> float:
+            if value is None or isinstance(value, bool):
+                return 0.0
+            if isinstance(value, (int, float)):
+                return float(value)
+            if isinstance(value, str):
+                try:
+                    return float(value)
+                except ValueError:
+                    return 0.0
+            return 0.0
+
+        def _field_float(source: Any, *keys: str) -> float:
+            for key in keys:
+                amount = _to_float(_get(source, key))
+                if amount:
+                    return amount
+            return 0.0
+
+        input_cost = 0.0
+        output_cost = 0.0
+        total_cost = 0.0
+        cost_info = _get(obj, "cost")
+        if cost_info is None:
+            cost_info = _get(obj, "usage_cost")
+        cost_details = _get(obj, "cost_details")
+
+        if cost_info is not None and cost_info != "":
+            if isinstance(cost_info, (int, float, str)):
+                total_cost = _to_float(cost_info)
+            elif isinstance(cost_info, dict):
+                input_cost = _field_float(cost_info, "input_cost", "prompt_cost")
+                output_cost = _field_float(
+                    cost_info, "output_cost", "completion_cost"
+                )
+                total_cost = _field_float(cost_info, "total_cost", "cost")
                 if not total_cost:
                     total_cost = input_cost + output_cost
-        if cost_details and not input_cost and not output_cost:
-            if isinstance(cost_details, dict):
-                input_cost = float(cost_details.get('upstream_inference_prompt_cost', 0) or 0)
-                output_cost = float(cost_details.get('upstream_inference_completions_cost', 0) or 0)
-                detail_total = float(cost_details.get('upstream_inference_cost', 0) or 0)
             else:
-                input_cost = float(getattr(cost_details, 'upstream_inference_prompt_cost', 0) or 0)
-                output_cost = float(getattr(cost_details, 'upstream_inference_completions_cost', 0) or 0)
-                detail_total = float(getattr(cost_details, 'upstream_inference_cost', 0) or 0)
-            if not total_cost:
-                total_cost = detail_total or (input_cost + output_cost)
+                input_cost = _field_float(cost_info, "input_cost", "prompt_cost")
+                output_cost = _field_float(
+                    cost_info, "output_cost", "completion_cost"
+                )
+                total_cost = _field_float(cost_info, "total_cost", "cost")
+                if not total_cost:
+                    total_cost = input_cost + output_cost
+
+        # cost_details is a fallback only when top-level cost/usage_cost did
+        # not supply any amount (OpenRouter may send both; prefer ``cost``).
+        no_top_level_cost = not (total_cost or input_cost or output_cost)
+        if cost_details is not None and no_top_level_cost:
+            input_cost = _field_float(
+                cost_details, "upstream_inference_prompt_cost"
+            )
+            output_cost = _field_float(
+                cost_details, "upstream_inference_completions_cost"
+            )
+            detail_total = _field_float(cost_details, "upstream_inference_cost")
+            total_cost = detail_total or (input_cost + output_cost)
+
         return input_cost, output_cost, total_cost
 
     def _get_client_name(self) -> str:

--- a/tests/unit_tests/core/foundation/llm/test_extract_cost_info.py
+++ b/tests/unit_tests/core/foundation/llm/test_extract_cost_info.py
@@ -1,0 +1,121 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Provider-reported USD must survive SDK typing (OpenRouter cascade)."""
+
+from types import SimpleNamespace
+
+from openjiuwen.core.foundation.llm.model_clients.base_model_client import (
+    BaseModelClient,
+)
+
+
+def _cost(usage) -> tuple[float, float, float]:
+    return BaseModelClient._extract_cost_info(usage)
+
+
+def test_openrouter_numeric_cost_on_dict_usage() -> None:
+    """OpenRouter puts ``usage.cost`` on the wire as a float."""
+    usage = {
+        "prompt_tokens": 194,
+        "completion_tokens": 2,
+        "total_tokens": 196,
+        "cost": 0.0015,
+        "cost_details": {
+            "upstream_inference_cost": 0.0012,
+            "upstream_inference_prompt_cost": 0.0010,
+            "upstream_inference_completions_cost": 0.0002,
+        },
+    }
+
+    input_cost, output_cost, total_cost = _cost(usage)
+
+    assert total_cost == 0.0015
+    # Numeric top-level cost wins; details are only a fallback when cost is absent.
+    assert input_cost == 0.0
+    assert output_cost == 0.0
+
+
+def test_openrouter_cost_in_pydantic_model_extra() -> None:
+    """Typed OpenAI Usage often drops unknown fields into model_extra."""
+    usage = SimpleNamespace(
+        prompt_tokens=10,
+        completion_tokens=5,
+        total_tokens=15,
+        model_extra={"cost": 0.00042},
+    )
+
+    _, _, total_cost = _cost(usage)
+
+    assert total_cost == 0.00042
+
+
+def test_openrouter_cost_in_pydantic_extra_dunder() -> None:
+    usage = SimpleNamespace(
+        prompt_tokens=10,
+        completion_tokens=5,
+        __pydantic_extra__={"cost": 0.0007},
+    )
+
+    _, _, total_cost = _cost(usage)
+
+    assert total_cost == 0.0007
+
+
+def test_cost_details_fallback_when_cost_missing() -> None:
+    usage = {
+        "prompt_tokens": 10,
+        "completion_tokens": 5,
+        "cost_details": {
+            "upstream_inference_prompt_cost": 0.001,
+            "upstream_inference_completions_cost": 0.002,
+            "upstream_inference_cost": 0.003,
+        },
+    }
+
+    input_cost, output_cost, total_cost = _cost(usage)
+
+    assert input_cost == 0.001
+    assert output_cost == 0.002
+    assert total_cost == 0.003
+
+
+def test_structured_cost_object() -> None:
+    usage = SimpleNamespace(
+        cost=SimpleNamespace(input_cost=0.01, output_cost=0.02, total_cost=0.0),
+    )
+
+    input_cost, output_cost, total_cost = _cost(usage)
+
+    assert input_cost == 0.01
+    assert output_cost == 0.02
+    assert total_cost == 0.03
+
+
+def test_structured_cost_dict() -> None:
+    usage = {"cost": {"prompt_cost": 0.01, "completion_cost": 0.04}}
+
+    input_cost, output_cost, total_cost = _cost(usage)
+
+    assert input_cost == 0.01
+    assert output_cost == 0.04
+    assert total_cost == 0.05
+
+
+def test_no_cost_fields_returns_zeros() -> None:
+    """DeepSeek-shaped usage: tokens only, no USD."""
+    usage = {
+        "prompt_tokens": 100,
+        "completion_tokens": 20,
+        "prompt_cache_hit_tokens": 80,
+        "prompt_cache_miss_tokens": 20,
+    }
+
+    assert _cost(usage) == (0.0, 0.0, 0.0)
+
+
+def test_attribute_cost_still_works() -> None:
+    usage = SimpleNamespace(cost=0.99, cost_details=None)
+
+    _, _, total_cost = _cost(usage)
+
+    assert total_cost == 0.99


### PR DESCRIPTION
Paired: [GitHub #375](https://github.com/openJiuwen-ai/agent-core/pull/375) ↔ [GitCode !2225](https://gitcode.com/openJiuwen/agent-core/merge_requests/2225)


<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openjiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
Choose one label from `bug`, `task`, `feature` and `refactor`, and replace `<label>` below the comment block. 

If this pr is not only bug fix/task/feature and also a refactor, you can append `/kind refactor` label after `/kind bug`, `/kind task` and `/kind feature`.
-->
/kind bug


**What does this PR do / why do we need it**:

OpenRouter bills via `usage.cost`, but the OpenAI SDK often drops unknown
fields from typed `Usage`. Look in dicts and pydantic extras so USD reaches
downstream cost cascades.

`_extract_cost_info` previously used only `getattr(obj, "cost")`. When the SDK
strips wire fields into `model_extra` / `__pydantic_extra__`, or the usage
object is a plain dict, provider cost never reached `UsageMetadata`. Callers
that prefer provider-reported money over a local rate table then saw every
OpenRouter turn as unpriced.

This change reads `cost` / `usage_cost` / `cost_details` from dicts, attributes,
and pydantic extras. A numeric top-level `cost` wins; `cost_details` is only a
fallback when no top-level amount was supplied. Stream and non-stream OpenAI
paths already call `_extract_cost_info` and pick up the richer extraction
without further wiring.


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/openJiuwen-ai/jiuwenswarm/issues/2481


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

* Unit: `pytest tests/unit_tests/core/foundation/llm/test_extract_cost_info.py`
  — 8 passed:
  - OpenRouter-shaped dict with numeric `usage.cost`
  - `cost` in `model_extra` / `__pydantic_extra__`
  - `cost_details` fallback when top-level cost is absent
  - structured cost object / dict
  - DeepSeek-shaped tokens-only usage → `(0, 0, 0)`
  - attribute `cost` still works
* Manual (with a consumer that prefers provider cost): OpenRouter turn shows
  non-zero `total_cost` without a local price table entry.


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bug Fix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

**Special notes for reviewers**:

- No public API change: same `_extract_cost_info` return shape
  `(input_cost, output_cost, total_cost)`.
- Does not poll OpenRouter `/generation`; relies on final-chunk `usage.cost`.
