### PR TITLE
fix(sandbox): let subagents read the skills they are delegated work from

### DIFF
--- a/openjiuwen/core/sys_operation/config.py
+++ b/openjiuwen/core/sys_operation/config.py
@@ -24,14 +24,15 @@ class LocalWorkConfig(BaseModel):
         default=None,
         description="Security boundary for fs operations.  Paths outside every entry are "
                     "rejected when restrict_to_sandbox is True.  When None (default), the "
-                    "effective list falls back to [workspace, project_root] read from the "
-                    "per-agent CwdState ContextVar.  Independent of CWD -- CWD can move "
-                    "freely while the sandbox stays fixed.")
+                    "effective list falls back to [workspace, project_root, cwd, *skill_roots] "
+                    "read from the per-agent CwdState ContextVar.  Independent of CWD -- CWD "
+                    "can move freely while the sandbox stays fixed.")
 
     restrict_to_sandbox: bool = Field(
         default=False,
         description="When True, fs operations reject paths outside every sandbox_root entry. "
-                    "If sandbox_root is None, falls back to [workspace, project_root] defaults.")
+                    "If sandbox_root is None, falls back to the "
+                    "[workspace, project_root, cwd, *skill_roots] defaults.")
 
     dangerous_patterns: Optional[List[str]] = Field(
         default=None,

--- a/openjiuwen/core/sys_operation/cwd.py
+++ b/openjiuwen/core/sys_operation/cwd.py
@@ -19,9 +19,12 @@ Auxiliary workspace locations (not part of the cwd fallback chain):
   - workspace: agent workspace root (DeepAgent per-agent artifact dir)
   - team_workspace: shared team workspace root (optionally symlinked into
     agent workspaces as .team/{team_id}/ for navigation)
+  - skill_roots: skill trees this agent loads skills from
 
-Both are optional and return ``None`` when unset -- they record
-related paths used by tools, not where shell commands run.
+All are optional -- they record related paths used by tools, not where
+shell commands run.  ``skill_roots`` is a list because an agent can
+mount several skill trees at once, and because a subagent inherits its
+parent's trees on top of the one in its own workspace.
 
 Implementation note -- mutable container pattern:
 
@@ -41,7 +44,7 @@ Implementation note -- mutable container pattern:
 
 import os
 from contextvars import ContextVar
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 
@@ -58,6 +61,7 @@ class CwdState:
     project_root: str | None = None
     workspace: str | None = None
     team_workspace: str | None = None
+    skill_roots: list[str] = field(default_factory=list)
 
 
 _cwd_state: ContextVar[CwdState | None] = ContextVar("cwd_state", default=None)
@@ -183,6 +187,24 @@ def get_agent_history_root() -> str:
     return str((Path(home) / ".jiuwenswarm").expanduser().resolve())
 
 
+# ---- Skill roots: skill trees mounted for this agent ----------------------
+
+def get_skill_roots() -> list[str]:
+    """Get the skill tree roots mounted for the current agent context.
+
+    These are the directories a ``SkillUseRail`` loads ``SKILL.md`` files
+    from, i.e. the trees whose ``references/``, ``assets/`` and
+    ``scripts/`` an agent is expected to reach while running a skill.
+    Returns an empty list when the agent mounts no skill tree.
+    """
+    return list(_state().skill_roots)
+
+
+def set_skill_roots(paths: list[str]) -> None:
+    """Replace the skill tree roots for the current agent context."""
+    _state().skill_roots = [_resolve(p) for p in paths]
+
+
 # ---- Bulk initialization ---------------------------------------------------
 
 def init_cwd(
@@ -191,6 +213,7 @@ def init_cwd(
     *,
     workspace: str | None = None,
     team_workspace: str | None = None,
+    skill_roots: list[str] | None = None,
 ) -> None:
     """Initialize all CWD layers with a NEW CwdState instance.
 
@@ -207,6 +230,8 @@ def init_cwd(
             agents without a workspace directory.
         team_workspace: Team shared workspace root.  Optional -- only
             set when the agent belongs to a team with a shared workspace.
+        skill_roots: Skill tree roots this agent loads skills from.
+            Optional -- leave unset for agents that mount no skills.
     """
     resolved = _resolve(cwd)
     state = CwdState(
@@ -215,5 +240,6 @@ def init_cwd(
         project_root=_resolve(project_root) if project_root else resolved,
         workspace=_resolve(workspace) if workspace else None,
         team_workspace=_resolve(team_workspace) if team_workspace else None,
+        skill_roots=[_resolve(p) for p in (skill_roots or [])],
     )
     _cwd_state.set(state)

--- a/openjiuwen/core/sys_operation/local/fs_operation.py
+++ b/openjiuwen/core/sys_operation/local/fs_operation.py
@@ -1053,17 +1053,21 @@ class FsOperation(BaseFsOperation):
         allowed root directories.  A path is accepted when it falls within
         any one of the entries.  When ``sandbox_root`` is ``None``, the
         effective list falls back to
-        ``[get_workspace(), get_project_root(), get_cwd()]`` read from the
-        per-agent CwdState ContextVar so every DeepAgent gets sensible
-        defaults without having to plumb paths through config.  ``get_cwd()``
-        is in the list because the three layers are independent: a team
-        member runs in the project dir (or an isolated worktree) while its
-        workspace stays a private artifact directory elsewhere, so cwd is not
-        necessarily inside either of the other two roots.
+        ``[get_workspace(), get_project_root(), get_cwd(), *get_skill_roots()]``
+        read from the per-agent CwdState ContextVar so every DeepAgent gets
+        sensible defaults without having to plumb paths through config.
+        ``get_cwd()`` is in the list because the three layers are independent:
+        a team member runs in the project dir (or an isolated worktree) while
+        its workspace stays a private artifact directory elsewhere, so cwd is
+        not necessarily inside either of the other two roots.
+        ``get_skill_roots()`` is in the list because a mounted skill tree can
+        sit outside all three -- always so for a subagent, whose workspace is
+        a fresh directory that contains no skills.
         """
         from openjiuwen.core.sys_operation.cwd import (
             get_cwd,
             get_project_root,
+            get_skill_roots,
             get_workspace,
         )
 
@@ -1083,8 +1087,20 @@ class FsOperation(BaseFsOperation):
                 roots = list(configured)
             else:
                 roots = [p for p in (get_workspace(), get_project_root(), get_cwd()) if p]
+                # Skill trees are their own roots: a skill's SKILL.md,
+                # references/ and assets/ must stay readable from an agent
+                # whose workspace does not contain the skill, and a
+                # subagent's workspace never does.
+                roots.extend(get_skill_roots())
 
-            resolved_roots = [pathlib.Path(r).expanduser().resolve() for r in roots]
+            # De-duplicate after resolution: the three fallback layers overlap
+            # by design (project_root defaults to cwd, and a subagent inherits
+            # both from its parent), so the raw list routinely repeats a root.
+            # Repetition changes no decision but is copied verbatim into the
+            # denial message, where a doubled entry reads like a bug.
+            resolved_roots = list(dict.fromkeys(
+                pathlib.Path(r).expanduser().resolve() for r in roots
+            ))
             if not any(self._is_within(normalized, root) for root in resolved_roots):
                 raise build_error(
                     status=StatusCode.SYS_OPERATION_FS_EXECUTION_ERROR,

--- a/openjiuwen/core/sys_operation/local/shell_operation.py
+++ b/openjiuwen/core/sys_operation/local/shell_operation.py
@@ -930,7 +930,12 @@ class ShellOperation(BaseShellOperation):
         """Return resolved sandbox roots when restrict_to_sandbox is active, else None."""
         if not getattr(self._run_config, "restrict_to_sandbox", False):
             return None
-        from openjiuwen.core.sys_operation.cwd import get_cwd, get_project_root, get_workspace
+        from openjiuwen.core.sys_operation.cwd import (
+            get_cwd,
+            get_project_root,
+            get_skill_roots,
+            get_workspace,
+        )
 
         configured = getattr(self._run_config, "sandbox_root", None)
         if configured:
@@ -940,7 +945,18 @@ class ShellOperation(BaseShellOperation):
             # member running in the project dir (or a worktree) with a private
             # workspace elsewhere would otherwise be locked out of its own cwd.
             raw_roots = [p for p in (get_workspace(), get_project_root(), get_cwd()) if p]
-        resolved = [pathlib.Path(r).expanduser().resolve() for r in raw_roots]
+            # Skill trees are their own roots: a skill's scripts/ must stay
+            # runnable from an agent whose workspace does not contain the
+            # skill, and a subagent's workspace never does.
+            raw_roots.extend(get_skill_roots())
+        # De-duplicate after resolution: the three fallback layers overlap by
+        # design (project_root defaults to cwd, and a subagent inherits both
+        # from its parent), so the raw list routinely repeats a root.
+        # Repetition changes no decision but is copied verbatim into the
+        # denial message, where a doubled entry reads like a bug.
+        resolved = list(dict.fromkeys(
+            pathlib.Path(r).expanduser().resolve() for r in raw_roots
+        ))
         return resolved or None
 
     def _extract_abs_paths(self, command: str) -> list[pathlib.PurePath]:

--- a/openjiuwen/harness/deep_agent.py
+++ b/openjiuwen/harness/deep_agent.py
@@ -143,7 +143,7 @@ from openjiuwen.harness.resources.extension_resolver import (
 )
 from openjiuwen.harness.schema.build_context import BuildContext
 from openjiuwen.harness.schema.extension_spec import AgentTemplateSpec, PluginSpec
-from openjiuwen.harness.workspace.workspace import Workspace
+from openjiuwen.harness.workspace.workspace import Workspace, WorkspaceNode
 
 # Events bridged to the inner ReActAgent.
 _BRIDGE_EVENTS = frozenset(
@@ -314,6 +314,7 @@ class DeepAgent(BaseAgent):
         self._active_interaction_round: Optional[ActiveInteractionRound] = None
         self._event_manager = EventManager()
         self._inherited_artifact_root: Optional[str] = None
+        self._inherited_skill_roots: List[str] = []
         self.goal_manager: Optional[GoalManager] = None
         self._interaction_output = OutputLeaseManager()
         self._interaction_supervisor_task: Optional[asyncio.Task[None]] = None
@@ -1229,6 +1230,25 @@ class DeepAgent(BaseAgent):
         )
         schedule_image_support_probe(config.model)
 
+    def _resolve_skill_roots(self) -> List[str]:
+        """Skill trees this agent may read from and execute scripts out of.
+
+        The ``skills`` node of this agent's own workspace, plus every tree
+        inherited from the agent that spawned it.  The inherited entries are
+        what make a delegated skill run possible at all: a subagent is given a
+        fresh workspace under ``sub_agents/<id>`` that contains no skills, so
+        the skill its parent just told it to run lives outside every root the
+        sandbox would otherwise derive for it.
+        """
+        roots: List[str] = []
+        workspace = self._deep_config.workspace if self._deep_config else None
+        if isinstance(workspace, Workspace):
+            skills_node = workspace.get_node_path(WorkspaceNode.SKILLS)
+            if skills_node is not None:
+                roots.append(str(skills_node))
+        roots.extend(self._inherited_skill_roots)
+        return list(dict.fromkeys(roots))
+
     def _apply_inherited_artifact_cwd(self) -> None:
         """Set cwd from ``_inherited_artifact_root`` for a reused subagent.
 
@@ -1246,6 +1266,7 @@ class DeepAgent(BaseAgent):
             self._inherited_artifact_root,
             project_root=self._inherited_artifact_root,
             workspace=init_root,
+            skill_roots=self._resolve_skill_roots(),
         )
 
     async def _ensure_initialized(self) -> None:
@@ -1267,11 +1288,13 @@ class DeepAgent(BaseAgent):
 
             workspace = self._deep_config.workspace
             workspace_root = (workspace.root_path if workspace else None) or os.getcwd()
+            skill_roots = self._resolve_skill_roots()
             if self._inherited_artifact_root:
                 init_cwd(
                     self._inherited_artifact_root,
                     project_root=self._inherited_artifact_root,
                     workspace=workspace_root,
+                    skill_roots=skill_roots,
                 )
             else:
                 # cwd and workspace are separate layers: the workspace holds
@@ -1281,7 +1304,12 @@ class DeepAgent(BaseAgent):
                 # keeping a private workspace).
                 cwd_root = self._deep_config.cwd or workspace_root
                 project_root = self._deep_config.project_root or cwd_root
-                init_cwd(cwd_root, project_root=project_root, workspace=workspace_root)
+                init_cwd(
+                    cwd_root,
+                    project_root=project_root,
+                    workspace=workspace_root,
+                    skill_roots=skill_roots,
+                )
 
         await self._register_pending_mcps()
 
@@ -1395,19 +1423,25 @@ class DeepAgent(BaseAgent):
         """React agent config. For testing only."""
         return self._react_agent.config
 
-    @staticmethod
-    def _bind_inherited_artifact_root(subagent: Any) -> Any:
+    def _bind_inherited_artifact_root(self, subagent: Any) -> Any:
         """Point subagent file writes at the parent's current artifact root.
 
         Prefer ``get_cwd()``: after a sibling subagent runs in the same Task,
         ambient ``get_workspace()`` may point at that sibling's ``sub_agents/``
         tree while cwd remains the shared artifact root.
+
+        The parent's skill trees ride along.  A skill that delegates part of
+        its work names its own absolute paths in the instructions it hands
+        the subagent, and those paths sit outside the subagent's workspace;
+        without the inherited roots every such read or script run is denied
+        by the sandbox and the delegated step silently produces nothing.
         """
         from openjiuwen.core.sys_operation.cwd import get_cwd, get_workspace
 
         artifact_root = get_cwd() or get_workspace()
         try:
             setattr(subagent, "_inherited_artifact_root", artifact_root)
+            setattr(subagent, "_inherited_skill_roots", self._resolve_skill_roots())
         except (AttributeError, TypeError):
             # Test mocks may return bare object(); real DeepAgent always accepts it.
             pass

--- a/tests/unit_tests/core/sys_operation/local/test_fs_operation.py
+++ b/tests/unit_tests/core/sys_operation/local/test_fs_operation.py
@@ -1551,3 +1551,112 @@ async def test_concurrent_upload_download_mixed(sys_op, work_dir):
     assert final_content != "", "Final content empty after mixed upload/download"
     assert final_content.startswith("upload_task_") or final_content == base_content, \
         "Final content corrupted after mixed concurrency"
+
+
+# ── sandbox path checks (unit, no Runner) ──────────────────────────────────
+
+class _FakeRunConfig:
+    """Minimal stand-in for LocalWorkConfig used in sandbox unit tests."""
+
+    def __init__(self, *, restrict: bool, roots: list[str] | None = None):
+        self.restrict_to_sandbox = restrict
+        self.sandbox_root = roots
+        self.shell_allowlist = None
+        self.dangerous_patterns = None
+
+
+def _make_fs_op(restrict: bool, roots: list[str] | None = None) -> FsOperation:
+    """Return an FsOperation whose _run_config mimics sandbox settings."""
+    op = object.__new__(FsOperation)
+    op._run_config = _FakeRunConfig(restrict=restrict, roots=roots)
+    return op
+
+
+@pytest.fixture
+def cwd_state():
+    """Isolate the CwdState ContextVar so fallback tests do not leak into others."""
+    from openjiuwen.core.sys_operation import cwd as cwd_mod
+
+    token = cwd_mod._cwd_state.set(cwd_mod.CwdState())
+    yield cwd_mod
+    cwd_mod._cwd_state.reset(token)
+
+
+def test_resolve_path_deduplicates_overlapping_defaults(cwd_state, tmp_path):
+    """The [workspace, project_root, cwd] fallback overlaps and must collapse.
+
+    project_root defaults to cwd, and a subagent inherits both from its
+    parent, so the raw fallback lists the same root twice.  The denial message
+    renders this list verbatim, where a repeated entry reads like a bug.
+    """
+    workspace = tmp_path / "workspace" / "sub_agents" / "sub"
+    artifact_root = tmp_path / "workspace" / "projects"
+    outside = tmp_path / "workspace" / "elsewhere"
+    workspace.mkdir(parents=True)
+    artifact_root.mkdir(parents=True)
+    outside.mkdir(parents=True)
+
+    cwd_state.init_cwd(
+        str(artifact_root),
+        project_root=str(artifact_root),
+        workspace=str(workspace),
+    )
+    op = _make_fs_op(restrict=True)
+
+    with pytest.raises(Exception) as excinfo:
+        op._resolve_path(str(outside / "note.md"))
+
+    message = str(excinfo.value)
+    assert message.count(str(artifact_root.resolve())) == 1
+    assert str(workspace.resolve()) in message
+
+
+def _make_subagent_layout(tmp_path):
+    """Build the directory shape a delegated skill run has in production.
+
+    A subagent's workspace is a fresh directory under ``sub_agents/`` and its
+    cwd is the artifact root it inherited from its parent; the skill it was
+    told to run lives in the parent workspace's ``skills`` tree, outside both.
+    """
+    root = tmp_path / "workspace"
+    sub_workspace = root / "sub_agents" / "sub-1"
+    artifact_root = root / "projects"
+    skill = root / "skills" / "sample-skill"
+    unrelated = tmp_path / "elsewhere"
+    for directory in (sub_workspace, artifact_root, skill, unrelated):
+        directory.mkdir(parents=True)
+    return sub_workspace, artifact_root, skill, unrelated
+
+
+def test_resolve_path_allows_file_in_skill_root(cwd_state, tmp_path):
+    """A subagent must be able to read the SKILL.md of an inherited skill."""
+    sub_workspace, artifact_root, skill, _ = _make_subagent_layout(tmp_path)
+    skill_md = skill / "SKILL.md"
+    skill_md.write_text("# skill", encoding="utf-8")
+
+    cwd_state.init_cwd(
+        str(artifact_root),
+        project_root=str(artifact_root),
+        workspace=str(sub_workspace),
+        skill_roots=[str(skill.parent)],
+    )
+    op = _make_fs_op(restrict=True)
+
+    assert op._resolve_path(str(skill_md)) == skill_md.resolve()
+
+
+def test_resolve_path_still_denies_outside_skill_root(cwd_state, tmp_path):
+    """Widening the sandbox for skills must not widen it for anything else."""
+    sub_workspace, artifact_root, skill, unrelated = _make_subagent_layout(tmp_path)
+
+    cwd_state.init_cwd(
+        str(artifact_root),
+        project_root=str(artifact_root),
+        workspace=str(sub_workspace),
+        skill_roots=[str(skill.parent)],
+    )
+    op = _make_fs_op(restrict=True)
+
+    with pytest.raises(Exception) as excinfo:
+        op._resolve_path(str(unrelated / "secret.txt"))
+    assert "outside sandbox" in str(excinfo.value)

--- a/tests/unit_tests/core/sys_operation/local/test_shell_operation.py
+++ b/tests/unit_tests/core/sys_operation/local/test_shell_operation.py
@@ -461,6 +461,122 @@ def test_get_sandbox_roots_explicit(tmp_path):
     assert any(r == tmp_path.resolve() for r in roots)
 
 
+@pytest.fixture
+def cwd_state():
+    """Isolate the CwdState ContextVar so fallback tests do not leak into others."""
+    from openjiuwen.core.sys_operation import cwd as cwd_mod
+
+    token = cwd_mod._cwd_state.set(cwd_mod.CwdState())
+    yield cwd_mod
+    cwd_mod._cwd_state.reset(token)
+
+
+def test_get_sandbox_roots_deduplicates_overlapping_defaults(cwd_state, tmp_path):
+    """The [workspace, project_root, cwd] fallback overlaps and must collapse.
+
+    project_root defaults to cwd, and a subagent inherits both from its
+    parent, so the raw fallback lists the same root twice.  The denial message
+    renders this list verbatim, where a repeated entry reads like a bug.
+    """
+    workspace = tmp_path / "workspace" / "sub_agents" / "sub"
+    artifact_root = tmp_path / "workspace" / "projects"
+    workspace.mkdir(parents=True)
+    artifact_root.mkdir(parents=True)
+
+    cwd_state.init_cwd(
+        str(artifact_root),
+        project_root=str(artifact_root),
+        workspace=str(workspace),
+    )
+    op = _make_shell_op(restrict=True)
+
+    assert op._get_sandbox_roots() == [workspace.resolve(), artifact_root.resolve()]
+
+
+def _make_subagent_layout(tmp_path):
+    """Build the directory shape a delegated skill run has in production.
+
+    A subagent's workspace is a fresh directory under ``sub_agents/`` and its
+    cwd is the artifact root it inherited from its parent; the skill it was
+    told to run lives in the parent workspace's ``skills`` tree, outside both.
+    """
+    root = tmp_path / "workspace"
+    sub_workspace = root / "sub_agents" / "sub-1"
+    artifact_root = root / "projects"
+    skill = root / "skills" / "sample-skill"
+    unrelated = tmp_path / "elsewhere"
+    for directory in (sub_workspace, artifact_root, skill / "scripts", unrelated):
+        directory.mkdir(parents=True)
+    return sub_workspace, artifact_root, skill, unrelated
+
+
+def test_check_shell_sandbox_allows_script_in_skill_root(cwd_state, tmp_path):
+    """A subagent must be able to run scripts out of an inherited skill tree."""
+    sub_workspace, artifact_root, skill, _ = _make_subagent_layout(tmp_path)
+
+    cwd_state.init_cwd(
+        str(artifact_root),
+        project_root=str(artifact_root),
+        workspace=str(sub_workspace),
+        skill_roots=[str(skill.parent)],
+    )
+    op = _make_shell_op(restrict=True)
+
+    err = op._check_shell_sandbox(
+        f"python {skill / 'scripts' / 'run.py'}", artifact_root
+    )
+    assert err is None
+
+
+def test_check_shell_sandbox_still_denies_outside_skill_root(cwd_state, tmp_path):
+    """Widening the sandbox for skills must not widen it for anything else."""
+    sub_workspace, artifact_root, skill, unrelated = _make_subagent_layout(tmp_path)
+
+    cwd_state.init_cwd(
+        str(artifact_root),
+        project_root=str(artifact_root),
+        workspace=str(sub_workspace),
+        skill_roots=[str(skill.parent)],
+    )
+    op = _make_shell_op(restrict=True)
+
+    err = op._check_shell_sandbox(
+        f"python {unrelated / 'run.py'}", artifact_root
+    )
+    assert err is not None
+    assert "outside sandbox" in err
+
+
+def test_get_sandbox_roots_ignores_skill_roots_when_configured(cwd_state, tmp_path):
+    """An explicit sandbox_root stays the whole boundary; skills add nothing."""
+    sub_workspace, artifact_root, skill, _ = _make_subagent_layout(tmp_path)
+
+    cwd_state.init_cwd(
+        str(artifact_root),
+        project_root=str(artifact_root),
+        workspace=str(sub_workspace),
+        skill_roots=[str(skill.parent)],
+    )
+    op = _make_shell_op(restrict=True, roots=[str(artifact_root)])
+
+    assert op._get_sandbox_roots() == [artifact_root.resolve()]
+
+
+def test_get_sandbox_roots_deduplicates_explicit_roots(tmp_path):
+    """An explicitly configured list is collapsed too, order preserved."""
+    first = tmp_path / "a"
+    second = tmp_path / "b"
+    first.mkdir()
+    second.mkdir()
+
+    op = _make_shell_op(
+        restrict=True,
+        roots=[str(first), str(second), str(first) + os.sep],
+    )
+
+    assert op._get_sandbox_roots() == [first.resolve(), second.resolve()]
+
+
 def test_extract_abs_paths_windows_quoted(monkeypatch):
     import openjiuwen.core.sys_operation.local.shell_operation as shell_mod
     monkeypatch.setattr(shell_mod.os, "name", "nt", raising=False)

--- a/tests/unit_tests/harness/test_deep_agent.py
+++ b/tests/unit_tests/harness/test_deep_agent.py
@@ -1884,3 +1884,67 @@ async def test_create_subagent_writes_relative_files_to_inherited_artifact_root(
     sub2 = parent.create_subagent("worker", "sub_sess_2")
     assert sub2._inherited_artifact_root == str(artifact_root.resolve())
     assert "sub_agents" not in sub2._inherited_artifact_root
+
+
+@pytest.mark.asyncio
+async def test_create_subagent_inherits_parent_skill_roots(tmp_path: Path) -> None:
+    """A subagent keeps sandbox access to the skill tree its parent mounted.
+
+    A skill that delegates part of its work hands the subagent absolute paths
+    into its own directory.  The subagent's workspace is a fresh directory
+    under ``sub_agents/`` that contains no skills, so unless the parent's
+    skills tree is inherited every read of ``SKILL.md`` and every run of a
+    ``scripts/*.py`` is denied by the sandbox.
+    """
+    from openjiuwen.core.sys_operation.cwd import get_skill_roots, init_cwd
+    from openjiuwen.core.sys_operation.local.fs_operation import FsOperation
+    from openjiuwen.harness.schema.config import SubAgentConfig
+
+    parent_ws = tmp_path / "workspace"
+    artifact_root = parent_ws / "projects"
+    skill_dir = parent_ws / "skills" / "sample-skill"
+    unrelated = tmp_path / "elsewhere"
+    for directory in (artifact_root, skill_dir, unrelated):
+        directory.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# sample", encoding="utf-8")
+
+    init_cwd(str(artifact_root), workspace=str(artifact_root))
+
+    parent = DeepAgent(AgentCard(name="parent", description="test")).configure(
+        DeepAgentConfig(
+            model=_create_dummy_model(),
+            workspace=Workspace(root_path=str(parent_ws)),
+            auto_create_workspace=False,
+            enable_task_loop=False,
+            add_general_purpose_agent=False,
+            restrict_to_work_dir=True,
+            subagents=[
+                SubAgentConfig(
+                    agent_card=AgentCard(name="worker", description="worker"),
+                    system_prompt="do work",
+                )
+            ],
+        )
+    )
+    parent.set_react_agent(FakeReactAgent(), initialized=True)
+
+    sub = parent.create_subagent("worker", "sub_sess")
+    assert sub._inherited_skill_roots == [str(parent_ws / "skills")]
+
+    await sub.ensure_initialized()
+    # Own workspace tree first, then the inherited one.
+    assert [Path(p).resolve() for p in get_skill_roots()] == [
+        (parent_ws / "sub_agents" / "sub_sess" / "skills").resolve(),
+        (parent_ws / "skills").resolve(),
+    ]
+
+    # The sandbox now admits the skill tree and still refuses everything else.
+    fs_op = object.__new__(FsOperation)
+    fs_op._run_config = SimpleNamespace(
+        restrict_to_sandbox=True, sandbox_root=None
+    )
+    resolved = fs_op._resolve_path(str(skill_dir / "SKILL.md"))
+    assert resolved == (skill_dir / "SKILL.md").resolve()
+    with pytest.raises(Exception) as excinfo:
+        fs_op._resolve_path(str(unrelated / "secret.txt"))
+    assert "outside sandbox" in str(excinfo.value)


### PR DESCRIPTION
Paired: [GitHub #378](https://github.com/openJiuwen-ai/agent-core/pull/378) ↔ [GitCode !2227](https://gitcode.com/openJiuwen/agent-core/merge_requests/2227)

**What type of PR is this?**

/kind bug

**Which issue(s) this PR fixes**:

Fixes #377

**What does this PR do / why do we need it**:


A skill whose workflow delegates to subagents cannot run at all. The parent loads `SKILL.md`, follows its instructions and hands a subagent absolute paths into the skill directory; the subagent is denied on every one of them, because the workspace `skills` tree is in none of the sandbox roots derived for it.

The issue reports two distinct defects visible in that one denial, and both are fixed here: a repeated entry in the derived root list, which makes the denial misleading, and the skill trees sitting outside every root, which is what actually breaks the run. They are described below in that order, by what they change; the branch is a single commit, so there is no per-commit split to follow.

---

### Repeated entries in the default sandbox roots

When `restrict_to_sandbox` is on and `sandbox_root` is unset, both the fs and the shell check build the effective root list from the per-agent `CwdState`: `[workspace, project_root, cwd]`. Those layers overlap by construction — `project_root` defaults to `cwd` where the host does not separate them, and a subagent is initialised with its inherited artifact root as *both* its cwd and its project root — so the list reliably contains the same directory twice.

The repetition changes no access decision, but it is rendered verbatim into the denial message of the two errors agents actually see. A denial reporting three roots of which two are byte-identical reads as a bug in the sandbox and misdirects diagnosis.

Roots are now resolved first, then deduplicated with order preserved, in both checks. Resolving before deduplicating also collapses entries spelled differently for the same directory (trailing separator, `~`, symlinked parents), so an explicitly configured `sandbox_root` benefits too.

### The parent's skill trees, inside a subagent's sandbox

`CwdState` gains `skill_roots` as a third auxiliary location beside `workspace` and `team_workspace`, added to the fallback in both checks. A DeepAgent resolves its own trees from the `skills` node of its workspace and inherits its parent's on top; the inherited entries are bound at subagent creation, next to the artifact root, so the two halves of what the parent handed down stay together.

The artifact root is already handed down this way — `7bbcdb1d`, `fix(agent): main agent and subagent share artifact directory` (Refs: #1381). This applies the same mechanism in the same place to skills, which were missed at the time.

---

### This does not weaken the subagent sandbox restriction

Stated explicitly given the history: `ac28d891`, reverted in `5ed9751b`, re-landed in `144debbd` (Refs: #944, #987).

That restriction governs **whether** a subagent is sandboxed — a subagent must not declare itself unrestricted to escape a restricted parent. `restrict_to_work_dir`, its inheritance, and every test covering it are untouched here.

What changes is **which roots** the sandbox contains, and only ever by adding directories the parent already holds. A subagent still cannot reach anything its parent could not: the grant is a subset, never a widening. A subagent whose parent has no skill trees is unaffected, and an explicitly configured `sandbox_root` remains the complete boundary — skill roots do not extend it. Both are covered by tests.

### On read-only

Skills are read and executed, not written to, so a read-only grant would be the tighter fit. It is not available and has not been faked: `sandbox_root` is a flat allow-list with no read/write axis, and it cannot acquire one on the shell side, because `_check_shell_sandbox` inspects the absolute paths a command mentions and cannot distinguish `python skill/scripts/x.py` from `rm skill/scripts/x.py`. Enforced on the fs side alone it would be defeated by a single shell command, so claiming it would be worse than not having it.

The read/write/exec distinction in `harness/security/file_guard.py` (`FileGuardAction`) is a different and higher layer, not the boundary that raises 199003/199004.

Execution needs nothing beyond membership: the shell check requires the working directory and every absolute path in a command to sit under some root, so a skill's `scripts/` becomes runnable as soon as its tree is a root.

### Not addressed here

- PR #380, `fix(skills): tell the agent where each skill is installed`, is adjacent but complementary: it tells the agent *where* a skill is installed; this makes those paths reachable. The two share no file — #380 changes the skills prompt section, the skill-use rail and the skill tool; this changes the two sandbox checks, `CwdState` and `DeepAgent`. Neither depends on the other and they can land in either order.
- Team-shared skills mounted via `{team_target}/skills` remain outside the sandbox for every agent, including the main one, because `get_team_workspace()` is not in the fallback either. Same class of defect, different trigger; left out to keep this change to the reported failure.
- Remote and `jiuwenbox` sandbox providers enforce their own boundary and are untouched.
- How a parent handles a failed delegation — continuing as though the subagent had succeeded — is a separate problem.


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

Nine tests added:

- a skills path is admitted and an unrelated outside path still denied, in both `_resolve_path` and `_check_shell_sandbox` (four tests);
- an explicit `sandbox_root` is not extended by skill roots (one);
- de-duplication of the fallback list in each check, and of an explicit `sandbox_root` (three);
- one end-to-end test: `create_subagent` binds the parent's trees, `ensure_initialized` lands them in the ContextVar, and a real `FsOperation` in the subagent's context then admits the skill tree and still refuses an unrelated path.

All nine fail against the base source, though not equally usefully: the three de-duplication tests fail on their assertion, because de-duplication is behaviour the base lacks. The other six fail earlier — `init_cwd()` has no `skill_roots` argument there and `get_skill_roots` cannot be imported — so they establish the contract rather than discriminating behaviour. The behavioural evidence for the reported failure is the live run below.

`tests/unit_tests/core/sys_operation/` and `tests/unit_tests/harness/test_deep_agent.py`, run on this branch and on a clean checkout of the base and compared test-by-test:

- the selection gains exactly the nine new tests, all passing, and no previously passing test changes state;
- the pre-existing failures are the same test names on both trees — none added, none fixed.

Absolute pass/fail counts are deliberately not quoted, because the pre-existing failures are host-dependent and will differ in CI. On the machine used here they are: two from a fixed-name entry in the shared temporary directory owned by a different account (they pass under a private `TMPDIR`), three from an installed `filelock` whose `_ManagedReadWriteLock` signature differs from the one the lock tests expect, and two others that are environment-dependent. None is touched by this change.

Beyond the suite, the change was run on a live deployment against the failure in the issue. The delegated skill run that previously produced three 199003/199004 denials produced none; the subagent read the `assets/` template it had been denied, and all of the parent's skill trees appeared in its sandbox roots.


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #377
- Fixes #944
<!-- /bot1-related-issues -->

