### PR TITLE
fix(skills): tell the agent where each skill is installed

### DIFF
--- a/openjiuwen/harness/prompts/sections/skills.py
+++ b/openjiuwen/harness/prompts/sections/skills.py
@@ -1,9 +1,15 @@
 # coding: utf-8
 # Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
-"""Skill prompt section for DeepAgent (used by SkillUseRail)."""
+"""Skill prompt section for DeepAgent, and the shared rendering of one skill.
+
+SkillUseRail builds the section from here; the skill tools render individual
+skills through the same helpers so a skill is described the same way
+wherever the model meets it.
+"""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, Iterable, List, Optional
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Union
 
 from openjiuwen.harness.prompts.sections import SectionName
 
@@ -43,14 +49,22 @@ SKILL_RAIL_LIST_SKILL_SYSTEM_PROMPT: Dict[str, str] = {
 # ---------------------------------------------------------------------------
 SKILL_RAIL_ALL_MODE_HEADER_CN = (
     "# 技能\n\n"
-    "选择与任务最相关的技能，使用技能前，调用 `skill_tool` 获取该技能的完整 `SKILL.md`。\n\n"
+    "选择与任务最相关的技能，使用技能前，调用 `skill_tool` 获取该技能的完整 `SKILL.md`。\n"
+    "每个技能下方的 `Directory:` 是该技能目录的绝对路径。技能随附的脚本、参考文档等文件"
+    "均位于该目录下：将 `SKILL.md` 中的相对路径拼接到该绝对路径之后，再用文件系统工具读取或执行，"
+    "不要按裸文件名搜索。\n\n"
     "当前可用技能：\n\n"
 )
 
 SKILL_RAIL_ALL_MODE_HEADER_EN = (
     "# Skills\n\n"
     "Select the skill most relevant to the task. Before using a skill, call "
-    "`skill_tool` to retrieve its complete `SKILL.md`.\n\n"
+    "`skill_tool` to retrieve its complete `SKILL.md`.\n"
+    "The `Directory:` line under each skill is the absolute path of that skill's own "
+    "directory. Files bundled with a skill (scripts, reference documents, templates) live "
+    "under it: join the relative paths used in `SKILL.md` onto that absolute path before "
+    "reading or executing them with the filesystem tools, instead of searching for bare "
+    "file names.\n\n"
     "Currently available skills:\n\n"
 )
 
@@ -111,6 +125,26 @@ SKILL_RAIL_NO_SKILL_PROMPT: Dict[str, str] = {
 
 
 # ---------------------------------------------------------------------------
+# Skill directory normalization
+# ---------------------------------------------------------------------------
+def resolve_skill_directory(directory: Union[str, Path, None]) -> str:
+    """Normalize a skill directory into the absolute path rendered to the model.
+
+    Returns an empty string when there is no directory to render. ``Path("")``
+    and ``Path(".")`` both resolve to the process working directory, which the
+    model cannot tell apart from a real skill directory and would join relative
+    paths onto, so neither is rendered.
+    """
+    raw = str(directory or "").strip()
+    if not raw or raw == ".":
+        return ""
+    try:
+        return str(Path(raw).resolve())
+    except (OSError, ValueError):
+        return ""
+
+
+# ---------------------------------------------------------------------------
 # Helper functions (same signatures, now accept language)
 # ---------------------------------------------------------------------------
 def build_skill_line(
@@ -119,12 +153,19 @@ def build_skill_line(
     skill_name: str,
     description: str,
     skill_md_path: Optional[str] = None,
+    skill_directory: Optional[str] = None,
     language: str = "cn",
 ) -> str:
-    """Build one rendered skill line."""
+    """Build one rendered skill line.
+
+    ``skill_directory`` renders the absolute path of the skill's own directory.
+    Without it the model has no way to resolve the relative paths a ``SKILL.md``
+    uses for its bundled scripts and reference documents.
+    """
     separator = "：" if language == "cn" else ": "
     return (
         f"{index}. `{skill_name}`{separator}{description}"
+        + (f"\n   Directory: {skill_directory}" if skill_directory else "")
         + (f"\n   Path: {skill_md_path}" if skill_md_path else "")
     )
 

--- a/openjiuwen/harness/rails/skills/skill_use_rail.py
+++ b/openjiuwen/harness/rails/skills/skill_use_rail.py
@@ -20,6 +20,7 @@ from openjiuwen.harness.prompts.sections.skills import (
     build_skill_line,
     build_skill_lines,
     build_skills_section,
+    resolve_skill_directory,
 )
 from openjiuwen.harness.prompts.prompt_attachment_manager import PromptAttachmentKind
 from openjiuwen.harness.rails.base import DeepAgentRail
@@ -468,7 +469,7 @@ class SkillUseRail(DeepAgentRail):
                         skill_name=skill.name,
                         description=skill.description,
                         language=self.system_prompt_builder.language,
-                        # skill_md_path=str(self._skill_md_path(skill)), # No longer needed with SkillTool
+                        skill_directory=self._skill_directory(skill),
                     )
                 )
             return build_skills_section(
@@ -626,6 +627,7 @@ class SkillUseRail(DeepAgentRail):
                         skill_name=skill.name,
                         description=skill.description,
                         language=self.system_prompt_builder.language,
+                        skill_directory=self._skill_directory(skill),
                     )
                     for index, skill in enumerate(additions)
                 )
@@ -648,6 +650,7 @@ class SkillUseRail(DeepAgentRail):
                     skill_name=skill.name,
                     description=skill.description,
                     language=self.system_prompt_builder.language,
+                    skill_directory=self._skill_directory(skill),
                 )
                 for index, skill in enumerate(additions)
             )
@@ -672,7 +675,7 @@ class SkillUseRail(DeepAgentRail):
                     skill_name=skill.name,
                     description=self._get_skill_description(skill),
                     language=self.system_prompt_builder.language,
-                    # skill_md_path=str(self._skill_md_path(skill)), # No longer needed with SkillTool
+                    skill_directory=self._skill_directory(skill),
                 )
             )
 
@@ -827,9 +830,14 @@ class SkillUseRail(DeepAgentRail):
         return str(description).strip()
 
     @staticmethod
-    def _skill_md_path(skill: Skill) -> Path:
-        """Return SKILL.md path for a skill."""
-        return skill.directory / "SKILL.md"
+    def _skill_directory(skill: Skill) -> str:
+        """Return the absolute directory a skill and its bundled files live in.
+
+        Empty when the skill carries no directory to render; see
+        ``resolve_skill_directory``, which the skill_tool result text renders
+        through as well so the field has one normalization rather than two.
+        """
+        return resolve_skill_directory(skill.directory)
 
     @staticmethod
     def _parse_skill_dirs(raw: str) -> List[str]:

--- a/openjiuwen/harness/tools/skills/skill_tool.py
+++ b/openjiuwen/harness/tools/skills/skill_tool.py
@@ -10,6 +10,7 @@ from typing import Any, AsyncIterator, Callable, Dict, List, Optional, Tuple
 from openjiuwen.core.foundation.tool import Tool
 from openjiuwen.core.single_agent.skills.skill_manager import Skill
 from openjiuwen.core.sys_operation.sys_operation import SysOperation
+from openjiuwen.harness.prompts.sections.skills import resolve_skill_directory
 from openjiuwen.harness.prompts.tools import build_tool_card
 from openjiuwen.harness.tools.skills.markdown_media import (
     markdown_has_image_reference,
@@ -280,11 +281,39 @@ def _skill_layout_metadata(skill_directory: Path) -> Dict[str, Any]:
     return meta
 
 
-def _format_layout_appendix_for_model(layout: Dict[str, Any], *, skill_name: str = "") -> str:
-    """Render directory layout for model-facing tool text.
+SKILL_DIRECTORY_HEADING = "## Skill directory"
 
-    AbilityManager prefers ``data['content']`` when present and drops other fields.
-    Append this block to ``content`` so directory_tree / nested skills stay visible.
+
+def _format_skill_directory_for_model(skill_directory: str) -> str:
+    """Render the skill's own absolute directory for model-facing tool text.
+
+    Normalized through the same helper the prompt listing uses, so a skill is
+    described by one path wherever the model meets it.
+    """
+    path = resolve_skill_directory(skill_directory)
+    if not path:
+        return ""
+    return (
+        f"{SKILL_DIRECTORY_HEADING}\n"
+        f"{path}\n"
+        "Files bundled with this skill live under that absolute path. Resolve every "
+        "relative path used below against it, then read or execute the result with the "
+        "filesystem tools."
+    )
+
+
+def _format_layout_appendix_for_model(
+    layout: Dict[str, Any],
+    *,
+    skill_name: str = "",
+    skill_directory: str = "",
+) -> str:
+    """Render the skill directory and layout for model-facing tool text.
+
+    This appendix is merged into ``data['content']``, which AbilityManager
+    renders verbatim; the sibling result fields never reach the model. The
+    skill's own absolute directory therefore has to be rendered here to be
+    readable at all.
 
     Args:
         layout: Metadata from :func:`_skill_layout_metadata`.
@@ -292,8 +321,14 @@ def _format_layout_appendix_for_model(layout: Dict[str, Any], *, skill_name: str
             example as a call that actually works — a nested skill is not
             registered as a top-level skill, so its own name is not a valid
             ``skill_name`` and the model has to keep passing the parent's.
+        skill_directory: Absolute directory the skill was installed in. A
+            ``SKILL.md`` addresses its bundled files relative to it, so without
+            it those paths cannot be resolved.
     """
     parts: List[str] = []
+    directory_block = _format_skill_directory_for_model(skill_directory)
+    if directory_block:
+        parts.append(directory_block)
     tree = layout.get("directory_tree")
     if isinstance(tree, list) and tree:
         tree_text = str(tree[0]).strip()
@@ -434,8 +469,13 @@ class SkillTool(Tool):
             # when present and otherwise falls back to ``str(result)``, which buries
             # the skill body — and this appendix with it — inside a pydantic repr of
             # the whole ToolOutput. The other keys stay in ``data`` for programmatic
-            # consumers; the model reads this.
-            appendix = _format_layout_appendix_for_model(layout, skill_name=skill.name)
+            # consumers; the model reads this. skill_directory is among the keys the
+            # model would otherwise never see, so it is rendered into the appendix.
+            appendix = _format_layout_appendix_for_model(
+                layout,
+                skill_name=skill.name,
+                skill_directory=str(skill.directory),
+            )
             data["content"] = f"{body.rstrip()}\n\n{appendix}" if appendix else body
 
             return ToolOutput(
@@ -472,6 +512,7 @@ __all__ = [
     "SKILL_TOOL_MARKDOWN_IMAGES_HINT",
     "SKILL_TOOL_MARKDOWN_IMAGES_VISION_HINT",
     "SKILL_TOOL_MARKDOWN_VIDEOS_HINT",
+    "SKILL_DIRECTORY_HEADING",
     "apply_skill_tool_markdown_images_hint",
     "skill_markdown_has_media",
 ]

--- a/tests/unit_tests/harness/prompts/test_skills_section.py
+++ b/tests/unit_tests/harness/prompts/test_skills_section.py
@@ -1,0 +1,181 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Skill listing must carry the absolute directory of each skill.
+
+A ``SKILL.md`` refers to the files bundled next to it with relative paths
+(``scripts/fetch.py``, ``references/report-format.md``).  Those paths are only
+resolvable when the model also knows the absolute directory the skill was
+installed in.  The skills tree is not necessarily under the search root the
+filesystem tools default to, so a model that is not given the directory cannot
+recover it by searching either.
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import tempfile
+
+import pytest
+import pytest_asyncio
+
+from openjiuwen.core.runner import Runner
+from openjiuwen.core.sys_operation import LocalWorkConfig, OperationMode, SysOperationCard
+from openjiuwen.core.sys_operation.cwd import init_cwd
+from openjiuwen.harness.prompts.sections.skills import (
+    build_all_mode_skill_prompt,
+    build_skill_line,
+    build_skill_lines,
+)
+from openjiuwen.harness.tools import BashTool, GlobTool, ReadFileTool
+
+_SKILL_NAME = "repository-activity"
+_BUNDLED_REFERENCE = "references/report-format.md"
+_BUNDLED_SCRIPT = "scripts/fetch_repository_activity.py"
+_REFERENCE_BODY = "# Report format\n\nOne section per repository.\n"
+
+
+@pytest.fixture
+def skills_and_project_dirs():
+    """Build the standard workspace layout: ``skills/`` beside ``projects/``.
+
+    A session runs rooted in ``projects/<name>``, so the skills tree is a
+    sibling of the search root, not a descendant of it.
+    """
+    root = tempfile.mkdtemp()
+    try:
+        skills_dir = os.path.join(root, "skills")
+        skill_dir = os.path.join(skills_dir, _SKILL_NAME)
+        os.makedirs(os.path.join(skill_dir, "references"))
+        os.makedirs(os.path.join(skill_dir, "scripts"))
+        with open(os.path.join(skill_dir, "SKILL.md"), "w", encoding="utf-8") as handle:
+            handle.write(
+                "---\n"
+                "description: Summarise repository activity\n"
+                "---\n\n"
+                f"Run `{_BUNDLED_SCRIPT}` and format the result as described in "
+                f"`{_BUNDLED_REFERENCE}`.\n"
+            )
+        with open(
+            os.path.join(skill_dir, _BUNDLED_REFERENCE), "w", encoding="utf-8"
+        ) as handle:
+            handle.write(_REFERENCE_BODY)
+        with open(
+            os.path.join(skill_dir, _BUNDLED_SCRIPT), "w", encoding="utf-8"
+        ) as handle:
+            handle.write("print('activity')\n")
+
+        project_dir = os.path.join(root, "projects", "reporting")
+        os.makedirs(project_dir)
+        yield skill_dir, project_dir
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+@pytest_asyncio.fixture(name="sys_op")
+async def sys_op_fixture():
+    await Runner.start()
+    card_id = "test_skills_section_op"
+    Runner.resource_mgr.add_sys_operation(
+        SysOperationCard(
+            id=card_id,
+            mode=OperationMode.LOCAL,
+            work_config=LocalWorkConfig(shell_allowlist=["echo", "ls", "python", "python3"]),
+        )
+    )
+    yield Runner.resource_mgr.get_sys_operation(card_id)
+    Runner.resource_mgr.remove_sys_operation(sys_operation_id=card_id)
+    await Runner.stop()
+
+
+def _rendered_prompt(skill_directory: str, language: str) -> str:
+    line = build_skill_line(
+        index=0,
+        skill_name=_SKILL_NAME,
+        description="Summarise repository activity",
+        skill_directory=skill_directory,
+        language=language,
+    )
+    return build_all_mode_skill_prompt(build_skill_lines([line]), language=language)
+
+
+def _directory_from_prompt(prompt: str) -> str:
+    """Recover the skill directory from the prompt the way a model would."""
+    match = re.search(r"^\s*Directory:\s*(.+?)\s*$", prompt, flags=re.MULTILINE)
+    assert match is not None, prompt
+    return match.group(1)
+
+
+def test_skill_line_omits_directory_when_not_supplied():
+    line = build_skill_line(index=0, skill_name=_SKILL_NAME, description="d")
+    assert "Directory:" not in line
+
+
+@pytest.mark.parametrize("language", ["cn", "en"])
+def test_all_mode_prompt_carries_absolute_skill_directory(skills_and_project_dirs, language):
+    skill_dir, _ = skills_and_project_dirs
+
+    prompt = _rendered_prompt(skill_dir, language)
+
+    assert f"Directory: {skill_dir}" in prompt
+    assert _directory_from_prompt(prompt) == skill_dir
+    # The header must explain what the directory is for, otherwise the path is
+    # just noise the model has no rule for applying.
+    assert ("绝对路径" in prompt) if language == "cn" else ("absolute path" in prompt)
+
+
+@pytest.mark.asyncio
+async def test_bundled_file_is_readable_through_the_advertised_directory(
+    sys_op, skills_and_project_dirs
+):
+    """Walk the whole route: prompt -> directory -> read a bundled file."""
+    skill_dir, project_dir = skills_and_project_dirs
+    init_cwd(project_dir, project_dir, workspace=project_dir)
+
+    advertised = _directory_from_prompt(_rendered_prompt(skill_dir, "en"))
+    reference_path = os.path.join(advertised, _BUNDLED_REFERENCE)
+
+    read_res = await ReadFileTool(sys_op).invoke({"file_path": reference_path})
+
+    assert read_res.success is True, read_res.error
+    assert "One section per repository." in read_res.data["content"]
+
+
+@pytest.mark.asyncio
+async def test_bundled_script_runs_through_the_advertised_directory(
+    sys_op, skills_and_project_dirs
+):
+    """The advertised directory is usable for execution, not only for reading."""
+    skill_dir, project_dir = skills_and_project_dirs
+    init_cwd(project_dir, project_dir, workspace=project_dir)
+
+    advertised = _directory_from_prompt(_rendered_prompt(skill_dir, "en"))
+    script_path = os.path.join(advertised, _BUNDLED_SCRIPT)
+
+    bash_res = await BashTool(sys_op).invoke({"command": f'python3 "{script_path}"'})
+
+    assert bash_res.success is True, bash_res.error
+    assert "activity" in bash_res.data["content"]
+
+
+@pytest.mark.asyncio
+async def test_bundled_file_is_not_reachable_by_searching_the_session_directory(
+    sys_op, skills_and_project_dirs
+):
+    """Why the directory has to be advertised: search alone cannot find it.
+
+    ``glob`` and ``grep`` root themselves at the session directory when no path
+    is given, and the skills tree is a sibling of that root, so an unqualified
+    recursive pattern can never reach a bundled file.
+    """
+    skill_dir, project_dir = skills_and_project_dirs
+    init_cwd(project_dir, project_dir, workspace=project_dir)
+
+    glob_res = await GlobTool(sys_op).invoke({"pattern": "**/*"})
+
+    assert glob_res.success is True, glob_res.error
+    assert glob_res.data["count"] == 0
+
+    scoped = await GlobTool(sys_op).invoke({"pattern": "**/*.md", "path": skill_dir})
+    assert scoped.success is True, scoped.error
+    assert scoped.data["count"] > 0

--- a/tests/unit_tests/harness/test_skill_rail.py
+++ b/tests/unit_tests/harness/test_skill_rail.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import re
 import time
 from pathlib import Path
 from typing import Any, Dict, List
@@ -14,6 +15,7 @@ from openjiuwen.core.foundation.llm.schema.message import SystemMessage
 from openjiuwen.core.runner.runner import Runner
 from openjiuwen.core.single_agent.rail.base import AgentCallbackContext, ModelCallInputs
 from openjiuwen.core.single_agent.schema.agent_card import AgentCard
+from openjiuwen.core.single_agent.skills.skill_manager import Skill
 from openjiuwen.core.sys_operation import (
     LocalWorkConfig,
     OperationMode,
@@ -24,7 +26,7 @@ from openjiuwen.harness.factory import create_deep_agent
 from openjiuwen.harness.prompts.builder import PromptSection, SystemPromptBuilder
 from openjiuwen.harness.prompts.prompt_attachment_manager import PromptAttachmentManager
 from openjiuwen.harness.rails.skills.skill_use_rail import SkillUseRail
-from openjiuwen.harness.tools import ListSkillTool
+from openjiuwen.harness.tools import BashTool, ListSkillTool, ReadFileTool
 from openjiuwen.harness.tools.skills.skill_tool import SKILL_TOOL_MARKDOWN_IMAGES_HINT
 
 
@@ -101,12 +103,17 @@ def _write_skill(
     return skill_dir
 
 
-def _make_sys_operation(tmp_path: Path):
+def _make_sys_operation(tmp_path: Path, shell_allowlist: List[str] | None = None):
     """Create a local SysOperation for tests."""
+    work_config = (
+        LocalWorkConfig(work_dir=str(tmp_path), shell_allowlist=shell_allowlist)
+        if shell_allowlist is not None
+        else LocalWorkConfig(work_dir=str(tmp_path))
+    )
     card = SysOperationCard(
         id=f"test_skill_rail_sysop_{tmp_path.name}",
         mode=OperationMode.LOCAL,
-        work_config=LocalWorkConfig(work_dir=str(tmp_path)),
+        work_config=work_config,
     )
     Runner.resource_mgr.add_sys_operation(card)
     return Runner.resource_mgr.get_sys_operation(card.id)
@@ -807,6 +814,154 @@ async def test_skill_rail_persists_baseline_and_attaches_only_runtime_additions(
     )
     assert "使用规则" not in (attachments[0].content or "")
     assert "Activation rule" not in (attachments[0].content or "")
+
+
+@pytest.mark.asyncio
+async def test_skill_rail_all_mode_section_carries_skill_directory(tmp_path: Path):
+    """The baseline skills section names the directory each skill lives in.
+
+    A renderer that accepts a directory argument proves nothing about what its
+    caller passes it, so this drives SkillUseRail over a real skills tree and
+    asserts on the system prompt section the rail itself builds, then follows
+    the advertised path to a bundled file the way a model would.
+    """
+    skills_root = tmp_path / "skills"
+    skills_root.mkdir(parents=True, exist_ok=True)
+    skill_dir = _write_skill(
+        skills_root,
+        "invoice-parser",
+        "Parse invoice pdf files",
+        body="\nFollow `references/format.md` when parsing an invoice.\n",
+    )
+    skill_dir.joinpath("references").mkdir()
+    skill_dir.joinpath("references", "format.md").write_text(
+        "# Format\n\nOne invoice per page.\n", encoding="utf-8"
+    )
+
+    sys_operation = _make_sys_operation(tmp_path)
+    rail = SkillUseRail(skills_dir=str(skills_root), skill_mode="all", include_tools=False)
+    rail.set_sys_operation(sys_operation)
+    rail.system_prompt_builder = SystemPromptBuilder(language="en")
+    rail.attachment_manager = PromptAttachmentManager()
+
+    session = _SessionState("all-mode-skill-directory")
+    ctx = AgentCallbackContext(agent=None, inputs=ModelCallInputs(tools=[]), session=session)
+    await rail.before_invoke(ctx)
+
+    system_prompt = rail.system_prompt_builder.build()
+    assert "invoice-parser" in system_prompt
+    assert f"Directory: {skill_dir.resolve()}" in system_prompt
+
+    # The all mode listing is rendered from a second builder over the same
+    # skills, which has to agree with the section the session prompt carries.
+    assert f"Directory: {skill_dir.resolve()}" in rail._build_all_mode_prompt()
+
+    # Follow the route a model would: recover the advertised directory from the
+    # rendered prompt and join onto it the relative path the SKILL.md uses.
+    advertised = re.search(r"^\s*Directory:\s*(.+?)\s*$", system_prompt, flags=re.MULTILINE)
+    assert advertised is not None, system_prompt
+
+    read_res = await ReadFileTool(sys_operation).invoke(
+        {"file_path": str(Path(advertised.group(1)) / "references" / "format.md")}
+    )
+    assert read_res.success is True, read_res.error
+    assert "One invoice per page." in read_res.data["content"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("language", "additions_heading"),
+    [("cn", "新增可用 Skill："), ("en", "Newly available skills:")],
+)
+async def test_skill_rail_runtime_addition_carries_skill_directory(
+    tmp_path: Path, language: str, additions_heading: str
+):
+    """A skill installed mid-session is announced with the directory it lives in.
+
+    The system prompt section is frozen to the session baseline, so this
+    attachment is the only place the model hears about a later installation. A
+    skill announced without its directory cannot resolve the relative paths its
+    own SKILL.md uses for bundled scripts and reference documents.
+    """
+    skills_root = tmp_path / "skills"
+    skills_root.mkdir(parents=True, exist_ok=True)
+    _write_skill(skills_root, "invoice-parser", "Parse invoice pdf files")
+
+    sys_operation = _make_sys_operation(tmp_path, shell_allowlist=["python", "python3"])
+    rail = SkillUseRail(skills_dir=str(skills_root), skill_mode="all", include_tools=False)
+    rail.set_sys_operation(sys_operation)
+    rail.system_prompt_builder = SystemPromptBuilder(language=language)
+    rail.attachment_manager = PromptAttachmentManager()
+
+    session = _SessionState(f"runtime-directory-{language}")
+    ctx = AgentCallbackContext(agent=None, inputs=ModelCallInputs(tools=[]), session=session)
+    await rail.before_invoke(ctx)
+
+    added_dir = _write_skill(
+        skills_root,
+        "xlsx-writer",
+        "Write xlsx reports",
+        body="\nRun `scripts/render.py` and follow `references/layout.md`.\n",
+    )
+    added_dir.joinpath("references").mkdir()
+    added_dir.joinpath("references", "layout.md").write_text(
+        "# Layout\n\nOne sheet per report.\n", encoding="utf-8"
+    )
+    added_dir.joinpath("scripts").mkdir()
+    added_dir.joinpath("scripts", "render.py").write_text(
+        "print('rendered')\n", encoding="utf-8"
+    )
+    await rail.before_model_call(ctx)
+
+    attachments = await rail.attachment_manager.collect_for_session(session.session_id)
+    content = attachments[0].content or ""
+
+    assert additions_heading in content
+    assert f"Directory: {added_dir.resolve()}" in content
+
+    # Follow the route a model would: take the advertised directory and join
+    # onto it the relative paths the skill's own SKILL.md uses, then read the
+    # reference document and run the script through the result.
+    advertised = re.search(r"^\s*Directory:\s*(.+?)\s*$", content, flags=re.MULTILINE)
+    assert advertised is not None, content
+    skill_dir = advertised.group(1)
+
+    read_res = await ReadFileTool(sys_operation).invoke(
+        {"file_path": str(Path(skill_dir) / "references" / "layout.md")}
+    )
+    assert read_res.success is True, read_res.error
+    assert "One sheet per report." in read_res.data["content"]
+
+    run_res = await BashTool(sys_operation).invoke(
+        {"command": f'python3 "{Path(skill_dir) / "scripts" / "render.py"}"'}
+    )
+    assert run_res.success is True, run_res.error
+    assert "rendered" in run_res.data["content"]
+
+    # The frozen baseline section is what makes the attachment the only route.
+    assert "xlsx-writer" not in rail.system_prompt_builder.build()
+
+
+@pytest.mark.parametrize("language", ["cn", "en"])
+def test_skill_rail_runtime_addition_omits_unresolvable_skill_directory(
+    tmp_path: Path, language: str
+):
+    """No directory is rendered when the skill carries none to render.
+
+    An empty directory resolves to the process working directory, which the
+    model cannot tell apart from a real skill path and would join relative
+    paths onto.
+    """
+    rail = SkillUseRail(skills_dir=str(tmp_path / "skills"), skill_mode="all", include_tools=False)
+    rail.system_prompt_builder = SystemPromptBuilder(language=language)
+
+    addition = Skill(name="xlsx-writer", description="Write xlsx reports", directory=Path(""))
+
+    content = rail._build_runtime_skill_change_content([addition], [], [])
+
+    assert "xlsx-writer" in content
+    assert "Directory:" not in content
+    assert str(Path.cwd()) not in content
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/harness/tools/test_skill_tool.py
+++ b/tests/unit_tests/harness/tools/test_skill_tool.py
@@ -372,3 +372,50 @@ async def test_skill_tool_media_hint_content_keeps_directory_layout(sys_op, temp
     assert "## Directory layout" in model_text
     assert "designer/SKILL.md" in model_text
     assert SKILL_TOOL_MARKDOWN_IMAGES_HINT in model_text
+
+
+@pytest.mark.parametrize(
+    "body, has_media",
+    [
+        # data['content'] is set for both: a9513636 made it unconditional. It is
+        # what AbilityManager returns on its own, dropping every sibling field --
+        # so skill_directory reaches the model only by being rendered into it.
+        # The bodies still differ in media detection, which is what this pins:
+        # the directory must not depend on it either way.
+        ("Save the rendered chart to output.png before reporting.", True),
+        ("Run scripts/fetch.py, then format per references/report-format.md.", False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_skill_tool_always_tells_the_model_the_skill_directory(
+    sys_op, temp_dir, body, has_media
+):
+    """The skill's own absolute path must not depend on media detection.
+
+    Bundled scripts and reference documents are addressed relatively from
+    SKILL.md; without the skill directory the model cannot turn those into
+    paths the filesystem tools accept.
+    """
+    from openjiuwen.core.single_agent.ability_manager import AbilityManager
+    from openjiuwen.harness.tools.skills.skill_tool import skill_markdown_has_media
+
+    skills_root = Path(temp_dir) / "skills"
+    skills_root.mkdir(parents=True, exist_ok=True)
+    skill = _write_skill(skills_root, "repository-activity", "activity report", body)
+
+    assert skill_markdown_has_media(body) is has_media
+
+    skill_tool = SkillTool(sys_op, lambda: [skill], multimodal_skill_mode="hint")
+    skill_res = await skill_tool.invoke({"skill_name": "repository-activity"})
+
+    assert skill_res.success is True
+    assert skill_res.data["skill_directory"] == str(skill.directory)
+    # Always set since a9513636, "fix(harness): make the nested-skill hint
+    # reachable and actionable", regardless of media detection. That is what
+    # makes rendering the directory into content necessary rather than
+    # optional: the serialized fallback that used to carry the sibling fields
+    # for a non-media skill is no longer reached.
+    assert "content" in skill_res.data
+
+    model_text = AbilityManager._build_tool_message_content(skill_res)
+    assert str(skill.directory) in model_text


### PR DESCRIPTION
Paired: [GitHub #380](https://github.com/openJiuwen-ai/agent-core/pull/380) ↔ [GitCode !2228](https://gitcode.com/openJiuwen/agent-core/merge_requests/2228)

**What type of PR is this?**

/kind bug


**Which issue(s) this PR fixes**:

Fixes #379


**What does this PR do / why do we need it**:

A `SKILL.md` addresses its bundled files with relative paths, and nothing tells the agent the absolute directory to join them onto. Any skill shipping files beside its `SKILL.md` therefore loses its function: the agent searches by bare file name, cannot reach a tree that is a sibling of its session directory, and gives up.

The directory has to survive three separate routes to the model, and it was absent from all three.

---

### 1. The skill listing in the system prompt

`SkillUseRail` renders the skill's own directory under each listing entry, and the section header states what it is for, so relative paths in a `SKILL.md` can be joined onto it directly. `build_skill_line` gains a `skill_directory` argument beside the existing `skill_md_path` one.

`ListSkillTool` already reports `directory` and `skill_md_path` for every skill it returns, so this brings the `all` listing mode in line with the `auto_list` one rather than introducing a new convention. The commented-out argument dates from `e9d85265`, `fix(Prompt Attachment): Move the skill section back into the system prompt`, which carried it over with the note that `SkillTool` had made it unnecessary.

### 2. The skill_tool result text

`skill_tool` returns `skill_directory` in its result data, but that field never reaches the model. The ability layer renders each tool result through the tool's `render_for_llm`, and the default implementation returns `data["content"]` alone on success. Every sibling field in `data` is dropped. The absolute directory is therefore prepended to the appendix already merged into `content`, alongside the directory tree and the nested skill list. The rendered block also states that bundled files resolve against that path, which the bare value did not.

The interaction predates this change and arrives in pieces. `skill_directory` has been in the result data since `8e8f8d6e`, `feat(skill): Add skill tool`. The preference for a `content` key arrives with `27062b2d`, `feat(harness): Add multimodal ability`. The media detector that used to decide whether `content` was set at all arrives with `cd29fa5e`, `feat(skill_tool): extend skill use for multimodal skill`. `5cf1f6c7`, `fix(core): enable skill_tool to return directory tree for agent sub-skill discovery`, added the appendix this change extends, and already noted that sibling fields would otherwise be hidden.

`a9513636`, `fix(harness): make the nested-skill hint reachable and actionable`, has since set `content` on every `skill_tool` result, so the appendix is now always the text the model reads. Before that commit, whether the appendix arrived at all turned on the detector matching a bare image or video file name anywhere in the `SKILL.md` body. That is why the result-text coverage is parametrized over a body that trips the detector and one that does not: the branch decides what the body is rewritten to, and the directory has to reach the model in both cases.

The renderer itself is deliberately left alone: changing which fields it shows would alter the message content of every tool result in the harness, well beyond skills. Making the directory part of the appendix fixes the reported failure and leaves every other tool result as it is.

### 3. Skills installed after a session starts

The skills section of the system prompt is frozen to the session baseline persisted at first skill use, so a skill installed later never enters it. In `all` mode its only announcement to the model is the `skills.runtime_changes` attachment, and both of its language branches called `build_skill_line` without a directory, so a mid-session installation arrived with no path to its own bundled files. Both branches now pass the directory through the same argument, so the field has one rendering rather than three. That route arrives with `1bf14832`, `fix(skill_rail): persist session baseline and track runtime changes`, and predates the `Directory` line.

---

### Relationship to #198 and #297

#297, `fix: skill_tool only support SKILL.md`, closes the route agents had been using to pull bundled files in through `skill_tool`, which is what #198 reports as a context-window problem. Its own diagnostic sends the agent elsewhere:

> `skill_tool only supports reading SKILL.md files under the skill directory; Use filesystem tools for other files under the skill directory.`

Following that requires knowing the skill directory, which nothing supplies today. These changes therefore compose rather than compete: #297 says which tool to use for bundled files, and this says where to point it. Without both, a skill that ships files beside its `SKILL.md` has no working path to them at all.

This also serves #198's underlying concern. An agent given the directory reads the one file it needs; an agent without it escalates to repeated globs, greps and a filesystem-wide `find`, which consumes far more context than the read being avoided.

Note on targeting: #297 is merged to `dev-stable` and is not on `develop`, so this change does not conflict with it today. The two touch the same files in `harness/tools/skills/skill_tool.py`, and a small reconciliation should be expected when those branches converge. This PR deliberately does not reintroduce any non-`SKILL.md` read through `skill_tool`; the directory is exposed as a path for the filesystem tools to use.

Note on #378, `fix(sandbox): let subagents read the skills they are delegated work from`: it grants a subagent access to the skill trees, and this supplies the path to join a `SKILL.md`'s relative paths onto. The two touch disjoint files and neither depends on the other.

### Not addressed here

The media detector's false positives remain: a body reading `Save the rendered chart to output.png before reporting.` still trips `skill_markdown_has_media`. They are why the `skill_tool` symptom was originally intermittent. The detector no longer decides whether a skill can find its own files: `a9513636` made `content` unconditional, and the directory is rendered into the appendix either way. What it still decides is how the body itself is rewritten.


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

The renderer tests exercise the path a model would take. One lays out a skills tree beside a session directory, recovers the directory from the rendered listing, then reads a bundled reference document and executes a bundled script through the recovered path. A companion test pins why the listing is needed at all, by showing that an unqualified recursive glob from the session directory finds nothing.

Those call `build_skill_line` and `build_all_mode_skill_prompt` directly, so they exercise the renderer against a directory the test itself supplies. They do not reach the rail's own call sites: re-commenting either of the two this change uncovers leaves every one of them green. A further test therefore drives `SkillUseRail` in `all` mode over a skills tree on disk, and asserts the `Directory:` line both in the section the rail installs in the system prompt and in the `all` mode listing, then recovers the path from the rendered prompt and reads a bundled reference document through it. Against `develop` it fails on the first of those assertions: the skills section there renders each skill's name and description and no `Directory:` line. With the two call sites re-commented on this branch, it is the only test in these three files that fails.

The result-text test is parametrized over one `SKILL.md` whose prose trips the media detector and one that does not. In both cases it asserts that the text `_build_tool_message_content` produces names the skill's absolute directory, and that `content` is set, so the appendix is the only route the field has. The coverage that already existed pins only the directory tree and nested skill names. That is why the missing field went unnoticed.

The mid-session test takes the same shape one level up: it starts a session over one skill, installs a second one that ships a bundled reference document and a bundled script, recovers the directory from the rendered attachment, and reads and executes them through it. It also pins the frozen baseline section as the reason the attachment is the route that matters. A companion test covers the empty-directory case, and asserts that no `Directory:` line is rendered and that the process working directory does not appear.

`tests/unit_tests/harness`, `tests/unit_tests/agent_teams` and `tests/unit_tests/rsi` were run against this change and against `develop`, and the results compared test by test. The failing and erroring sets are identical on both sides, and no test in either set touches skills. This change adds thirteen passing tests. No test passes on `develop` and fails here.

Beyond the suite, the change was applied to a live deployment and the run described in the issue was repeated: it went from 21 tool calls ending in a cancelled task and a request for the file paths, to 3 tool calls with no blind searches at all.


### Rebased onto `develop` at `6dfda012`

One conflict, in `skill_tool.py`, on the comment above the appendix call. `develop` had rewritten that comment to describe the default `Tool.render_for_llm`, where this branch described `AbilityManager._build_tool_message_content`. That method has since been removed: `AbilityManager` now renders each result through `_render_tool_result`, which delegates to the tool's `render_for_llm`. `SkillTool` does not override `render_for_llm`, so the default runs and still returns `data["content"]` alone on success. The fix is unaffected, and the appendix remains the only route the directory has to the model. Only the explanation of why was out of date, and it has been corrected here and in the source comments.

One test had to be reworked for the same reason. The result-text test called `AbilityManager._build_tool_message_content` directly and now drives `AbilityManager._render_tool_result` instead, which is the method the ability layer actually uses. It still fails when the directory is removed from the appendix call, and this was checked in both directions.

`#297` remains merged to `dev-stable` only. `develop` still accepts an arbitrary `relative_file_path` under the traversal guard, so the note on targeting above is unchanged.

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #198
- Fixes #379
<!-- /bot1-related-issues -->
