### PR TITLE
fix(observability): trace standalone DeepAgent runs

### DIFF
--- a/openjiuwen/harness/factory.py
+++ b/openjiuwen/harness/factory.py
@@ -44,6 +44,7 @@ from openjiuwen.harness.tools import create_vision_tools, is_free_search_enabled
 
 if TYPE_CHECKING:
     from openjiuwen.agent_evolving.trajectory.processor import TrajectorySpanProcessor
+    from openjiuwen.extensions.observability.config import ObservabilityConfig
 
 
 def _is_disabled_free_search_tool(tool: Tool | ToolCard) -> bool:
@@ -218,6 +219,7 @@ def resolve_deep_agent_parts(
     enable_model_anomaly_detection_rail: bool = True,
     enable_sys_operation: bool = True,
     trajectory_span_processor: TrajectorySpanProcessor | None = None,
+    observability_config: ObservabilityConfig | None = None,
     **config_kwargs: Any,
 ) -> DeepAgentParts:
     """Assemble DeepAgent config + rails + tools without creating an instance.
@@ -355,6 +357,16 @@ def resolve_deep_agent_parts(
     def _already_provided(rail_cls: type) -> bool:
         return any(issubclass(t, rail_cls) for t in user_provided_rail_types)
 
+    if observability_config is not None and observability_config.enabled:
+        from openjiuwen.harness.observability import (
+            AgentObservabilityRail,
+            acquire_observability,
+        )
+
+        acquire_observability(observability_config)
+        if not _already_provided(AgentObservabilityRail):
+            all_rails.append(AgentObservabilityRail())
+
     def _make_skill_rail() -> SkillUseRail:
         skills_dirs: list[str] = []
         skills_base = workspace_obj.get_node_path("skills")
@@ -483,6 +495,7 @@ def create_deep_agent(
     parallel_tool_calls: bool = True,
     enable_security_rail: bool = True,
     enable_model_anomaly_detection_rail: bool = True,
+    observability_config: ObservabilityConfig | None = None,
     **config_kwargs: Any,
 ) -> DeepAgent:
     """Create and configure a DeepAgent instance.
@@ -578,6 +591,7 @@ def create_deep_agent(
         parallel_tool_calls=parallel_tool_calls,
         enable_security_rail=enable_security_rail,
         enable_model_anomaly_detection_rail=enable_model_anomaly_detection_rail,
+        observability_config=observability_config,
         **config_kwargs,
     )
     agent = DeepAgent(parts.config.card)

--- a/tests/unit_tests/harness/test_factory_model_anomaly_detection_rail.py
+++ b/tests/unit_tests/harness/test_factory_model_anomaly_detection_rail.py
@@ -2,7 +2,9 @@
 # Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
 
 from openjiuwen.core.foundation.llm import Model, ModelClientConfig, ModelRequestConfig
+from openjiuwen.extensions.observability.config import ObservabilityConfig
 from openjiuwen.harness import create_deep_agent
+from openjiuwen.harness.observability.rail import AgentObservabilityRail
 from openjiuwen.harness.rails.model_anomaly_detection_rail import ModelAnomalyDetectionRail
 
 
@@ -48,3 +50,40 @@ def test_create_deep_agent_does_not_duplicate_manual_model_anomaly_detection_rai
 
     anomaly_rails = [rail for rail in agent._pending_rails if isinstance(rail, ModelAnomalyDetectionRail)]
     assert anomaly_rails == [manual_rail]
+
+
+def test_create_deep_agent_observability_config_auto_adds_rail(monkeypatch) -> None:
+    init_calls: list[ObservabilityConfig] = []
+
+    monkeypatch.setattr(
+        "openjiuwen.harness.observability.acquire_observability",
+        lambda config: init_calls.append(config),
+    )
+
+    config = ObservabilityConfig(enabled=True, exporter="console")
+    agent = create_deep_agent(
+        model=_create_dummy_model(),
+        observability_config=config,
+        auto_create_workspace=False,
+    )
+
+    assert init_calls == [config]
+    assert sum(1 for rail in agent._pending_rails if isinstance(rail, AgentObservabilityRail)) == 1
+
+
+def test_create_deep_agent_observability_config_does_not_duplicate_manual_rail(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "openjiuwen.harness.observability.acquire_observability",
+        lambda config: None,
+    )
+
+    manual_rail = AgentObservabilityRail()
+    agent = create_deep_agent(
+        model=_create_dummy_model(),
+        rails=[manual_rail],
+        observability_config=ObservabilityConfig(enabled=True, exporter="console"),
+        auto_create_workspace=False,
+    )
+
+    obs_rails = [rail for rail in agent._pending_rails if isinstance(rail, AgentObservabilityRail)]
+    assert obs_rails == [manual_rail]


### PR DESCRIPTION
Paired: [GitHub #427](https://github.com/openJiuwen-ai/agent-core/pull/427) ↔ [GitCode !2254](https://gitcode.com/openJiuwen/agent-core/merge_requests/2254)

> *This was generated by AI during triage.*

## Summary

Fixes standalone DeepAgent observability. The existing observability rail skipped or failed to parent spans when no team/root span already existed, so explicitly opted-in standalone runs did not produce a complete trace.

Fixes #917.
Refs #426.

Changes:

- Adds explicit observability_config opt-in to create_deep_agent and resolve_deep_agent_parts.
- Initializes observability when needed and auto-adds ObservabilityRail without duplicating a manual rail.
- Adds standalone agent root spans so task-loop and single-round DeepAgent runs can emit a complete trace outside team context.
- Starts standalone root spans from a clean OTel context so sequential invocations do not inherit an ended span.
- Reuses existing ObservabilityRail and parent-resolution paths for LLM/tool spans.
- Keeps observability imports lazy so normal harness imports do not require optional OTel dependencies.
- Adds regression coverage for standalone task-loop, single-round, sequential invocation, and factory wiring behavior.

## Validation

```bash
env UV_CACHE_DIR=/tmp/uv-cache uv run --extra observability pytest tests/unit_tests/agent_teams/observability/test_observability.py tests/unit_tests/harness/test_factory_model_anomaly_detection_rail.py -q
```

Result: 50 passed.

```bash
git diff --check origin/develop..HEAD
```

Result: clean.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #426
- Fixes #917
<!-- /bot1-related-issues -->
