### PR TITLE
feat(interaction): real mid-turn steering with applied reporting

### DIFF
--- a/openjiuwen/agent_teams/agent/member_runtime.py
+++ b/openjiuwen/agent_teams/agent/member_runtime.py
@@ -162,4 +162,61 @@ class MemberRuntime(Protocol):
         ...
 
 
-__all__ = ["MemberRuntime"]
+@runtime_checkable
+class SupportsRoundSteering(Protocol):
+    """A runtime that can inject text into one specific in-flight round.
+
+    Kept out of :class:`MemberRuntime` on purpose. That Protocol is what *every*
+    runtime must satisfy -- ``isinstance`` checks assert exactly that -- and
+    round-scoped steering is a capability only some have. Declaring it there made
+    ``ExternalCliRuntime`` stop conforming, which is the honest answer to the
+    wrong question: the CLI runtime is a perfectly good MemberRuntime that simply
+    cannot do this.
+
+    Ask with ``isinstance(runtime, SupportsRoundSteering)`` and report the
+    absence as its own outcome. A runtime that cannot steer a round is not the
+    same as a round that ended, and telling a user "your instruction arrived
+    late" when the truth is "this member can never take one" sends them looking
+    for a race that does not exist.
+
+    Method-only on purpose: a Protocol carrying a non-method member cannot be
+    used with ``issubclass``, and a class-level check is what a test can assert
+    without constructing a runtime. ``active_round`` is therefore not declared
+    here; callers that want a round id read it defensively, since it only names
+    the round a steer is aimed at.
+    """
+
+    async def steer_round(
+        self,
+        content: str,
+        *,
+        steer_id: str | None = None,
+        expected_round_id: int | None = None,
+    ) -> bool:
+        """Inject text into the in-flight round, or report there was none.
+
+        Distinct from ``send(content, immediate=True)`` in exactly one way, and
+        that way is the whole reason this exists: ``send`` starts a round when
+        idle, turning a correction aimed at a finished round into a turn nobody
+        asked for. This refuses instead.
+
+        Also distinct from the CLI runtimes' pre-existing ``steer``, which is
+        declared ``-> None`` and *buffers* when no turn is in flight -- the same
+        silent promotion, one layer down. The names differ so that a runtime
+        cannot satisfy this contract by accident.
+
+        Args:
+            content: Steering text.
+            steer_id: Correlation id surfaced in ``STEER_APPLIED``, so a client
+                can tell which of its steers a rail dropped.
+            expected_round_id: Refuse unless that specific round is running.
+                A live round is not the invariant a caller cares about -- *which*
+                round is.
+
+        Returns:
+            True when the text was queued against the intended live round.
+        """
+        ...
+
+
+__all__ = ["MemberRuntime", "SupportsRoundSteering"]

--- a/openjiuwen/agent_teams/agent/team_agent.py
+++ b/openjiuwen/agent_teams/agent/team_agent.py
@@ -518,10 +518,48 @@ class TeamAgent(BaseAgent):
                 exc,
             )
 
-    async def steer(self, content: str) -> None:
+    async def steer(
+        self,
+        content: str,
+        *,
+        steer_id: str | None = None,
+        expected_round_id: int | None = None,
+    ) -> bool:
+        """Inject text into this agent's running round.
+
+        Goes through the runtime's ``steer_round`` rather than
+        ``send(immediate=True)`` because ``send`` starts a round when idle, which
+        turns a correction for a finished round into a new one.
+
+        The capability is checked rather than assumed, and the reason is
+        concrete: the default runtime is a ``TeamHarness``, CLI members carry an
+        ``ExternalCliRuntime``, and only the former can scope an injection to a
+        round. Assuming the method is how this path came to raise
+        ``AttributeError`` for every real team while its tests -- which built the
+        runtime surface out of mocks -- stayed green.
+
+        Returns:
+            True when the text was queued against the intended live round.
+
+        Raises:
+            NotImplementedError: when this agent's runtime has no round-scoped
+                steering. A caller must distinguish that from "nothing was
+                running", because they mean different things to a user.
+        """
+        # Imported here rather than at module scope: member_runtime is only a
+        # TYPE_CHECKING import above, and this check needs the class at runtime.
+        from openjiuwen.agent_teams.agent.member_runtime import SupportsRoundSteering
+
         harness = self.harness
-        if harness is not None:
-            await harness.send(content, immediate=True)
+        if harness is None:
+            return False
+        if not isinstance(harness, SupportsRoundSteering):
+            raise NotImplementedError(
+                f"{type(harness).__name__} has no round-scoped steering"
+            )
+        return await harness.steer_round(
+            content, steer_id=steer_id, expected_round_id=expected_round_id
+        )
 
     async def resume_interrupt(self, user_input) -> None:
         if not self._stream_controller.is_valid_interrupt_resume(user_input):

--- a/openjiuwen/agent_teams/harness/control.py
+++ b/openjiuwen/agent_teams/harness/control.py
@@ -104,8 +104,46 @@ class _CmdResume:
     query: str | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class _CmdSteer:
+    """A steer() invocation reaching the supervisor.
+
+    Distinct from ``_CmdSend`` with ``immediate=True`` because the two want
+    opposite things from an idle harness. ``send`` starts a round; steering has
+    no meaning without a round already running and must say so instead.
+
+    The phase can only be read safely here. A caller that checks
+    ``active_round`` and then calls ``send`` has an await between the two, and
+    the round it saw may have finished by the time the supervisor acts on the
+    message -- turning a correction for a finished round into a brand new one.
+
+    Attributes:
+        content: Steering text to inject into the running round.
+        ack: Future resolved True when the text was pushed into the active
+            round's steering queue, False when there was no round to steer.
+        steer_id: Correlation id for the request that produced this steer.
+            Carried so ``STEER_APPLIED`` can name which steer a rail dropped;
+            its ``dropped`` list is built from these ids and skips ``None``, so
+            without one a dropped steer is silently reported as applied.
+        expected_round_id: The round the caller believed was running. Present
+            because "a round is running" is not the invariant that matters --
+            *which* round is. ``_CmdRoundFinished`` shares this control queue and
+            ``_on_round_done`` can start the next round synchronously (follow-up
+            drain, abnormal-death replay, task-plan continuation), so a steer
+            dequeued behind one would find a live round that the user never saw
+            and inject the correction into it. ``None`` means the caller does not
+            care which round receives it.
+    """
+
+    content: str
+    ack: asyncio.Future
+    steer_id: str | None = None
+    expected_round_id: int | None = None
+
+
 ControlEvent = Union[
     _CmdSend,
+    _CmdSteer,
     _CmdAbort,
     _CmdPause,
     _CmdResume,

--- a/openjiuwen/agent_teams/harness/native_harness.py
+++ b/openjiuwen/agent_teams/harness/native_harness.py
@@ -61,12 +61,14 @@ from openjiuwen.core.single_agent.rail.base import (
 )
 from openjiuwen.harness.deep_agent import DeepAgent
 from openjiuwen.harness.schema.state import DeepAgentState
+from openjiuwen.harness.task_loop.loop_queues import SteeringInput
 from openjiuwen.agent_teams.harness.control import (
     _CmdAbort,
     _CmdPause,
     _CmdResume,
     _CmdRoundFinished,
     _CmdSend,
+    _CmdSteer,
     _CmdStop,
 )
 from openjiuwen.agent_teams.harness.async_tools import AsyncToolRuntime
@@ -542,6 +544,52 @@ class NativeHarness(DeepAgent):
         await self._control.put(_CmdSend(msg=msg, ack=ack))
         return await ack
 
+    async def steer(
+        self,
+        content: str,
+        *,
+        steer_id: str | None = None,
+        expected_round_id: int | None = None,
+    ) -> bool:
+        """Inject text into the round that is running, or report there is none.
+
+        The difference from ``send(content, immediate=True)`` is what happens
+        when nothing is running. ``send`` starts a round -- correct for a new
+        message, wrong for a correction aimed at a round that has since
+        finished, which would silently become a turn the user never asked for.
+        This refuses instead.
+
+        Checking ``active_round`` before calling ``send`` cannot achieve the
+        same thing: the check and the supervisor's decision are separated by at
+        least one await, and the round can finish in between. Here the phase is
+        read by the supervisor itself, in the same step that queues the text, so
+        there is no window between deciding and acting.
+
+        Args:
+            content: Steering text.
+            steer_id: Correlation id, surfaced in ``STEER_APPLIED`` so a client
+                can tell which of its steers a rail dropped. Without it the
+                event's ``dropped`` list is always empty.
+            expected_round_id: Refuse unless *this* round is the one running.
+                Omit to accept whichever round is live.
+
+        Returns:
+            True when the text was pushed into the active round's steering
+            queue; False when no round was running, or a different one was, and
+            nothing was queued.
+        """
+        self._require_alive()
+        ack: asyncio.Future = asyncio.get_running_loop().create_future()
+        await self._control.put(
+            _CmdSteer(
+                content=content,
+                ack=ack,
+                steer_id=steer_id,
+                expected_round_id=expected_round_id,
+            )
+        )
+        return await ack
+
     async def abort(self, *, immediate: bool = False) -> None:
         """Abort the current round; the harness settles to IDLE.
 
@@ -747,6 +795,8 @@ class NativeHarness(DeepAgent):
         """Route a non-Stop control event to its handler."""
         if isinstance(cmd, _CmdSend):
             await self._on_send(cmd)
+        elif isinstance(cmd, _CmdSteer):
+            await self._on_steer(cmd)
         elif isinstance(cmd, _CmdAbort):
             await self._on_abort(cmd)
         elif isinstance(cmd, _CmdPause):
@@ -843,6 +893,44 @@ class NativeHarness(DeepAgent):
             await self._transition(HarnessState.RUNNING)
             await self._emit_round("started", active.round_id)
         self._ack(cmd.ack, seq)
+
+    async def _on_steer(self, cmd: _CmdSteer) -> None:
+        """Push steering into the active round, or refuse when there is none.
+
+        Only RUNNING with a live round qualifies. Every other phase is a
+        refusal rather than a fallback:
+
+        - **IDLE**: nothing to steer. ``send`` would start a round here.
+        - **PAUSED**: ``send`` resumes the paused round and injects the text,
+          which is a resume the caller did not ask for. Steering does not wake
+          a harness up.
+        - **PAUSING**: the round is on its way out at the next boundary, so text
+          injected now may never be read. Refusing is honest; queueing is not.
+        - **TERMINATED**: ``_require_alive`` in ``steer`` already rejected it.
+
+        A live round is necessary but not sufficient. ``_CmdRoundFinished``
+        shares this queue and ``_on_round_done`` can start the *next* round
+        synchronously, so a steer dequeued behind one would land in a round the
+        caller never saw. When the caller named a round, only that round counts.
+        """
+        phase = self._st.phase
+        active = self._st.active
+        if phase is not HarnessState.RUNNING or active is None:
+            self._ack(cmd.ack, False)
+            return
+        if (
+            cmd.expected_round_id is not None
+            and active.round_id != cmd.expected_round_id
+        ):
+            logger.info(
+                "[NativeHarness] steer refused: round %s ended, %s is running now",
+                cmd.expected_round_id,
+                active.round_id,
+            )
+            self._ack(cmd.ack, False)
+            return
+        self._push_steer(SteeringInput(text=cmd.content, id=cmd.steer_id))
+        self._ack(cmd.ack, True)
 
     async def _on_abort(self, cmd: _CmdAbort) -> None:
         """Abort the current round; the harness settles to IDLE either way.
@@ -1399,8 +1487,13 @@ class NativeHarness(DeepAgent):
     # Task-loop bridge helpers
     # ------------------------------------------------------------------
 
-    def _push_steer(self, content: str) -> None:
-        """Push a steering message into the shared steering queue."""
+    def _push_steer(self, content: "str | SteeringInput") -> None:
+        """Push a steering message into the shared steering queue.
+
+        Accepts a bare string as well, because ``_on_send`` still pushes raw
+        content for ``send(immediate=True)`` -- that path has no request id to
+        carry, and ``push_steer`` coerces either form.
+        """
         handler = self.event_handler
         if handler is not None and handler.interaction_queues is not None:
             handler.interaction_queues.push_steer(content)
@@ -1482,6 +1575,40 @@ class NativeHarness(DeepAgent):
             logger.exception("[NativeHarness] output forwarder crashed")
         finally:
             await self._st.output_queue.put(_END)
+
+    def _emit_interaction_event(self, event: "InteractionEvent") -> None:
+        """Put an interaction event on *this* harness's output stream.
+
+        DeepAgent emits these through ``_interaction_output``, the lease the
+        interaction loop hands to ``attach_output``. A Team never attaches that
+        lease -- its consumer reads ``_st.output_queue`` -- so inherited emits
+        found ``current_token() is None`` and were dropped without a trace. The
+        sink was bound, the event was built, and nothing ever came out.
+
+        That is why ``steer.applied`` never reached a Team client: not a missing
+        binding, a stream nobody was listening to.
+
+        Synchronous by contract, because rails and the inner agent call it from
+        hooks that cannot await -- hence ``put_nowait``. The queue is unbounded,
+        so it cannot raise ``QueueFull``, and going through a tracked
+        ``create_task`` instead would have been a comfortable-looking lie:
+        ``NativeHarness.stop`` overrides ``DeepAgent.stop`` without calling
+        ``super()``, so the parent's cancel loop over ``_interaction_emit_tasks``
+        never runs for a Team and nothing would have cancelled those tasks.
+
+        Also note what this override changes for the events DeepAgent emits
+        through the same seam (``goal.updated``, ``execution.error``): they would
+        land here too. Harmless today because those emit sites live on the
+        interaction loop, which a NativeHarness never runs -- but if that stops
+        being true, this is where they arrive.
+        """
+        queue = self._st.output_queue
+        if queue is None:
+            return
+        try:
+            queue.put_nowait(event.to_output_schema())
+        except Exception:  # noqa: BLE001 - observability must not break a round
+            logger.exception("[NativeHarness] interaction event emit failed")
 
     async def _emit_round_aborted(self, round_id: int, kind: str) -> None:
         """Emit a marker chunk so consumers know prior chunks of this round are void.

--- a/openjiuwen/agent_teams/harness/team_harness.py
+++ b/openjiuwen/agent_teams/harness/team_harness.py
@@ -288,6 +288,37 @@ class TeamHarness:
             )
         return await self._native.send(content, immediate=immediate)
 
+    @property
+    def active_round(self) -> Any:
+        """Return the native's in-flight round, or None when no cycle is live."""
+        return self._native.active_round if self._is_cycle_active() else None
+
+    async def steer_round(
+        self,
+        content: str,
+        *,
+        steer_id: str | None = None,
+        expected_round_id: int | None = None,
+    ) -> bool:
+        """Inject text into the in-flight round; False when there is none.
+
+        Named apart from the CLI runtimes' ``steer`` deliberately. That one is
+        declared ``-> None`` and *buffers* when no turn is in flight, which is
+        the silent promotion this method exists to refuse: a buffered steer
+        becomes the next turn's input and the caller is told nothing. Reusing the
+        name would have made a CLI-backed leader satisfy the type and violate the
+        contract.
+
+        Returns False rather than raising when no run cycle is live, matching
+        ``abort`` and ``pause``: steering a team that is not running is a
+        harmless impossibility, not a programming error.
+        """
+        if not self._is_cycle_active():
+            return False
+        return await self._native.steer(
+            content, steer_id=steer_id, expected_round_id=expected_round_id
+        )
+
     async def abort(self, *, immediate: bool = False) -> None:
         """Abort the active round: graceful (False) or hard+rollback (True).
 

--- a/openjiuwen/agent_teams/runtime/manager.py
+++ b/openjiuwen/agent_teams/runtime/manager.py
@@ -445,6 +445,94 @@ class TeamRuntimeManager:
         finally:
             await entry.interact_gate.consume_done(ticket)
 
+    async def steer_leader(
+        self,
+        content: str,
+        *,
+        team_name: str,
+        session_id: str,
+        steer_id: str | None = None,
+    ) -> DeliverResult:
+        """Steer the leader's in-flight round, or say why it could not.
+
+        Deliberately not a variant of :meth:`interact`. Interact routes a
+        payload to whichever channel its prefix names — leader, an avatar, a
+        broadcast — and starts a round when the team is idle. Steering does
+        neither: it is text for a round already running, and with no such round
+        there is nothing to steer.
+
+        That distinction is the reason for a separate entry point. Folding
+        steering into interact would silently turn a stale steer into a new
+        leader round, which is exactly the behaviour the single-agent path was
+        changed to stop doing.
+
+        Args:
+            content: Steering text.
+            team_name: Team whose leader to steer.
+            session_id: Session the steer belongs to.
+            steer_id: Correlation id, surfaced in ``STEER_APPLIED`` so a client
+                can tell which of its steers a rail dropped.
+
+        Returns:
+            ``DeliverResult.success(None)`` when the text was handed to the
+            leader — no message id, since steering writes no bus message.
+            ``failure("not_active")`` when no runtime matches,
+            ``failure("no_active_round")`` when the leader is idle or its round
+            ended in flight, ``failure("gate_closed")`` while the runtime is
+            shutting down, and ``failure("unsupported_runtime")`` when the
+            leader's runtime cannot scope an injection to a round (a CLI-backed
+            member, for instance).
+        """
+        entry = await self._resolve_entry(team_name=team_name, session_id=session_id)
+        if entry is None:
+            return DeliverResult.failure("not_active")
+
+        # A fast path only, not the guarantee. It saves taking a ticket for a
+        # leader that is plainly idle, but it cannot be the check that matters:
+        # `admit` and the control-queue hop are await points, and the round can
+        # finish inside them. The authority is the harness's own answer below,
+        # which reads the phase in the same step that queues the text.
+        #
+        # Asked through the agent rather than by reaching for `harness.active_round`
+        # directly: `has_in_flight_round` is the surface every runtime flavour
+        # implements, and reading a NativeHarness-only attribute here is what made
+        # this method raise AttributeError for every real team, whose runtime is a
+        # TeamHarness.
+        if not entry.agent.has_in_flight_round():
+            return DeliverResult.failure("no_active_round")
+
+        # Name the round the caller meant. A live round is not enough -- the
+        # supervisor can start the next one synchronously while this steer is in
+        # the control queue, and injecting into a round the user never saw is
+        # worse than refusing.
+        harness = getattr(entry.agent, "harness", None)
+        active = getattr(harness, "active_round", None)
+        expected_round_id = getattr(active, "round_id", None)
+
+        ticket = await entry.interact_gate.admit()
+        if ticket is None:
+            return DeliverResult.failure("gate_closed")
+        try:
+            steered = await entry.agent.steer(
+                content, steer_id=steer_id, expected_round_id=expected_round_id
+            )
+        except NotImplementedError:
+            # Reported apart from "nothing was running" on purpose: the two look
+            # the same to this method and mean opposite things to a user -- one
+            # says "you were too late", the other "this leader can never take a
+            # steer". Collapsing them sends people looking for a race that is not
+            # there.
+            return DeliverResult.failure("unsupported_runtime")
+        finally:
+            await entry.interact_gate.consume_done(ticket)
+        if not steered:
+            # The round ended, or was replaced, while this steer was in flight.
+            # Reported as the same rejection an idle leader gets, because that is
+            # what happened -- and reporting success here would claim a finished
+            # round had taken the correction.
+            return DeliverResult.failure("no_active_round")
+        return DeliverResult.success(None)
+
     @staticmethod
     def _as_swarmflow_human_reply(
         payloads: list[InteractPayload],

--- a/openjiuwen/core/runner/team_runner.py
+++ b/openjiuwen/core/runner/team_runner.py
@@ -444,6 +444,41 @@ class _TeamRunnerMixin:
                 session_id=session_id,
             )
 
+    async def steer_agent_team(
+        self,
+        content: str,
+        *,
+        team_name: Optional[str] = None,
+        session_id: Optional[str] = None,
+        steer_id: Optional[str] = None,
+    ):
+        """Steer the leader's in-flight round on an active TeamAgent runtime.
+
+        Text-only, and separate from :meth:`interact_agent_team` on purpose:
+        interact starts a leader round when the team is idle, while steering
+        has to report that there was nothing to steer instead.
+
+        ``steer_id`` is the caller's request id. It rides through to
+        ``STEER_APPLIED`` so a client can tell which of its steers a rail
+        dropped; omit it and that event's ``dropped`` list is always empty.
+
+        Returns a ``DeliverResult``. Missing ``team_name`` or ``session_id``
+        returns ``DeliverResult.failure("missing_target")``; the runtime layer
+        adds ``not_active``, ``no_active_round``, ``gate_closed`` and
+        ``unsupported_runtime``.
+        """
+        from openjiuwen.agent_teams.interaction.payload import DeliverResult
+
+        if team_name is None or session_id is None:
+            return DeliverResult.failure("missing_target")
+        with self._bind_interact_team_session(session_id):
+            return await self._get_team_runtime_manager().steer_leader(
+                content,
+                team_name=team_name,
+                session_id=session_id,
+                steer_id=steer_id,
+            )
+
     async def register_human_agent_inbound(
         self,
         *,
@@ -994,6 +1029,23 @@ class _TeamRunnerClassMixin:
             payload,
             team_name=team_name,
             session_id=session_id,
+        )
+
+    @classmethod
+    async def steer_agent_team(
+        cls,
+        content: str,
+        *,
+        team_name: Optional[str] = None,
+        session_id: Optional[str] = None,
+        steer_id: Optional[str] = None,
+    ):
+        """Steer the leader's in-flight round on an active TeamAgent runtime."""
+        return await _global_runner().steer_agent_team(
+            content,
+            team_name=team_name,
+            session_id=session_id,
+            steer_id=steer_id,
         )
 
     @classmethod

--- a/openjiuwen/core/single_agent/agents/react_agent.py
+++ b/openjiuwen/core/single_agent/agents/react_agent.py
@@ -16,7 +16,17 @@ import inspect
 import json
 import time
 from dataclasses import dataclass
-from typing import Any, AsyncIterator, Dict, Iterable, List, Optional, Tuple, Union
+from typing import (
+    Any,
+    AsyncIterator,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
 from pydantic import Field, BaseModel
 
@@ -649,6 +659,18 @@ class ReActAgent(BaseAgent):
         """
         self._llm = llm
 
+    def set_steering_applied_sink(
+        self,
+        sink: Optional[Callable[[List[Dict[str, Any]], List[str]], None]],
+    ) -> None:
+        """Register a callback for steers that reached (or missed) model context.
+
+        Hosts that wrap this agent (for example DeepAgent) bind a sink so they
+        can emit interaction events. Pass ``None`` to clear. Embedders that
+        never set one see no reporting and no behavioural change.
+        """
+        self._steering_applied_sink = sink
+
     def _get_llm(self) -> Model:
         """Get LLM instance (lazy initialization)
 
@@ -737,8 +759,12 @@ class ReActAgent(BaseAgent):
             *,
             source: str,
             prefix: str = "",
-    ) -> None:
+    ) -> List[str]:
         """Join one batch of consumed inputs into the conversation, rails first.
+
+        Returns the parts that were actually admitted, post-rail and in final
+        order -- empty when a rail dropped everything. Callers that only need
+        the side effect can ignore it.
 
         Every input the agent consumes -- a new round's query, the follow-ups
         that queued up while it was busy, a batch of steering messages, a
@@ -767,12 +793,57 @@ class ReActAgent(BaseAgent):
         finally:
             ctx.inputs = previous_inputs
         if not parts:
-            return
+            return []
         body = "\n".join(parts)
         await context.add_messages(UserMessage(content=f"{prefix}{body}"))
+        # Rails mutate ``parts`` in place, so this is the post-rail list in
+        # final order -- what actually reached model context. Returned so a
+        # caller can report it; nothing here depends on the value.
+        return list(parts)
 
-    async def _drain_steering_batch(self, ctx: AgentCallbackContext) -> List[str]:
-        """Take the share of the steering backlog this model call absorbs.
+    def _report_steering_applied(
+            self,
+            drained: List[Any],
+            admitted: List[str],
+    ) -> None:
+        """Tell the host which steers reached model context, and which did not.
+
+        The sink takes plain data rather than a harness event type on purpose.
+        ``core`` should not learn what an interaction event is -- that concept
+        belongs to the loop wrapping this one -- so the seam carries primitives
+        and the wrapper builds the event. Defaulted to ``None``, so an embedder
+        that never sets it sees byte-identical behaviour.
+
+        Correlation is by text, matching each admitted string back to the first
+        unclaimed input that carried it. Rails receive the batch as a list of
+        strings and may reorder or drop entries, so identity is not preserved
+        across admission; matching on content is what survives. Two steers with
+        the same text resolve in queue order, which is the only order anyone
+        could mean.
+        """
+        sink = getattr(self, "_steering_applied_sink", None)
+        if sink is None:
+            return
+        remaining = list(drained)
+        applied: List[Dict[str, Any]] = []
+        for text in admitted:
+            for index, item in enumerate(remaining):
+                if item.text == text:
+                    applied.append({"id": item.id, "text": text})
+                    remaining.pop(index)
+                    break
+            else:
+                # A rail synthesised text that no input carried. Report it, so
+                # the transcript matches the model's view, with no id to claim.
+                applied.append({"id": None, "text": text})
+        dropped = [item.id for item in remaining if item.id is not None]
+        try:
+            sink(applied, dropped)
+        except Exception:  # noqa: BLE001 - observability must not break a turn
+            logger.exception("steering applied sink failed")
+
+    async def _drain_steering_batch(self, ctx: AgentCallbackContext) -> List[Any]:
+        """Take the share of the steering queue this model call absorbs.
 
         Everything queued used to go into one message. That is right when a
         couple of instructions piled up, and wrong when a member comes back to
@@ -790,8 +861,8 @@ class ReActAgent(BaseAgent):
             ctx: Callback context; carries the bound queue and the rails.
 
         Returns:
-            The messages to admit now, oldest first; empty when nothing is
-            queued, which also means no event was fired.
+            ``SteeringInput`` envelopes to admit now, oldest first; empty when
+            nothing is queued, which also means no event was fired.
         """
         queue = ctx.steering_queue
         if queue is None or queue.empty():
@@ -2020,13 +2091,14 @@ class ReActAgent(BaseAgent):
                         # before the next model call.
                         steering = await self._drain_steering_batch(ctx)
                         if steering:
-                            await self._admit_user_message(
+                            admitted = await self._admit_user_message(
                                 ctx,
                                 context,
-                                steering,
+                                [item.text for item in steering],
                                 source="steering",
                                 prefix="[STEERING] ",
                             )
+                            self._report_steering_applied(steering, admitted)
 
                         ai_message = await self._call_model(
                             ctx,

--- a/openjiuwen/core/single_agent/rail/base.py
+++ b/openjiuwen/core/single_agent/rail/base.py
@@ -287,7 +287,7 @@ class SteeringDrainInputs:
 
     Fired before each model call that has steering waiting, and *only* then —
     an empty queue skips the event entirely. It asks the rails one question:
-    how much of the backlog does this model call absorb? Whatever a rail does
+    how much of the queue does this model call absorb? Whatever a rail does
     not let through stays queued in order, and the loop keeps running while the
     queue is non-empty, so the rest arrives at the following model calls.
 
@@ -304,7 +304,7 @@ class SteeringDrainInputs:
             left, so the value standing at the end is the one that applies.
             A non-empty queue always yields at least one message regardless:
             consumption has to make progress or the loop would spin on a
-            backlog it refuses to touch.
+            queue it refuses to touch.
     """
     pending: int = 0
     limit: int | None = None
@@ -545,13 +545,13 @@ class AgentCallbackContext:
 
     def drain_steering(
         self, limit: int | None = None,
-    ) -> List[str]:
+    ) -> List["SteeringInput"]:
         """Drain pending steering messages, oldest first.
 
         What is not taken stays queued in order, so the next drain resumes
         where this one stopped. A non-empty queue always yields at least one
         message: consumption has to make progress, or ``has_pending_steering``
-        would keep the loop going over a backlog nothing ever consumes.
+        would keep the loop going over a queue nothing ever consumes.
 
         Args:
             limit: The most this call may take. ``None`` (the default) takes
@@ -559,19 +559,26 @@ class AgentCallbackContext:
                 policy on the matter.
 
         Returns:
-            List of steering message strings,
-            empty if no queue bound or queue empty.
+            The queued inputs, oldest first; empty if no queue is bound.
+
+        The queue has two producers writing two shapes. Hosts push through
+        ``LoopQueues.push_steer`` and may attach a request id; rails call
+        :meth:`push_steering` above, which writes a bare string straight into
+        the queue. Both are coerced here, so a reader never has to test which
+        form it received.
         """
+        from openjiuwen.harness.task_loop.loop_queues import SteeringInput
+
         if self._steering_queue is None:
             return []
         take = None if limit is None else max(1, limit)
-        msgs: List[str] = []
+        msgs: List[SteeringInput] = []
         while not self._steering_queue.empty():
             if take is not None and len(msgs) >= take:
                 break
             try:
                 msgs.append(
-                    self._steering_queue.get_nowait()
+                    SteeringInput.coerce(self._steering_queue.get_nowait())
                 )
             except asyncio.QueueEmpty:
                 break

--- a/openjiuwen/harness/deep_agent.py
+++ b/openjiuwen/harness/deep_agent.py
@@ -80,6 +80,7 @@ from openjiuwen.harness.task_loop.loop_coordinator import (
 )
 from openjiuwen.harness.task_loop.loop_queues import (
     LoopQueues,
+    SteeringInput,
 )
 from openjiuwen.harness.task_loop.task_loop_controller import (
     TaskLoopController,
@@ -102,9 +103,11 @@ from openjiuwen.harness.schema.interaction import (
     OutputLease,
     OutputLeaseManager,
     InputDispatchMode,
+    InputDisposition,
     RoundOutcome,
     RoundWorkItem,
     SendInputRequest,
+    SendInputResult,
 )
 from openjiuwen.harness.task_loop.event_manager import EventManager
 
@@ -369,6 +372,7 @@ class DeepAgent(BaseAgent):
             self.ability_manager.set_owner_id(self._resolve_tool_owner_id(config))
 
         self._react_agent = self._create_react_agent()
+        self._bind_steering_applied_sink()
         self._queue_pending_rails(config)
 
     def _hot_reconfigure(self, config: DeepAgentConfig) -> None:
@@ -525,7 +529,6 @@ class DeepAgent(BaseAgent):
             ))
         else:
             prompt_builder.add_section(build_identity_section(language))
-        prompt = prompt_builder.build()
         new_react_config = self._react_agent.config.model_copy()
         new_react_config.prompt_template = [
             {"role": "system", "content": _render_identity_prompt(prompt_builder, language)}
@@ -627,8 +630,37 @@ class DeepAgent(BaseAgent):
     ) -> "DeepAgent":
         """Inject an inner agent implementation for runtime wiring/tests."""
         self._react_agent = cast(ReActAgent, react_agent)
+        self._bind_steering_applied_sink()
         self._initialized = initialized
         return self
+
+    def _bind_steering_applied_sink(self) -> None:
+        """Let the inner agent report steering that reached model context.
+
+        This is the bridge between the two loops. The inner ReAct loop is the
+        only place that knows when steering text was admitted, post-rail; this
+        loop is the only one that can put an event on the active output stream.
+        Neither could do it alone, and the inner agent has no upward path of its
+        own.
+
+        The seam carries primitives -- a list of applied entries and a list of
+        dropped ids -- rather than an ``InteractionEvent``. ``core`` should not
+        learn a harness concept just to report something, so the event is built
+        here, at the layer that owns it.
+        """
+        agent = self._react_agent
+        if agent is None:
+            return
+
+        def _sink(applied: List[Dict[str, Any]], dropped: List[str]) -> None:
+            self._emit_interaction_event(
+                InteractionEvent.steer_applied(applied=applied, dropped=dropped)
+            )
+
+        # Real ReActAgent exposes the setter; harness test doubles often do not.
+        binder = getattr(agent, "set_steering_applied_sink", None)
+        if callable(binder):
+            binder(_sink)
 
     @property
     def is_initialized(self) -> bool:
@@ -3068,21 +3100,26 @@ class DeepAgent(BaseAgent):
                         self._notify_work()
                 return stream
 
-    async def send_input(self, request: SendInputRequest) -> None:
+    async def send_input(self, request: SendInputRequest) -> SendInputResult:
         """Dispatch user text or interrupt-resume input.
 
         Hosts that need to read output must call ``attach_output`` first (or
         already hold a stream).  Steer / follow-up requests typically skip
         attach and let the existing consumer receive output.  Dispatch modes
         do not apply to ``InteractiveInput`` recovery requests.
+
+        Returns what actually happened.  A steer that arrives with no active
+        round is reported as rejected rather than being downgraded to
+        follow-up or fresh-turn work, so the host can acknowledge it truthfully
+        instead of starting a turn the user did not ask for.
         """
         if not self._interaction_started or self._interaction_phase is InteractionPhase.TERMINATED:
             raise RuntimeError("interaction_terminated")
 
         async with self._interaction_send_lock:
-            await self._send_user(request)
+            return await self._send_user(request)
 
-    async def _send_user(self, request: SendInputRequest) -> None:
+    async def _send_user(self, request: SendInputRequest) -> SendInputResult:
         inputs = request.inputs
         if not isinstance(inputs, dict):
             raise ValueError(
@@ -3109,7 +3146,7 @@ class DeepAgent(BaseAgent):
                     )
                 )
                 self._notify_work()
-                return
+                return SendInputResult.queued(InputDisposition.RESUME_QUEUED)
 
             loop = self.loop_controller
             try:
@@ -3124,10 +3161,40 @@ class DeepAgent(BaseAgent):
             if mode is InputDispatchMode.STEER and self._active_interaction_round is not None:
                 if loop is None:
                     raise RuntimeError("active interaction round cannot accept steer without loop_controller")
-                loop.enqueue_steer(str(inputs["query"]))
+                expected = (request.expected_round_id or "").strip()
+                if expected:
+                    active_round_id = self._active_interaction_round.work.request_id
+                    if not active_round_id or expected != active_round_id:
+                        return SendInputResult.rejected("round_mismatch")
+                # Carry the request id into the queue. Without it every
+                # SteeringInput.id is None, and since ``dropped`` is built from
+                # those ids it comes out empty every single time -- a steer
+                # removed by a rail would be reported as applied. The id is what
+                # lets a client match STEER_APPLIED back to the ACK it received.
+                loop.enqueue_steer(
+                    SteeringInput(text=str(inputs["query"]), id=request.request_id)
+                )
                 self._notify_work()
-                return
+                return SendInputResult.queued(InputDisposition.STEER_QUEUED)
 
+            # A client that bound the steer to a specific round id has already
+            # lost that round when we get here. Do not promote it to a Goal
+            # follow-up: that turns an end-of-turn race into silent success.
+            if mode is InputDispatchMode.STEER:
+                expected = (request.expected_round_id or "").strip()
+                if expected:
+                    return SendInputResult.rejected("round_mismatch")
+
+            # A steer with no active round is NOT automatically invalid, and it
+            # must not short-circuit here.  While a Goal is ACTIVE the Web sends
+            # ordinary input as ``input_mode="steer"`` so it lands as a
+            # supplementary constraint on the running Goal rather than
+            # overwriting it, and between attempts there is legitimately no
+            # active round.  Falling through keeps that working, and it is the
+            # only path that runs ``_should_keep_interaction_open_locked()``,
+            # whose intentional side effect queues the Goal's next attempt.
+            # Returning above would drop the message *and* stall the Goal.
+            # (Only unbound steers reach this path: see expected_round_id above.)
             keep_open = self._should_keep_interaction_open_locked()
             if keep_open:
                 self._event_manager.push_user(
@@ -3139,7 +3206,15 @@ class DeepAgent(BaseAgent):
                     )
                 )
                 self._notify_work()
-                return
+                return SendInputResult.queued(InputDisposition.FOLLOW_UP_QUEUED)
+
+            if mode is InputDispatchMode.STEER:
+                # Reached only when there is no active round *and* nothing keeps
+                # the interaction open: genuinely nothing to steer.  This is the
+                # case the contract exists for -- previously it fell into the
+                # fresh-turn path below and started a whole turn the user never
+                # asked for, indistinguishable from success at the wire.
+                return SendInputResult.rejected("no_active_round")
 
             # Fresh user turn.  Output lease ownership stays with the host via
             # ``attach_output``; send_input never steals or creates a stream.
@@ -3147,6 +3222,7 @@ class DeepAgent(BaseAgent):
                 RoundWorkItem.user(request_id=request.request_id, inputs=inputs)
             )
             self._notify_work()
+            return SendInputResult.queued(InputDisposition.TURN_QUEUED)
 
     async def _attach_output_locked(self) -> Optional[InteractionOutputStream]:
         lease = await self._interaction_output.attach()
@@ -3455,9 +3531,37 @@ class DeepAgent(BaseAgent):
                 emitted = await self._emit_round_boundary(session)
                 if not emitted:
                     forwarded.set()
+            # Drop leftovers before clearing the active round marker. The
+            # steering queue is session-scoped; anything still sitting here
+            # would otherwise be drained into the *next* round as if it were
+            # aimed at that turn.
+            self._drop_undrained_steering()
             self._active_interaction_round = None
             if self._interaction_phase is InteractionPhase.RUNNING:
                 self._interaction_phase = InteractionPhase.IDLE
+
+    def _drop_undrained_steering(self) -> None:
+        """Report and clear steers that never reached a model-call boundary.
+
+        Emits ``steer.applied`` with an empty ``applied`` list so hosts can
+        mark ACK'd bubbles as not delivered, matching the rail-drop path.
+        """
+        loop = self.loop_controller
+        if loop is None:
+            return
+        get_queues = getattr(loop, "_get_interaction_queues", None)
+        if get_queues is None:
+            return
+        queues = get_queues()
+        if queues is None:
+            return
+        leftover = queues.drain_steering()
+        if not leftover:
+            return
+        dropped = [item.id for item in leftover if item.id is not None]
+        self._emit_interaction_event(
+            InteractionEvent.steer_applied(applied=[], dropped=dropped)
+        )
 
     def _load_goal_record_locked(self) -> Optional[GoalRecord]:
         if self.goal_manager is None:

--- a/openjiuwen/harness/schema/interaction.py
+++ b/openjiuwen/harness/schema/interaction.py
@@ -15,7 +15,7 @@ import uuid
 from dataclasses import dataclass, field
 from enum import Enum
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any, Dict, Literal, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional
 
 from openjiuwen.core.session.stream import OutputSchema
 
@@ -49,11 +49,59 @@ class SendInputRequest:
     conversation id and trusted directories) travels with the work item.
     The query may also be an ``InteractiveInput`` for interrupt recovery;
     ``mode`` applies only to user text.
+
+    ``expected_round_id`` is an optional precondition for steer: when set it
+    must match ``ActiveInteractionRound.work.request_id`` or the steer is
+    rejected as ``round_mismatch`` instead of landing on a different turn.
     """
 
     request_id: str
     inputs: Dict[str, object]
     mode: Optional[InputDispatchMode] = None
+    expected_round_id: Optional[str] = None
+
+
+class InputDisposition(str, Enum):
+    """What ``send_input`` actually did with the request.
+
+    Named separately from :class:`InputDispatchMode` because the mode is what
+    the caller *asked for* and the disposition is what *happened*.  A steer may
+    legitimately end as ``REJECTED``; before this contract existed it silently
+    became a follow-up or a fresh turn instead, which is the failure this type
+    exists to make impossible.
+    """
+
+    STEER_QUEUED = "steer_queued"
+    FOLLOW_UP_QUEUED = "follow_up_queued"
+    TURN_QUEUED = "turn_queued"
+    RESUME_QUEUED = "resume_queued"
+    REJECTED = "rejected"
+
+
+@dataclass(frozen=True)
+class SendInputResult:
+    """Outcome of one ``send_input`` call.
+
+    ``accepted`` is the only field a host must read.  ``reason`` is set only
+    when ``accepted`` is false and is a stable machine token
+    (``no_active_round``, ``round_mismatch``) -- not a message for humans.
+    """
+
+    accepted: bool
+    disposition: InputDisposition
+    reason: Optional[str] = None
+
+    @classmethod
+    def queued(cls, disposition: InputDisposition) -> "SendInputResult":
+        return cls(accepted=True, disposition=disposition)
+
+    @classmethod
+    def rejected(cls, reason: str) -> "SendInputResult":
+        return cls(
+            accepted=False,
+            disposition=InputDisposition.REJECTED,
+            reason=reason,
+        )
 
 
 @dataclass(frozen=True)
@@ -145,6 +193,7 @@ class InteractionEventType(str, Enum):
 
     GOAL_UPDATED = "goal.updated"
     EXECUTION_ERROR = "execution.error"
+    STEER_APPLIED = "steer.applied"
 
 
 @dataclass(frozen=True)
@@ -176,6 +225,35 @@ class InteractionEvent:
         if goal is not None:
             payload["goal"] = copy.deepcopy(goal)
         return cls(type=InteractionEventType.EXECUTION_ERROR, payload=payload)
+
+    @classmethod
+    def steer_applied(
+        cls,
+        *,
+        applied: List[Dict[str, object]],
+        dropped: List[str],
+    ) -> InteractionEvent:
+        """Steering text reached model context.
+
+        Distinct from the host's acknowledgement, which only says the text was
+        queued. This is the other half a client needs to tell a slow model from
+        a dropped instruction.
+
+        Emitted once per admitted batch, after admission, because that is when
+        the content is final: several steers drain together and are joined into
+        one message, and rails may drop or reorder them on the way in.
+
+        ``dropped`` carries the ids a rail removed. Without it a client cannot
+        distinguish "still working on it" from "a rail discarded it", and the
+        bubble stays pending forever.
+        """
+        return cls(
+            type=InteractionEventType.STEER_APPLIED,
+            payload={
+                "applied": copy.deepcopy(applied),
+                "dropped": list(dropped),
+            },
+        )
 
 
 @dataclass(frozen=True)

--- a/openjiuwen/harness/task_loop/loop_queues.py
+++ b/openjiuwen/harness/task_loop/loop_queues.py
@@ -14,7 +14,29 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Optional
+
+
+@dataclass(frozen=True)
+class SteeringInput:
+    """One queued steering message, optionally carrying its request id.
+
+    The id exists so a host can tell the client *which* steer reached the model,
+    which a queue of bare strings cannot express: several steers are drained
+    together and joined into one message, and rails may drop some of them along
+    the way.
+
+    ``id`` is optional because not every steer comes from a client request --
+    rails steer on their own and have nothing to correlate.
+    """
+
+    text: str
+    id: Optional[str] = None
+
+    @classmethod
+    def coerce(cls, msg: "str | SteeringInput") -> "SteeringInput":
+        """Accept either form, so existing callers keep working unchanged."""
+        return msg if isinstance(msg, cls) else cls(text=str(msg))
 
 
 @dataclass
@@ -35,13 +57,15 @@ class LoopQueues:
         default_factory=asyncio.Queue
     )
 
-    def push_steer(self, msg: str) -> None:
+    def push_steer(self, msg: "str | SteeringInput") -> None:
         """Push a steering message.
 
         Args:
-            msg: Steering instruction text.
+            msg: Steering text, or a :class:`SteeringInput` when the caller has
+                an id to correlate an acknowledgement with. Coerced on push, so
+                readers never have to test which form arrived.
         """
-        self.steering.put_nowait(msg)
+        self.steering.put_nowait(SteeringInput.coerce(msg))
 
     def push_follow_up(self, msg: str) -> None:
         """Push a follow-up message.
@@ -55,16 +79,17 @@ class LoopQueues:
         """Return whether follow-up messages are pending."""
         return not self.follow_up.empty()
 
-    def drain_steering(self) -> List[str]:
+    def drain_steering(self) -> List[SteeringInput]:
         """Drain all pending steering messages.
 
         Returns:
-            List of steering message strings.
+            The queued inputs, oldest first. Always ``SteeringInput`` — the
+            queue coerces on push.
         """
-        msgs: List[str] = []
+        msgs: List[SteeringInput] = []
         while not self.steering.empty():
             try:
-                msgs.append(self.steering.get_nowait())
+                msgs.append(SteeringInput.coerce(self.steering.get_nowait()))
             except asyncio.QueueEmpty:
                 break
         return msgs

--- a/openjiuwen/harness/task_loop/task_loop_controller.py
+++ b/openjiuwen/harness/task_loop/task_loop_controller.py
@@ -15,6 +15,7 @@ from openjiuwen.core.controller.schema.event import InputEvent
 from openjiuwen.core.session.agent import Session
 from openjiuwen.harness.task_loop.loop_queues import (
     LoopQueues,
+    SteeringInput,
 )
 
 
@@ -136,12 +137,19 @@ class TaskLoopController(Controller):
         if queues is not None:
             queues.push_follow_up(msg)
 
-    def enqueue_steer(self, msg: str) -> None:
+    def enqueue_steer(self, msg: "str | SteeringInput") -> None:
         """Push a steering message into the current round's steering queue.
 
         The inner ReAct loop drains this queue before each model call,
         allowing real-time guidance without interrupting the current round.
         Used when a user sends a message while a goal round is running.
+
+        Args:
+            msg: Steering text, or a :class:`SteeringInput` when the caller has
+                a request id to correlate the acknowledgement with. Passing bare
+                text is still valid -- a rail steering on its own has nothing to
+                correlate -- but it leaves the entry unidentifiable, which means
+                it can never appear in ``STEER_APPLIED``'s ``dropped`` list.
         """
         queues = self._get_interaction_queues()
         if queues is not None:

--- a/tests/unit_tests/agent_teams/harness/fixtures.py
+++ b/tests/unit_tests/agent_teams/harness/fixtures.py
@@ -61,6 +61,7 @@ from openjiuwen.core.single_agent.rail.base import (
 from openjiuwen.core.single_agent.schema.agent_card import AgentCard
 from openjiuwen.harness.deep_agent import DeepAgent
 from openjiuwen.harness.schema.config import DeepAgentConfig
+from openjiuwen.harness.task_loop.loop_queues import SteeringInput
 
 
 class MockContext:
@@ -211,7 +212,13 @@ class FakeReactAgent:
             steering_q = inputs.get("_steering_queue")
             if steering_q is not None:
                 while not steering_q.empty():
-                    self.seen_steers.append(steering_q.get_nowait())
+                    # The queue carries SteeringInput envelopes now. Record the
+                    # text, so seen_steers stays the list of strings its readers
+                    # expect; the id is covered in
+                    # tests/unit_tests/harness/test_steering_applied.py.
+                    self.seen_steers.append(
+                        SteeringInput.coerce(steering_q.get_nowait()).text
+                    )
             resume_continuation = bool(inputs.get("_resume_continuation"))
 
         context = self.context_engine.get_context(session_id=session.get_session_id())

--- a/tests/unit_tests/agent_teams/harness/test_steer.py
+++ b/tests/unit_tests/agent_teams/harness/test_steer.py
@@ -1,0 +1,148 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""NativeHarness steering: reaches a running round, refuses everything else.
+
+``steer`` exists because ``send(content, immediate=True)`` does the wrong thing
+when nothing is running -- it starts a round. For a new message that is correct;
+for a correction aimed at a round that has since finished it invents a turn the
+user never asked for.
+
+The phase can only be decided by the supervisor. A caller that reads
+``active_round`` and then calls ``send`` has at least one await between them, and
+the round can finish inside it. Here the phase is read in the same step that
+queues the text, so the decision cannot go stale.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from openjiuwen.core.runner import Runner
+from openjiuwen.agent_teams.harness import HarnessState, NativeHarness
+from openjiuwen.harness.task_loop.loop_queues import SteeringInput
+from tests.unit_tests.agent_teams.harness.fixtures import (
+    drain_outputs,
+    make_spec,
+    start_harness,
+    wait_for_state,
+    wait_invoke_running,
+)
+
+
+@pytest.mark.asyncio
+async def test_steering_a_running_round_reaches_the_inner_loop() -> None:
+    await Runner.start()
+    try:
+        harness = NativeHarness(make_spec())
+        fake = await start_harness(harness, iterations=3, sleep_seconds=5.0)
+        collected: list = []
+        consumer = asyncio.create_task(drain_outputs(harness, collected))
+        try:
+            await harness.send("first")
+            await wait_invoke_running(fake)
+
+            assert await harness.steer("prefer the async client") is True
+
+            # Asserted on the queue rather than on what the agent saw. The fake
+            # drains steering once at the top of ``invoke``, so a mid-round steer
+            # can never show up in ``seen_steers`` -- the real react_agent drains
+            # before every model call, and that side is covered by
+            # tests/unit_tests/harness/test_steering_applied.py. What _on_steer
+            # owns is exactly this: the text is in the running round's queue.
+            queues = harness.event_handler.interaction_queues
+            assert [
+                SteeringInput.coerce(queues.steering.get_nowait()).text
+                for _ in range(queues.steering.qsize())
+            ] == ["prefer the async client"]
+        finally:
+            await harness.stop()
+            await consumer
+    finally:
+        await Runner.stop()
+
+
+@pytest.mark.asyncio
+async def test_steering_an_idle_harness_refuses_and_starts_nothing() -> None:
+    """The whole point: no round appears, and the caller is told so."""
+    await Runner.start()
+    try:
+        harness = NativeHarness(make_spec())
+        fake = await start_harness(harness)
+        collected: list = []
+        consumer = asyncio.create_task(drain_outputs(harness, collected))
+        try:
+            assert harness.state is HarnessState.IDLE
+
+            assert await harness.steer("too late") is False
+
+            # Nothing ran and nothing was queued for a future round either.
+            assert harness.state is HarnessState.IDLE
+            assert harness.active_round is None
+            assert fake.seen_steers == []
+            assert fake.completed_iterations == 0
+        finally:
+            await harness.stop()
+            await consumer
+    finally:
+        await Runner.stop()
+
+
+@pytest.mark.asyncio
+async def test_send_immediate_on_an_idle_harness_does_start_a_round() -> None:
+    """Control, and the reason ``steer`` had to be added.
+
+    If this ever stops starting a round then ``send(immediate=True)`` became
+    safe for stale steering and the separate entry point is redundant. Until
+    then, the two behaviours differ and the difference is the bug being avoided.
+    """
+    await Runner.start()
+    try:
+        harness = NativeHarness(make_spec())
+        fake = await start_harness(harness)
+        collected: list = []
+        consumer = asyncio.create_task(drain_outputs(harness, collected))
+        try:
+            assert harness.state is HarnessState.IDLE
+
+            await harness.send("too late", immediate=True)
+
+            await wait_for_state(harness, HarnessState.IDLE)
+            # A whole round ran, from text that meant to steer an old one.
+            assert fake.completed_iterations >= 1
+        finally:
+            await harness.stop()
+            await consumer
+    finally:
+        await Runner.stop()
+
+
+@pytest.mark.asyncio
+async def test_steering_a_paused_harness_refuses_and_does_not_resume_it() -> None:
+    """``send`` would resume the paused round and inject; steering must not.
+
+    Waking a harness to hand it a correction is the same silent-promotion
+    problem as starting a fresh round: the user asked to adjust something that
+    is running, not to restart something that stopped.
+    """
+    await Runner.start()
+    try:
+        harness = NativeHarness(make_spec())
+        fake = await start_harness(harness, iterations=3, sleep_seconds=5.0)
+        collected: list = []
+        consumer = asyncio.create_task(drain_outputs(harness, collected))
+        try:
+            await harness.send("first")
+            await wait_invoke_running(fake)
+            await harness.pause()
+            assert harness.state is HarnessState.PAUSED
+
+            assert await harness.steer("while paused") is False
+
+            assert harness.state is HarnessState.PAUSED
+            assert "while paused" not in fake.seen_steers
+        finally:
+            await harness.stop()
+            await consumer
+    finally:
+        await Runner.stop()

--- a/tests/unit_tests/agent_teams/harness/test_team_harness_steer.py
+++ b/tests/unit_tests/agent_teams/harness/test_team_harness_steer.py
@@ -1,0 +1,117 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""TeamHarness must actually expose round-scoped steering.
+
+This file exists because of a bug, and the bug is worth stating. Team steering
+was written against ``NativeHarness``, calling ``harness.steer`` and reading
+``harness.active_round``. But ``TeamAgent.harness`` returns a ``MemberRuntime``,
+and the default one is a **TeamHarness** -- a plain adapter with no
+``__getattr__`` that forwards a hand-picked set of methods. It forwarded
+``send`` and not ``steer``, so ``steer_leader`` raised ``AttributeError`` for
+every real team.
+
+Nothing caught it: the runtime tests built the harness surface out of
+``MagicMock`` and ``SimpleNamespace``, so they asserted against attributes they
+had invented rather than ones that exist. A mock cannot tell you a method is
+missing -- it grows one on demand. These tests use the real class.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from openjiuwen.agent_teams.harness.team_harness import TeamHarness
+
+
+def _harness(*, native, cycle_active: bool = True) -> TeamHarness:
+    """A TeamHarness over a stand-in native, with the run cycle live or not."""
+    harness = TeamHarness.__new__(TeamHarness)
+    harness._native = native
+    harness._active_agent_session = object() if cycle_active else None
+    return harness
+
+
+def test_the_forwarding_surface_carries_round_steering() -> None:
+    """The regression guard, asserted on the class rather than an instance.
+
+    A mock of this object would satisfy any call; the point is that the real
+    class declares these. If either disappears, Team steering fails as an
+    AttributeError at runtime -- which the caller turns into a generic
+    "exception", not a usable reason.
+    """
+    assert hasattr(TeamHarness, "steer_round")
+    assert hasattr(TeamHarness, "active_round")
+    # And it is not accidentally satisfied by a catch-all.
+    assert "__getattr__" not in TeamHarness.__dict__
+
+
+@pytest.mark.asyncio
+async def test_steering_forwards_the_id_and_the_expected_round() -> None:
+    native = MagicMock()
+    native.steer = AsyncMock(return_value=True)
+
+    result = await _harness(native=native).steer_round(
+        "prefer the async client", steer_id="req-9", expected_round_id=7
+    )
+
+    assert result is True
+    native.steer.assert_awaited_once_with(
+        "prefer the async client", steer_id="req-9", expected_round_id=7
+    )
+
+
+@pytest.mark.asyncio
+async def test_steering_before_start_is_refused_not_raised() -> None:
+    """Matches abort/pause: a dead cycle is a harmless impossibility.
+
+    ``send`` raises here instead, because sending to a team that was never
+    started is a caller error. Steering one is not -- the round it meant to
+    reach may simply have ended, which is exactly what False reports.
+    """
+    native = MagicMock()
+    native.steer = AsyncMock(return_value=True)
+    harness = _harness(native=native, cycle_active=False)
+
+    assert await harness.steer_round("too late") is False
+    native.steer.assert_not_awaited()
+
+
+def test_active_round_is_none_when_no_cycle_is_live() -> None:
+    """The caller uses this to decide whether to take a gate ticket at all.
+
+    Reading it off a torn-down native would raise; reading a stale round would
+    send a steer to a harness that cannot take it.
+    """
+    native = MagicMock()
+    native.active_round = object()
+
+    assert _harness(native=native).active_round is native.active_round
+    assert _harness(native=native, cycle_active=False).active_round is None
+
+
+def test_round_steering_is_a_capability_not_part_of_every_runtime() -> None:
+    """Two contracts, two Protocols, and the split is load-bearing both ways.
+
+    ``ExternalCliRuntime.steer`` is declared ``-> None`` and buffers when no turn
+    is in flight -- a buffered steer silently becomes the next turn's input,
+    which is the promotion this path exists to prevent. Had the new method reused that
+    name, a CLI-backed leader would satisfy the type and violate the contract,
+    and its falsy ``None`` would be reported as a rejection *after* delivery.
+
+    Declaring ``steer_round`` on ``MemberRuntime`` instead was also wrong, and a
+    pre-existing conformance test said so: ``ExternalCliRuntime`` stopped being a
+    ``MemberRuntime``, which is false -- it is a perfectly good one that simply
+    cannot steer a round. Hence a separate capability Protocol.
+    """
+    from openjiuwen.agent_teams.agent.member_runtime import (
+        MemberRuntime,
+        SupportsRoundSteering,
+    )
+    from openjiuwen.agent_teams.external.runtime import ExternalCliRuntime
+
+    assert issubclass(TeamHarness, SupportsRoundSteering)
+    assert not issubclass(ExternalCliRuntime, SupportsRoundSteering)
+    # And the capability split did not cost the CLI runtime its base conformance.
+    assert hasattr(ExternalCliRuntime, "steer")
+    assert "steer_round" not in dir(MemberRuntime)

--- a/tests/unit_tests/agent_teams/runtime/test_steer_leader.py
+++ b/tests/unit_tests/agent_teams/runtime/test_steer_leader.py
@@ -1,0 +1,220 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Tests for steering the leader's in-flight round.
+
+The reason this is separate from ``interact`` is the idle case. Interact starts
+a leader round when the team has nothing running; steering must report that
+there was nothing to steer instead, so a stale steer never becomes work the
+user did not ask for.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from openjiuwen.agent_teams.runtime.manager import TeamRuntimeManager
+from openjiuwen.agent_teams.runtime.pool import ActiveTeam, RuntimeState
+
+
+def _agent(
+    *,
+    active_round: object | None,
+    steered: bool = True,
+    unsupported: bool = False,
+) -> MagicMock:
+    """A TeamAgent stub whose runtime reports whether a round is in flight.
+
+    ``steered`` is what ``TeamAgent.steer`` returns -- False meaning the harness
+    found no round when it came to queue the text. That is a different moment
+    from the in-flight check beforehand, and the two can disagree.
+
+    ``unsupported`` makes ``steer`` raise ``NotImplementedError``, the way it does
+    for a runtime with no round-scoped steering.
+
+    A stub with an `active_round` attribute is how this file missed the bug that
+    mattered: the real default runtime is a ``TeamHarness``, which had neither
+    ``steer`` nor ``active_round``, so `steer_leader` raised ``AttributeError``
+    for every real team while these tests stayed green. The integration test at
+    the bottom of the file is the one that would have caught it; these remain for
+    the branch logic they can reach cheaply.
+    """
+    agent = MagicMock()
+    agent.has_in_flight_round = MagicMock(return_value=active_round is not None)
+    if unsupported:
+        agent.steer = AsyncMock(side_effect=NotImplementedError("no steer_round"))
+    else:
+        agent.steer = AsyncMock(return_value=steered)
+    agent.harness = SimpleNamespace(active_round=active_round)
+    return agent
+
+
+async def _manager_with(agent: MagicMock) -> TeamRuntimeManager:
+    manager = TeamRuntimeManager()
+    await manager.pool.add(
+        ActiveTeam(
+            team_name="alpha",
+            agent=agent,
+            current_session_id="session-1",
+            state=RuntimeState.RUNNING,
+        )
+    )
+    return manager
+
+
+@pytest.mark.asyncio
+async def test_steering_an_in_flight_round_reaches_the_leader() -> None:
+    agent = _agent(active_round=object())
+    manager = await _manager_with(agent)
+
+    agent.harness = SimpleNamespace(active_round=SimpleNamespace(round_id=7))
+    result = await manager.steer_leader(
+        "prefer the async client",
+        team_name="alpha",
+        session_id="session-1",
+        steer_id="req-9",
+    )
+
+    assert result.ok is True
+    # No message id: steering writes no bus message, like deliver_to_leader.
+    assert result.message_id is None
+    # The id must reach the runtime -- STEER_APPLIED's `dropped` is built from it,
+    # so dropping it here makes a rail-removed steer look applied. And the round
+    # is named, so a steer cannot land in a round that replaced the intended one.
+    agent.steer.assert_awaited_once_with(
+        "prefer the async client", steer_id="req-9", expected_round_id=7
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_idle_leader_is_rejected_and_starts_nothing() -> None:
+    """The load-bearing case, and the reason this is not a variant of interact.
+
+    Interact would start a leader round here. A steer must not: the user was
+    correcting work in flight, and there is no work in flight.
+    """
+    agent = _agent(active_round=None)
+    manager = await _manager_with(agent)
+
+    result = await manager.steer_leader("too late", team_name="alpha", session_id="session-1")
+
+    assert result.ok is False
+    assert result.reason == "no_active_round"
+    agent.steer.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_runtime_for_the_target_is_not_active() -> None:
+    manager = TeamRuntimeManager()
+
+    result = await manager.steer_leader("hello", team_name="ghost", session_id="session-1")
+
+    assert result.ok is False
+    assert result.reason == "not_active"
+
+
+@pytest.mark.asyncio
+async def test_a_shutting_down_runtime_reports_gate_closed() -> None:
+    agent = _agent(active_round=object())
+    manager = await _manager_with(agent)
+    entry = await manager.pool.get("alpha")
+    assert entry is not None
+    await entry.interact_gate.close_and_drain()
+
+    result = await manager.steer_leader("late", team_name="alpha", session_id="session-1")
+
+    assert result.ok is False
+    assert result.reason == "gate_closed"
+    agent.steer.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_an_agent_without_a_harness_is_rejected_not_crashed() -> None:
+    """A member still starting up has no harness yet."""
+    agent = MagicMock()
+    agent.steer = AsyncMock()
+    agent.has_in_flight_round = MagicMock(return_value=False)
+    agent.harness = None
+    manager = await _manager_with(agent)
+
+    result = await manager.steer_leader("hi", team_name="alpha", session_id="session-1")
+
+    assert result.ok is False
+    assert result.reason == "no_active_round"
+    agent.steer.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_the_idle_check_happens_before_the_gate_ticket() -> None:
+    """A guaranteed no-op must not queue behind live traffic.
+
+    If the idle check ran after admission, a steer with nothing to steer would
+    wait for the gate before discovering it had nothing to do.
+    """
+    agent = _agent(active_round=None)
+    manager = await _manager_with(agent)
+    entry = await manager.pool.get("alpha")
+    assert entry is not None
+    entry.interact_gate.admit = AsyncMock(side_effect=AssertionError("gate was taken"))
+
+    result = await manager.steer_leader("nothing", team_name="alpha", session_id="session-1")
+
+    assert result.reason == "no_active_round"
+
+
+@pytest.mark.asyncio
+async def test_a_round_that_ends_in_flight_is_reported_as_no_active_round() -> None:
+    """The race the pre-check cannot win.
+
+    ``active_round`` says a round is live, then the gate ticket and the harness
+    control-queue hop both yield to the event loop, and the round finishes in
+    between. The harness refuses, and that refusal has to reach the caller --
+    reporting success would claim a finished round took the correction.
+    """
+    agent = _agent(active_round=object(), steered=False)
+    manager = await _manager_with(agent)
+
+    result = await manager.steer_leader("too late", team_name="alpha", session_id="session-1")
+
+    assert result.ok is False
+    assert result.reason == "no_active_round"
+    # It really was attempted; this is not the pre-check rejecting it early.
+    agent.steer.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_a_runtime_without_round_steering_says_so_instead() -> None:
+    """A CLI-backed leader is not a race, and must not be reported as one.
+
+    Its runtime's own ``steer`` buffers rather than injecting, so there is no
+    round-scoped delivery to attempt. Calling that "no_active_round" would send
+    the user -- and whoever reads the log -- hunting for a timing problem that
+    does not exist.
+    """
+    agent = _agent(active_round=object(), unsupported=True)
+    manager = await _manager_with(agent)
+    entry = await manager.pool.get("alpha")
+    assert entry is not None
+
+    result = await manager.steer_leader("hi", team_name="alpha", session_id="session-1")
+
+    assert result.ok is False
+    assert result.reason == "unsupported_runtime"
+    # The NotImplementedError must not escape, and the ticket must still drain.
+    assert entry.interact_gate._inflight == 0
+
+
+@pytest.mark.asyncio
+async def test_the_gate_ticket_is_released_even_when_the_harness_refuses() -> None:
+    """A refusal must not leak the inflight count, or shutdown never drains."""
+    agent = _agent(active_round=object(), steered=False)
+    manager = await _manager_with(agent)
+    entry = await manager.pool.get("alpha")
+    assert entry is not None
+
+    result = await manager.steer_leader("too late", team_name="alpha", session_id="session-1")
+
+    assert result.ok is False
+    # close_and_drain waits on this reaching zero.
+    assert entry.interact_gate._inflight == 0

--- a/tests/unit_tests/core/single_agent/rail/test_before_steering_drain.py
+++ b/tests/unit_tests/core/single_agent/rail/test_before_steering_drain.py
@@ -115,7 +115,7 @@ async def test_rail_caps_the_batch_and_leaves_the_rest_queued() -> None:
 
     batch = await _agent()._drain_steering_batch(ctx)
 
-    assert batch == ["m1", "m2"]
+    assert [item.text for item in batch] == ["m1", "m2"]
     assert ctx.has_pending_steering()
     assert ctx.steering_queue.qsize() == 3
 
@@ -128,7 +128,10 @@ async def test_successive_calls_walk_the_backlog_in_order() -> None:
     ctx = _ctx("m1", "m2", "m3", "m4", "m5", rails=[rail])
     agent = _agent()
 
-    batches = [await agent._drain_steering_batch(ctx) for _ in range(3)]
+    batches = [
+        [item.text for item in await agent._drain_steering_batch(ctx)]
+        for _ in range(3)
+    ]
 
     assert batches == [["m1", "m2"], ["m3", "m4"], ["m5"]]
     assert not ctx.has_pending_steering()
@@ -154,7 +157,8 @@ async def test_rail_is_shown_the_current_queue_depth() -> None:
 async def test_no_rail_opinion_takes_the_whole_backlog() -> None:
     ctx = _ctx("m1", "m2", "m3", rails=[_InertRail()])
 
-    assert await _agent()._drain_steering_batch(ctx) == ["m1", "m2", "m3"]
+    batch = await _agent()._drain_steering_batch(ctx)
+    assert [item.text for item in batch] == ["m1", "m2", "m3"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/core/single_agent/rail/test_ctx_steering.py
+++ b/tests/unit_tests/core/single_agent/rail/test_ctx_steering.py
@@ -1,11 +1,19 @@
 # coding: utf-8
 # Copyright (c) Huawei Technologies Co., Ltd. 2025.
 # All rights reserved.
-"""Unit tests for AgentCallbackContext steering methods."""
+"""Unit tests for AgentCallbackContext steering methods.
+
+``drain_steering`` returns ``SteeringInput`` envelopes rather than bare strings: a
+steer carries the id of the request that produced it, so ``STEER_APPLIED`` can
+name which one a rail dropped. Producers may still push plain text -- a rail
+steering on its own has nothing to correlate -- and the drain coerces, which is
+what ``_texts`` unwraps below.
+"""
 
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 from unittest.mock import MagicMock
 
 from openjiuwen.core.single_agent.rail.base import (
@@ -17,6 +25,11 @@ def _make_ctx() -> AgentCallbackContext:
     """Create a minimal AgentCallbackContext."""
     mock_agent = MagicMock()
     return AgentCallbackContext(agent=mock_agent)
+
+
+def _texts(drained: list[Any]) -> list[str]:
+    """The text of each drained steer, for assertions about content and order."""
+    return [item.text for item in drained]
 
 
 class TestCtxSteeringQueue:
@@ -46,7 +59,9 @@ class TestCtxSteeringQueue:
         ctx.push_steering("msg2")
 
         result = ctx.drain_steering()
-        assert result == ["msg1", "msg2"]
+        assert _texts(result) == ["msg1", "msg2"]
+        # Pushed as plain text, so there is no id to carry.
+        assert [item.id for item in result] == [None, None]
 
     @staticmethod
     def test_drain_clears_queue() -> None:
@@ -56,7 +71,7 @@ class TestCtxSteeringQueue:
         ctx.bind_steering_queue(q)
 
         ctx.push_steering("once")
-        assert ctx.drain_steering() == ["once"]
+        assert _texts(ctx.drain_steering()) == ["once"]
         assert ctx.drain_steering() == []
 
     @staticmethod
@@ -66,11 +81,12 @@ class TestCtxSteeringQueue:
         ctx = _make_ctx()
         ctx.bind_steering_queue(q)
 
-        # Simulate EventHandler writing directly
+        # Simulate EventHandler writing directly. It writes a bare string, which
+        # is why the drain coerces rather than assuming envelopes.
         q.put_nowait("external_msg")
 
         result = ctx.drain_steering()
-        assert result == ["external_msg"]
+        assert _texts(result) == ["external_msg"]
 
     @staticmethod
     def test_multiple_drain_cycles() -> None:
@@ -80,11 +96,11 @@ class TestCtxSteeringQueue:
         ctx.bind_steering_queue(q)
 
         ctx.push_steering("a")
-        assert ctx.drain_steering() == ["a"]
+        assert _texts(ctx.drain_steering()) == ["a"]
 
         ctx.push_steering("b")
         ctx.push_steering("c")
-        assert ctx.drain_steering() == ["b", "c"]
+        assert _texts(ctx.drain_steering()) == ["b", "c"]
 
 
 def _ctx_with_queue(*messages: str) -> AgentCallbackContext:
@@ -100,30 +116,30 @@ def test_limit_takes_the_oldest_and_leaves_the_rest_queued() -> None:
     """The surplus stays in the queue, in order, for the next drain."""
     ctx = _ctx_with_queue("m1", "m2", "m3", "m4", "m5")
 
-    assert ctx.drain_steering(2) == ["m1", "m2"]
+    assert _texts(ctx.drain_steering(2)) == ["m1", "m2"]
     assert ctx.has_pending_steering()
-    assert ctx.drain_steering(2) == ["m3", "m4"]
-    assert ctx.drain_steering(2) == ["m5"]
+    assert _texts(ctx.drain_steering(2)) == ["m3", "m4"]
+    assert _texts(ctx.drain_steering(2)) == ["m5"]
     assert not ctx.has_pending_steering()
 
 
-def test_limit_above_the_backlog_takes_what_there_is() -> None:
+def test_limit_above_the_queue_takes_what_there_is() -> None:
     ctx = _ctx_with_queue("only")
-    assert ctx.drain_steering(5) == ["only"]
+    assert _texts(ctx.drain_steering(5)) == ["only"]
 
 
 def test_no_limit_still_takes_everything() -> None:
     """The default is the behaviour of a loop with no policy on the matter."""
     ctx = _ctx_with_queue("a", "b", "c")
-    assert ctx.drain_steering() == ["a", "b", "c"]
+    assert _texts(ctx.drain_steering()) == ["a", "b", "c"]
     assert ctx.drain_steering(None) == []
 
 
 def test_a_non_empty_queue_always_yields_one() -> None:
-    """Consumption has to advance, or the loop would spin on an untouched backlog."""
+    """Consumption has to advance, or the loop would spin on an untouched queue."""
     ctx = _ctx_with_queue("a", "b")
-    assert ctx.drain_steering(0) == ["a"]
-    assert ctx.drain_steering(-3) == ["b"]
+    assert _texts(ctx.drain_steering(0)) == ["a"]
+    assert _texts(ctx.drain_steering(-3)) == ["b"]
 
 
 def test_limit_on_an_empty_queue_returns_empty() -> None:

--- a/tests/unit_tests/harness/test_deep_agent_event_handler.py
+++ b/tests/unit_tests/harness/test_deep_agent_event_handler.py
@@ -247,10 +247,11 @@ async def test_handle_task_interaction() -> None:
     assert result["status"] == "steer_injected"
     assert "change plan" in result["msg"]
 
-    # Verify message was pushed to steering queue
+    # Verify message was pushed to steering queue. drain_steering yields
+    # SteeringInput now, so the text is read off the envelope.
     msgs = queues.drain_steering()
     assert len(msgs) == 1
-    assert msgs[0] == "change plan"
+    assert msgs[0].text == "change plan"
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/harness/test_deep_agent_interaction.py
+++ b/tests/unit_tests/harness/test_deep_agent_interaction.py
@@ -12,9 +12,13 @@ import pytest
 from openjiuwen.core.session import InteractiveInput
 from openjiuwen.core.single_agent.schema.agent_card import AgentCard
 from openjiuwen.harness.deep_agent import DeepAgent
+from openjiuwen.harness.task_loop.loop_queues import LoopQueues, SteeringInput
+from openjiuwen.harness.task_loop.task_loop_controller import TaskLoopController
 from openjiuwen.harness.schema.interaction import (
     ActiveInteractionRound,
     InputDispatchMode,
+    InputDisposition,
+    InteractionEventType,
     RoundWorkItem,
     SendInputRequest,
 )
@@ -239,3 +243,295 @@ async def test_cancel_active_round_does_not_block_on_slow_cancel_task() -> None:
     agent.abort.assert_awaited_once()
     assert elapsed < 1.0
     assert agent._interaction_round_task.cancelled() or agent._interaction_round_task.done()
+
+
+# ------------------------------------------------- explicit steer dispatch
+
+
+def _steer(
+    request_id: str = "steer-1",
+    *,
+    expected_round_id: str | None = None,
+) -> SendInputRequest:
+    return SendInputRequest(
+        request_id=request_id,
+        inputs={"query": "prefer the async client"},
+        mode=InputDispatchMode.STEER,
+        expected_round_id=expected_round_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_steer_with_active_round_is_queued_and_reported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = DeepAgent(AgentCard(name="deep", description="test"))
+    agent._interaction_started = True
+    monkeypatch.setattr(agent, "_notify_work", MagicMock())
+
+    loop = MagicMock()
+    agent._loop_controller = loop
+    agent._active_interaction_round = ActiveInteractionRound(
+        work=RoundWorkItem.user(request_id="round-1", inputs={"query": "start"}),
+        task_id="task-1",
+    )
+
+    result = await agent.send_input(_steer())
+
+    assert result.accepted is True
+    assert result.disposition is InputDisposition.STEER_QUEUED
+    assert result.reason is None
+    # The id must ride along, not just the text. STEER_APPLIED builds ``dropped``
+    # from these ids, so queuing a bare string makes every dropped steer
+    # invisible -- reported as applied when a rail actually removed it.
+    loop.enqueue_steer.assert_called_once_with(
+        SteeringInput(text="prefer the async client", id="steer-1")
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_request_id_survives_the_whole_queue_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End to end through a real controller and queue, not a mock.
+
+    The mock above proves ``send_input`` passes an id to ``enqueue_steer``. It
+    cannot prove the id is still there when the ReAct loop drains it, because
+    every hop between them could drop it: ``enqueue_steer`` narrowed its
+    parameter to ``str`` for a while, and coercion happens in two different
+    drains. That gap is exactly how ``dropped`` came to be permanently empty
+    while ten unit tests passed -- they all built SteeringInput by hand and so
+    never crossed a single one of these hops.
+    """
+    agent = DeepAgent(AgentCard(name="deep", description="test"))
+    agent._interaction_started = True
+    monkeypatch.setattr(agent, "_notify_work", MagicMock())
+
+    queues = LoopQueues()
+    controller = TaskLoopController.__new__(TaskLoopController)
+    monkeypatch.setattr(
+        controller, "_get_interaction_queues", lambda: queues, raising=False
+    )
+    agent._loop_controller = controller
+    agent._active_interaction_round = ActiveInteractionRound(
+        work=RoundWorkItem.user(request_id="round-1", inputs={"query": "start"}),
+        task_id="task-1",
+    )
+
+    await agent.send_input(_steer("steer-real-path"))
+
+    drained = queues.drain_steering()
+    assert [item.text for item in drained] == ["prefer the async client"]
+    assert [item.id for item in drained] == ["steer-real-path"]
+
+
+@pytest.mark.asyncio
+async def test_steer_with_matching_expected_round_id_is_queued(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = DeepAgent(AgentCard(name="deep", description="test"))
+    agent._interaction_started = True
+    monkeypatch.setattr(agent, "_notify_work", MagicMock())
+    loop = MagicMock()
+    agent._loop_controller = loop
+    agent._active_interaction_round = ActiveInteractionRound(
+        work=RoundWorkItem.user(request_id="round-a", inputs={"query": "start"}),
+        task_id="task-1",
+    )
+
+    result = await agent.send_input(_steer(expected_round_id="round-a"))
+
+    assert result.accepted is True
+    assert result.disposition is InputDisposition.STEER_QUEUED
+    loop.enqueue_steer.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_steer_with_wrong_expected_round_id_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = DeepAgent(AgentCard(name="deep", description="test"))
+    agent._interaction_started = True
+    monkeypatch.setattr(agent, "_notify_work", MagicMock())
+    loop = MagicMock()
+    agent._loop_controller = loop
+    agent._active_interaction_round = ActiveInteractionRound(
+        work=RoundWorkItem.user(request_id="round-a", inputs={"query": "start"}),
+        task_id="task-1",
+    )
+
+    result = await agent.send_input(_steer("steer-stale-round", expected_round_id="round-b"))
+
+    assert result.accepted is False
+    assert result.reason == "round_mismatch"
+    assert result.disposition is InputDisposition.REJECTED
+    loop.enqueue_steer.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_idle_steer_is_rejected_instead_of_starting_a_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Acceptance criterion: no silent downgrade to a fresh turn.
+
+    Rejection requires *both* no active round and nothing keeping the
+    interaction open -- genuinely nothing to steer.  Before the dispatch result
+    existed this case fell into the fresh-turn path, so a stale steer started a
+    whole turn the user never asked for, indistinguishable from success at the
+    wire.
+    """
+    agent = DeepAgent(AgentCard(name="deep", description="test"))
+    agent._interaction_started = True
+    monkeypatch.setattr(agent, "_notify_work", MagicMock())
+    monkeypatch.setattr(
+        agent, "_should_keep_interaction_open_locked", MagicMock(return_value=False)
+    )
+
+    loop = MagicMock()
+    agent._loop_controller = loop
+    assert agent._active_interaction_round is None
+
+    result = await agent.send_input(_steer("steer-stale"))
+
+    assert result.accepted is False
+    assert result.reason == "no_active_round"
+    assert result.disposition is InputDisposition.REJECTED
+
+    # The load-bearing assertion: nothing was queued at all. A rejected steer
+    # must not become a follow-up, a fresh turn, or a steer on a later round.
+    assert agent._event_manager.next_work() is None
+    loop.enqueue_steer.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_steer_with_open_interaction_still_queues_as_follow_up(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression guard for the Goal-supplement path.
+
+    While a Goal is ACTIVE the Web sends ordinary input as
+    ``input_mode="steer"`` (``useWebSocket.ts:1474``) so it lands as a
+    supplementary constraint on the running Goal rather than overwriting it.
+    Between attempts there is legitimately no active round, so an
+    unconditional rejection would silently drop the user's message.
+
+    It would also stall the Goal: ``_should_keep_interaction_open_locked`` is
+    what queues the next attempt, and returning before it skips that.
+    """
+    agent = DeepAgent(AgentCard(name="deep", description="test"))
+    agent._interaction_started = True
+    monkeypatch.setattr(agent, "_notify_work", MagicMock())
+    keep_open = MagicMock(return_value=True)
+    monkeypatch.setattr(agent, "_should_keep_interaction_open_locked", keep_open)
+
+    agent._loop_controller = MagicMock()
+    assert agent._active_interaction_round is None
+
+    result = await agent.send_input(_steer("steer-during-goal"))
+
+    assert result.accepted is True
+    assert result.disposition is InputDisposition.FOLLOW_UP_QUEUED
+
+    work = agent._event_manager.next_work()
+    assert work is not None
+    assert work.query == "prefer the async client"
+
+    # The side effect matters as much as the queued work: this is the call that
+    # schedules the Goal's next attempt.
+    keep_open.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_accepted_paths_report_their_own_disposition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every accepted path names what it did, not merely that it succeeded."""
+    agent = DeepAgent(AgentCard(name="deep", description="test"))
+    agent._interaction_started = True
+    monkeypatch.setattr(agent, "_notify_work", MagicMock())
+
+    fresh = await agent.send_input(
+        SendInputRequest(request_id="turn-1", inputs={"query": "hello"})
+    )
+    assert fresh.accepted is True
+    assert fresh.disposition is InputDisposition.TURN_QUEUED
+
+    interactive_input = InteractiveInput()
+    interactive_input.update("call_1", {"action": "allow_once"})
+    resumed = await agent.send_input(
+        SendInputRequest(request_id="resume-1", inputs={"query": interactive_input})
+    )
+    assert resumed.accepted is True
+    assert resumed.disposition is InputDisposition.RESUME_QUEUED
+
+
+@pytest.mark.asyncio
+async def test_undrained_steers_are_dropped_when_the_round_ends(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A steer ACKed after the last model call must not reach the next round.
+
+    The session steering queue outlives one interaction round. Without a
+    teardown flush, ``steer_queued`` text sits until the following round's
+    first drain and is admitted under the wrong turn.
+    """
+    agent = DeepAgent(AgentCard(name="deep", description="test"))
+    agent._interaction_started = True
+    monkeypatch.setattr(agent, "_notify_work", MagicMock())
+
+    queues = LoopQueues()
+    controller = TaskLoopController.__new__(TaskLoopController)
+    monkeypatch.setattr(
+        controller, "_get_interaction_queues", lambda: queues, raising=False
+    )
+    agent._loop_controller = controller
+    agent._active_interaction_round = ActiveInteractionRound(
+        work=RoundWorkItem.user(request_id="round-1", inputs={"query": "start"}),
+        task_id="task-1",
+    )
+
+    await agent.send_input(_steer("steer-late"))
+    assert queues.steering.qsize() == 1
+
+    events: list = []
+    monkeypatch.setattr(
+        agent, "_emit_interaction_event", lambda event: events.append(event)
+    )
+
+    agent._drop_undrained_steering()
+
+    assert queues.steering.qsize() == 0
+    assert len(events) == 1
+    assert events[0].type is InteractionEventType.STEER_APPLIED
+    assert events[0].payload["applied"] == []
+    assert events[0].payload["dropped"] == ["steer-late"]
+
+
+@pytest.mark.asyncio
+async def test_steer_with_expected_round_id_and_no_active_round_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A client-bound round id must not fall through to follow_up_queued.
+
+    ``chat.steer`` stamps ``expected_round_id``. When that round is already
+    gone, promoting the text into a Goal follow-up is a silent race win.
+    """
+    agent = DeepAgent(AgentCard(name="deep", description="test"))
+    agent._interaction_started = True
+    monkeypatch.setattr(agent, "_notify_work", MagicMock())
+    keep_open = MagicMock(return_value=True)
+    monkeypatch.setattr(agent, "_should_keep_interaction_open_locked", keep_open)
+    loop = MagicMock()
+    agent._loop_controller = loop
+    assert agent._active_interaction_round is None
+
+    result = await agent.send_input(
+        _steer("steer-stale-bound", expected_round_id="round-gone")
+    )
+
+    assert result.accepted is False
+    assert result.reason == "round_mismatch"
+    assert result.disposition is InputDisposition.REJECTED
+    loop.enqueue_steer.assert_not_called()
+    assert agent._event_manager.next_work() is None
+    keep_open.assert_not_called()

--- a/tests/unit_tests/harness/test_loop_queues.py
+++ b/tests/unit_tests/harness/test_loop_queues.py
@@ -17,7 +17,12 @@ def test_push_and_drain_steering() -> None:
     q.push_steer("msg2")
 
     msgs = q.drain_steering()
-    assert msgs == ["msg1", "msg2"]
+    # drain_steering yields SteeringInput, not bare strings: the queue now
+    # carries an optional request id so a host can correlate an ack.
+    assert [m.text for m in msgs] == ["msg1", "msg2"]
+    # A bare string push leaves the id unset -- rails steer with nothing
+    # to correlate.
+    assert all(m.id is None for m in msgs)
 
     # Second drain returns empty
     assert q.drain_steering() == []
@@ -43,7 +48,7 @@ def test_queues_are_independent() -> None:
     q.push_steer("steer1")
     q.push_follow_up("follow1")
 
-    assert q.drain_steering() == ["steer1"]
+    assert [m.text for m in q.drain_steering()] == ["steer1"]
     assert q.drain_follow_up() == ["follow1"]
 
     # Both empty now
@@ -63,11 +68,11 @@ def test_multiple_drain_cycles() -> None:
     q = LoopQueues()
 
     q.push_steer("a")
-    assert q.drain_steering() == ["a"]
+    assert [m.text for m in q.drain_steering()] == ["a"]
 
     q.push_steer("b")
     q.push_steer("c")
-    assert q.drain_steering() == ["b", "c"]
+    assert [m.text for m in q.drain_steering()] == ["b", "c"]
 
 
 def test_has_follow_up_does_not_consume() -> None:

--- a/tests/unit_tests/harness/test_steering_applied.py
+++ b/tests/unit_tests/harness/test_steering_applied.py
@@ -1,0 +1,159 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Tests for reporting which steers reached model context.
+
+The acknowledgement a host sends says the text was *queued*. This says it was
+*applied*, and the two are different facts: a client that only has the first
+cannot tell a slow model from an instruction a rail discarded.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from openjiuwen.core.single_agent.agents.react_agent import ReActAgent
+from openjiuwen.core.single_agent.schema.agent_card import AgentCard
+from openjiuwen.harness.schema.interaction import InteractionEvent, InteractionEventType
+from openjiuwen.harness.task_loop.loop_queues import LoopQueues, SteeringInput
+
+
+def _agent() -> ReActAgent:
+    return ReActAgent(AgentCard(name="react", description="test"))
+
+
+def _capture(agent: ReActAgent) -> List[tuple]:
+    calls: List[tuple] = []
+    agent.set_steering_applied_sink(
+        lambda applied, dropped: calls.append((applied, dropped))
+    )
+    return calls
+
+
+def test_no_sink_means_no_work_and_no_failure() -> None:
+    """An embedder that never binds the bridge sees identical behaviour."""
+    agent = _agent()
+    # Deliberately not calling set_steering_applied_sink.
+    agent._report_steering_applied([SteeringInput("a", "r1")], ["a"])
+
+
+def test_applied_entries_carry_the_id_that_queued_them() -> None:
+    agent = _agent()
+    calls = _capture(agent)
+
+    drained = [SteeringInput("use async", "req-1"), SteeringInput("and retry", "req-2")]
+    agent._report_steering_applied(drained, ["use async", "and retry"])
+
+    applied, dropped = calls[0]
+    assert applied == [
+        {"id": "req-1", "text": "use async"},
+        {"id": "req-2", "text": "and retry"},
+    ]
+    assert dropped == []
+
+
+def test_a_rail_dropping_a_part_is_reported_as_dropped() -> None:
+    """Without this the client's bubble stays pending forever."""
+    agent = _agent()
+    calls = _capture(agent)
+
+    drained = [SteeringInput("keep me", "req-1"), SteeringInput("drop me", "req-2")]
+    # A rail removed the second part during admission.
+    agent._report_steering_applied(drained, ["keep me"])
+
+    applied, dropped = calls[0]
+    assert applied == [{"id": "req-1", "text": "keep me"}]
+    assert dropped == ["req-2"]
+
+
+def test_reordering_by_a_rail_does_not_scramble_ids() -> None:
+    """Rails may reorder the batch; correlation follows content, not position."""
+    agent = _agent()
+    calls = _capture(agent)
+
+    drained = [SteeringInput("first", "req-1"), SteeringInput("second", "req-2")]
+    agent._report_steering_applied(drained, ["second", "first"])
+
+    applied, _ = calls[0]
+    assert applied == [
+        {"id": "req-2", "text": "second"},
+        {"id": "req-1", "text": "first"},
+    ]
+
+
+def test_duplicate_text_resolves_in_queue_order() -> None:
+    """Two steers with identical text are matched oldest first.
+
+    Content is the only handle that survives admission, so identical text is
+    genuinely ambiguous. Queue order is the only tie-break anyone could mean.
+    """
+    agent = _agent()
+    calls = _capture(agent)
+
+    drained = [SteeringInput("again", "req-1"), SteeringInput("again", "req-2")]
+    agent._report_steering_applied(drained, ["again"])
+
+    applied, dropped = calls[0]
+    assert applied == [{"id": "req-1", "text": "again"}]
+    assert dropped == ["req-2"]
+
+
+def test_rail_pushed_steering_has_no_id_and_is_never_reported_dropped() -> None:
+    """Rails steer with nothing to correlate, so a drop has nobody to tell."""
+    agent = _agent()
+    calls = _capture(agent)
+
+    drained = [SteeringInput("from a rail"), SteeringInput("from a client", "req-1")]
+    agent._report_steering_applied(drained, [])
+
+    applied, dropped = calls[0]
+    assert applied == []
+    assert dropped == ["req-1"]
+
+
+def test_text_a_rail_synthesised_is_reported_without_an_id() -> None:
+    """The event describes what the model saw, even when no input carried it."""
+    agent = _agent()
+    calls = _capture(agent)
+
+    drained = [SteeringInput("original", "req-1")]
+    agent._report_steering_applied(drained, ["original", "rail addendum"])
+
+    applied, dropped = calls[0]
+    assert applied == [
+        {"id": "req-1", "text": "original"},
+        {"id": None, "text": "rail addendum"},
+    ]
+    assert dropped == []
+
+
+def test_a_failing_sink_never_breaks_the_turn() -> None:
+    """Observability is not allowed to take down the round it observes."""
+    agent = _agent()
+
+    def _boom(applied: List[Dict[str, Any]], dropped: List[str]) -> None:
+        raise RuntimeError("consumer exploded")
+
+    agent.set_steering_applied_sink(_boom)
+    agent._report_steering_applied([SteeringInput("x", "req-1")], ["x"])
+
+
+def test_event_payload_shape() -> None:
+    event = InteractionEvent.steer_applied(
+        applied=[{"id": "req-1", "text": "use async"}], dropped=["req-2"]
+    )
+    assert event.type is InteractionEventType.STEER_APPLIED
+    assert event.payload == {
+        "applied": [{"id": "req-1", "text": "use async"}],
+        "dropped": ["req-2"],
+    }
+    # It travels an output stream, like every other interaction event.
+    assert event.to_output_schema().type == "steer.applied"
+
+
+def test_queue_coerces_both_producer_shapes() -> None:
+    """Hosts push envelopes, rails push bare strings, both drain the same."""
+    queues = LoopQueues()
+    queues.push_steer(SteeringInput("with id", "req-1"))
+    queues.push_steer("bare string")
+
+    drained = queues.drain_steering()
+    assert [(d.text, d.id) for d in drained] == [("with id", "req-1"), ("bare string", None)]


### PR DESCRIPTION
Paired: [GitHub #497](https://github.com/openJiuwen-ai/agent-core/pull/497) ↔ [GitCode !2305](https://gitcode.com/openJiuwen/agent-core/merge_requests/2305)

<!-- Title suggestion: feat(interaction): real mid-turn steering with applied reporting -->
<!-- Branch: feat/mid-turn-steering → develop | Commit: b52d8f00 -->
<!-- Land and publish before the jiuwenswarm chat.steer PR bumps the pin -->

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openJiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
Choose one label from `bug`, `task`, `feature` and `refactor`, and replace `<label>` below the comment block. 

If this pr is not only bug fix/task/feature and also a refactor, you can append `/kind refactor` label after `/kind bug`, `/kind task` and `/kind feature`.
-->
/kind feature


**What does this PR do / why do we need it**:

Wire `send_input` so hosts can steer an active round without stealing the output lease, refuse steers after the round ends, and report what reached model context.

- `SendInputResult` / `InputDisposition` on every `send_input` path
- `STEER` with no active round rejects (`no_active_round`); `expected_round_id` rejects `round_mismatch` when the client races past turn end
- Drop undrained steers at round teardown so they cannot bleed into the next turn; emit `steer.applied` with dropped ids
- Steering envelopes carry optional request ids; rails can bound a drain
- Team leader and member steers reach the live runtime; applied/dropped surfaces for hosts
- Unit coverage for interaction, team harness, and applied reporting

Hosts need a truthful mid-turn path. A bare success flag hid follow-up downgrades and end-of-turn races. This contract is the dependency for the JiuwenSwarm `chat.steer` PR.


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2748


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

**Function**

- `pytest tests/unit_tests/harness/test_deep_agent_interaction.py` — steer queue, `expected_round_id`, `no_active_round`, undrained drop at round end (steer-related cases passed)
- `pytest tests/unit_tests/harness/test_steering_applied.py` — applied/dropped reporting
- Team: `test_steer.py`, `test_team_harness_steer.py`, `test_steer_leader.py`

**Reliability**

- Steer with matching `expected_round_id` → `steer_queued`
- Wrong or stale `expected_round_id` → `round_mismatch` (does not fall through to follow-up)
- Idle steer with nothing open → `no_active_round`
- Leftover queue at round end → `steer.applied` with empty `applied` and dropped ids

**Contract smoke (publish install)**

```bash
python -c "from openjiuwen.harness.schema.interaction import SendInputResult; print(SendInputResult)"
python -c "from openjiuwen.core.runner.runner import Runner; assert hasattr(Runner, 'steer_agent_team')"
```

**Performance:** not a target of this change.

**Security:** steer does not take or replace the output lease.


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [x] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

**Special notes for reviewers**

- Public API: `SendInputResult` replaces a `None` return from `send_input`. Hosts must read `accepted` / `disposition` / `reason`.
- Publish this package before JiuwenSwarm bumps its pin.
