### PR TITLE
refactor(symphony): register orchestration modes in one place

### DIFF
--- a/openjiuwen/symphony/orchestration/__init__.py
+++ b/openjiuwen/symphony/orchestration/__init__.py
@@ -8,9 +8,17 @@ from openjiuwen.symphony.orchestration.contracts import (
     OrchestrationPlan,
     OrchestrationProgress,
 )
+from openjiuwen.symphony.orchestration.modes import (
+    BUILTIN_MODES,
+    PlannerFactory,
+    available_modes,
+    register_mode,
+    unregister_mode,
+)
 from openjiuwen.symphony.orchestration.service import OrchestrationService, PrepareArtifactHook
 
 __all__ = [
+    "BUILTIN_MODES",
     "CapabilityGraph",
     "GraphArtifactStatus",
     "GraphBuildResult",
@@ -18,5 +26,9 @@ __all__ = [
     "OrchestrationPlan",
     "OrchestrationProgress",
     "OrchestrationService",
+    "PlannerFactory",
     "PrepareArtifactHook",
+    "available_modes",
+    "register_mode",
+    "unregister_mode",
 ]

--- a/openjiuwen/symphony/orchestration/config.py
+++ b/openjiuwen/symphony/orchestration/config.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from openjiuwen.symphony.orchestration.modes import is_supported, unsupported_mode_error
+
 
 @dataclass(frozen=True)
 class OrchestrationConfig:
@@ -14,8 +16,8 @@ class OrchestrationConfig:
     dynamic_graph_enabled: bool = False
 
     def __post_init__(self) -> None:
-        if self.mode not in {"fast", "beam"}:
-            raise ValueError(f"Unsupported orchestration mode: {self.mode}")
+        if not is_supported(self.mode):
+            raise unsupported_mode_error(self.mode)
         if self.top_k < 1 or self.max_depth < 1:
             raise ValueError("top_k and max_depth must be positive.")
         if not 0 <= self.min_edge_confidence <= 1:

--- a/openjiuwen/symphony/orchestration/modes.py
+++ b/openjiuwen/symphony/orchestration/modes.py
@@ -1,0 +1,103 @@
+"""Registry of orchestration planning modes.
+
+The supported mode names used to be spelled out as a literal set in two
+places: ``OrchestrationConfig.__post_init__`` (validation) and
+``OrchestrationService.plan`` (dispatch). The two copies had to be kept in
+sync by hand, and an integrator could not add a planning mode without
+patching the library.
+
+This module keeps the set in one place and lets callers register extra
+modes. The built-in modes stay exactly as they were: with nothing
+registered, ``available_modes()`` is ``("fast", "beam")`` and dispatch is
+unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+BUILTIN_MODES: tuple[str, ...] = ("fast", "beam")
+"""Modes implemented by this package. They cannot be overridden."""
+
+PlannerFactory = Callable[..., Any]
+"""Builds a planner for a registered mode.
+
+Called with keyword arguments only, so new context can be added later
+without breaking existing factories. A factory currently receives:
+
+``artifacts``
+    Loaded :class:`~openjiuwen.symphony.orchestration.contracts.CapabilityGraph`
+    artifacts, already filtered by ``disabled_capability_ids``.
+``model``
+    The planning model.
+``model_response_observer``
+    Usage observer, may be ``None``.
+``config``
+    The active :class:`~openjiuwen.symphony.orchestration.config.OrchestrationConfig`.
+``candidate_skill_ids``
+    Skill ids selected by the caller, may be ``None``.
+``progress_callback``
+    Planner-level progress callback.
+``language``
+    Normalized orchestration language.
+``dynamic_overlay``
+    Session-derived edge overlay, ``{}`` when disabled.
+
+The returned object must expose ``async def plan(query: str)`` returning the
+same payload shape the built-in planners return.
+"""
+
+_EXTRA_MODES: dict[str, PlannerFactory] = {}
+
+
+def register_mode(name: str, factory: PlannerFactory) -> None:
+    """Register an additional planning mode.
+
+    Raises ``ValueError`` for an empty name or an attempt to shadow a
+    built-in mode, so a typo cannot silently replace ``fast`` or ``beam``.
+    """
+
+    normalized = str(name or "").strip()
+    if not normalized:
+        raise ValueError("Orchestration mode name must be a non-empty string.")
+    if normalized in BUILTIN_MODES:
+        raise ValueError(f"Cannot override built-in orchestration mode: {normalized}")
+    if not callable(factory):
+        raise TypeError("Orchestration mode factory must be callable.")
+    _EXTRA_MODES[normalized] = factory
+
+
+def unregister_mode(name: str) -> None:
+    """Remove a previously registered mode. Unknown names are ignored."""
+
+    _EXTRA_MODES.pop(str(name or "").strip(), None)
+
+
+def registered_modes() -> tuple[str, ...]:
+    """Return only the externally registered mode names, sorted."""
+
+    return tuple(sorted(_EXTRA_MODES))
+
+
+def available_modes() -> tuple[str, ...]:
+    """Return every accepted mode name: built-ins first, then registered."""
+
+    return (*BUILTIN_MODES, *registered_modes())
+
+
+def is_supported(name: str | None) -> bool:
+    """Return whether ``name`` is an accepted orchestration mode."""
+
+    return str(name or "").strip() in set(available_modes())
+
+
+def planner_factory(name: str | None) -> PlannerFactory | None:
+    """Return the factory for a registered mode, or ``None`` for built-ins."""
+
+    return _EXTRA_MODES.get(str(name or "").strip())
+
+
+def unsupported_mode_error(name: str | None) -> ValueError:
+    """Build the shared error for an unknown mode, listing what is accepted."""
+
+    return ValueError(f"Unsupported orchestration mode: {name}. Available modes: {', '.join(available_modes())}.")

--- a/openjiuwen/symphony/orchestration/service.py
+++ b/openjiuwen/symphony/orchestration/service.py
@@ -44,6 +44,11 @@ from openjiuwen.symphony.orchestration.graph.matcher.ontology import (
 )
 from openjiuwen.symphony.orchestration.language import resolve_orchestration_language
 from openjiuwen.symphony.orchestration.model import ModelResponseObserver
+from openjiuwen.symphony.orchestration.modes import (
+    is_supported,
+    planner_factory,
+    unsupported_mode_error,
+)
 from openjiuwen.symphony.orchestration.planning.beam import BidirectionalBeamPlanner
 from openjiuwen.symphony.orchestration.planning.fast import FastOneShotPlanner
 from openjiuwen.symphony.shared.fingerprint import Fingerprint, coerce_fingerprint
@@ -230,13 +235,25 @@ class OrchestrationService:
             disabled_capability_ids,
         )
         planning_mode = mode or self.config.mode
-        if planning_mode not in {"fast", "beam"}:
-            raise ValueError(f"Unsupported orchestration mode: {planning_mode}")
+        if not is_supported(planning_mode):
+            raise unsupported_mode_error(planning_mode)
         normalized_language = resolve_orchestration_language(language)
         selected, summary = _input_candidate_summary(candidate_ids, artifacts.skills)
         effective_overlay = dynamic_overlay if self.config.dynamic_graph_enabled and dynamic_overlay else {}
         planner: Any
-        if planning_mode == "beam":
+        factory = planner_factory(planning_mode)
+        if factory is not None:
+            planner = factory(
+                artifacts=artifacts,
+                model=self.model,
+                model_response_observer=self.model_response_observer,
+                config=self.config,
+                candidate_skill_ids=selected,
+                progress_callback=_planner_progress_callback(callback),
+                language=normalized_language,
+                dynamic_overlay=effective_overlay,
+            )
+        elif planning_mode == "beam":
             planner = BidirectionalBeamPlanner(
                 artifacts,
                 model=self.model,

--- a/tests/unit_tests/symphony/test_orchestration_modes.py
+++ b/tests/unit_tests/symphony/test_orchestration_modes.py
@@ -1,0 +1,119 @@
+import pytest
+
+from openjiuwen.symphony.orchestration import OrchestrationConfig
+from openjiuwen.symphony.orchestration.modes import (
+    BUILTIN_MODES,
+    available_modes,
+    is_supported,
+    planner_factory,
+    register_mode,
+    registered_modes,
+    unregister_mode,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Keep the process-global registry isolated between tests."""
+
+    for name in registered_modes():
+        unregister_mode(name)
+    yield
+    for name in registered_modes():
+        unregister_mode(name)
+
+
+def test_builtin_modes_are_the_default_surface() -> None:
+    assert BUILTIN_MODES == ("fast", "beam")
+    assert available_modes() == ("fast", "beam")
+    assert registered_modes() == ()
+
+
+@pytest.mark.parametrize("mode", ["fast", "beam"])
+def test_builtin_modes_are_accepted_by_config(mode: str) -> None:
+    assert OrchestrationConfig(mode=mode).mode == mode
+
+
+def test_builtin_modes_have_no_factory() -> None:
+    """Built-ins keep their in-service dispatch; only extras go through a factory."""
+
+    assert planner_factory("fast") is None
+    assert planner_factory("beam") is None
+
+
+def test_unregistered_mode_is_rejected() -> None:
+    with pytest.raises(ValueError, match="Unsupported orchestration mode: plan"):
+        OrchestrationConfig(mode="plan")
+
+
+def test_error_lists_available_modes() -> None:
+    with pytest.raises(ValueError, match="Available modes: fast, beam"):
+        OrchestrationConfig(mode="nope")
+
+
+def test_registered_mode_becomes_available() -> None:
+    def factory(**_: object) -> object:
+        return object()
+
+    register_mode("plan", factory)
+
+    assert registered_modes() == ("plan",)
+    assert available_modes() == ("fast", "beam", "plan")
+    assert is_supported("plan")
+    assert planner_factory("plan") is factory
+    assert OrchestrationConfig(mode="plan").mode == "plan"
+
+
+def test_registered_mode_is_removed_on_unregister() -> None:
+    register_mode("plan", lambda **_: None)
+    unregister_mode("plan")
+
+    assert available_modes() == ("fast", "beam")
+    with pytest.raises(ValueError):
+        OrchestrationConfig(mode="plan")
+
+
+def test_unregister_unknown_mode_is_a_no_op() -> None:
+    unregister_mode("never-registered")
+
+    assert available_modes() == ("fast", "beam")
+
+
+@pytest.mark.parametrize("mode", ["fast", "beam"])
+def test_builtin_modes_cannot_be_overridden(mode: str) -> None:
+    with pytest.raises(ValueError, match="Cannot override built-in orchestration mode"):
+        register_mode(mode, lambda **_: None)
+
+
+@pytest.mark.parametrize("name", ["", "   ", None])
+def test_blank_mode_name_is_rejected(name: object) -> None:
+    with pytest.raises(ValueError, match="non-empty string"):
+        register_mode(name, lambda **_: None)  # type: ignore[arg-type]
+
+
+def test_non_callable_factory_is_rejected() -> None:
+    with pytest.raises(TypeError, match="must be callable"):
+        register_mode("plan", "not-callable")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("name", ["", "   ", None, "unknown"])
+def test_is_supported_rejects_unknown_names(name: object) -> None:
+    assert not is_supported(name)  # type: ignore[arg-type]
+
+
+def test_mode_name_is_trimmed_on_registration() -> None:
+    register_mode("  plan  ", lambda **_: None)
+
+    assert is_supported("plan")
+    assert available_modes() == ("fast", "beam", "plan")
+
+
+def test_other_config_validation_is_unchanged() -> None:
+    """The refactor must not alter the non-mode invariants."""
+
+    with pytest.raises(ValueError, match="top_k and max_depth must be positive"):
+        OrchestrationConfig(top_k=0)
+    with pytest.raises(ValueError, match="top_k and max_depth must be positive"):
+        OrchestrationConfig(max_depth=0)
+    with pytest.raises(ValueError, match="min_edge_confidence must be between 0 and 1"):
+        OrchestrationConfig(min_edge_confidence=1.5)


### PR DESCRIPTION
Paired: [GitHub #701](https://github.com/openJiuwen-ai/agent-core/pull/701) ↔ [GitCode !2380](https://gitcode.com/openJiuwen/agent-core/merge_requests/2380)

## What changed and why

The supported planning mode names were spelled out as a literal set in two places:

- `OrchestrationConfig.__post_init__` — validation
- `OrchestrationService.plan` — dispatch

The two copies had to be kept in sync by hand, and an integrator could not add a
planning mode without patching the library.

This PR moves the set into a small registry (`orchestration/modes.py`) so there is
one source of truth, and lets callers register extra modes:

```python
from openjiuwen.symphony.orchestration import register_mode

register_mode("my-mode", my_planner_factory)
```

Built-in `fast` and `beam` keep their existing dispatch branches and cannot be
overridden — `register_mode("fast", ...)` raises rather than silently shadowing.

## Behavior

Unchanged with nothing registered:

- `available_modes()` returns `("fast", "beam")`
- `OrchestrationConfig` accepts and rejects exactly the same values
- `OrchestrationService.plan` takes the same branches as before
- other `OrchestrationConfig` invariants (`top_k`, `max_depth`,
  `min_edge_confidence`) are untouched

One user-visible difference: the error message now lists the accepted modes.

```
Unsupported orchestration mode: plan. Available modes: fast, beam.
```

The prefix is unchanged, so `pytest.raises(match="Unsupported orchestration mode")`
still matches.

## A note on `ValueError`

`.claude/rules/error-codes.md` asks for `StatusCode`-carrying exceptions. This PR
keeps the existing `ValueError` on purpose:

- it matches the surrounding module, which already raises bare `ValueError`
- changing the exception type would break callers that catch `ValueError` around
  `OrchestrationConfig` construction

Happy to migrate this call site to `StatusCode` in a separate PR if you would
like it done as its own change.

## Factory contract

A registered factory is called with keyword arguments only, so context can be
added later without breaking existing factories:

`artifacts`, `model`, `model_response_observer`, `config`, `candidate_skill_ids`,
`progress_callback`, `language`, `dynamic_overlay`

It must return an object exposing `async def plan(query: str)`.

## How to verify

```bash
uv run pytest tests/unit_tests/symphony/test_orchestration_modes.py   # 21 passed
uv run pytest tests/unit_tests/symphony/                              # regression
uv run ruff check <changed files>                                     # clean
uv run ruff format --check <changed files>                            # clean
uv run mypy <changed files>                                           # no new errors
```

Full `tests/unit_tests/symphony/` run: **554 passed, 4 failed**. The 4 failures are
pre-existing on `develop` at `cf8ed4d` — verified by stashing this branch's changes
and re-running the same 4 tests on a clean tree. They are in
`test_scanner.py` and `test_index_output_writer.py`, unrelated to orchestration
(they look Windows/symlink related in this environment).

## Breaking changes

None.
