### PR TITLE
fix(llm): read reasoning_tokens from Responses usage

### DIFF
--- a/openjiuwen/core/foundation/llm/utils/responses_utils.py
+++ b/openjiuwen/core/foundation/llm/utils/responses_utils.py
@@ -554,6 +554,11 @@ def _usage_from_payload(usage: Any, *, model_name: str) -> Optional[UsageMetadat
     if isinstance(token_details, dict):
         cache_tokens = _int_or_zero(token_details.get("cached_tokens"))
 
+    reasoning_tokens = 0
+    output_details = usage.get("output_tokens_details") or usage.get("completion_tokens_details")
+    if isinstance(output_details, dict):
+        reasoning_tokens = _int_or_zero(output_details.get("reasoning_tokens"))
+
     return UsageMetadata(
         model_name=model_name,
         input_tokens=input_tokens,
@@ -564,6 +569,7 @@ def _usage_from_payload(usage: Any, *, model_name: str) -> Optional[UsageMetadat
         cache_status="observed" if token_details is not None else None,
         cache_source="provider_usage" if token_details is not None else None,
         cache_authoritative=token_details is not None,
+        reasoning_tokens=reasoning_tokens,
     )
 
 

--- a/tests/unit_tests/core/foundation/llm/test_responses_usage_reasoning.py
+++ b/tests/unit_tests/core/foundation/llm/test_responses_usage_reasoning.py
@@ -1,0 +1,61 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+from __future__ import annotations
+
+from openjiuwen.core.foundation.llm.utils.responses_utils import parse_response
+
+
+def _payload(usage: dict) -> dict:
+    return {"output": [{"type": "message", "content": [{"type": "output_text", "text": "ok"}]}],
+            "usage": usage}
+
+
+def test_reasoning_tokens_read_from_output_tokens_details():
+    """The Responses API reports the count under ``output_tokens_details``."""
+    message = parse_response(_payload({
+        "input_tokens": 73,
+        "output_tokens": 161,
+        "output_tokens_details": {"reasoning_tokens": 65},
+        "total_tokens": 234,
+    }), model_name="gpt-5.6-luna")
+
+    assert message.usage_metadata is not None
+    assert message.usage_metadata.reasoning_tokens == 65
+
+
+def test_reasoning_tokens_read_from_completion_tokens_details():
+    """Some OpenAI-compatible providers use the chat-completions spelling."""
+    message = parse_response(_payload({
+        "input_tokens": 10,
+        "output_tokens": 20,
+        "completion_tokens_details": {"reasoning_tokens": 12},
+    }), model_name="m")
+
+    assert message.usage_metadata.reasoning_tokens == 12
+
+
+def test_reasoning_tokens_default_to_zero():
+    """Absent, malformed, or non-numeric details must not raise."""
+    for usage in (
+        {"input_tokens": 1, "output_tokens": 2},
+        {"input_tokens": 1, "output_tokens": 2, "output_tokens_details": None},
+        {"input_tokens": 1, "output_tokens": 2, "output_tokens_details": {}},
+        {"input_tokens": 1, "output_tokens": 2, "output_tokens_details": {"reasoning_tokens": "x"}},
+    ):
+        message = parse_response(_payload(usage), model_name="m")
+        assert message.usage_metadata.reasoning_tokens == 0
+
+
+def test_other_usage_fields_are_unchanged():
+    message = parse_response(_payload({
+        "input_tokens": 73,
+        "output_tokens": 161,
+        "input_tokens_details": {"cached_tokens": 40},
+        "output_tokens_details": {"reasoning_tokens": 65},
+        "total_tokens": 234,
+    }), model_name="gpt-5.6-luna")
+
+    usage = message.usage_metadata
+    assert (usage.input_tokens, usage.output_tokens) == (73, 161)
+    assert (usage.total_tokens, usage.cache_tokens) == (234, 40)


### PR DESCRIPTION
Paired: [GitHub #771](https://github.com/openJiuwen-ai/agent-core/pull/771) ↔ [GitCode !2412](https://gitcode.com/openJiuwen/agent-core/merge_requests/2412)

Fixes #767.

`UsageMetadata` declares `reasoning_tokens` and the Responses API reports the
count under `usage.output_tokens_details.reasoning_tokens`, but
`_usage_from_payload` only reads input/output/total tokens plus `cached_tokens`
from `input_tokens_details`. Every reasoning count produced on this path was 0.

`base_model_client._extract_reasoning_tokens` does not cover it either: its path
table knows `completion_tokens_details` (chat-completions) and not
`output_tokens_details` (Responses).

### Verification

Measured against `gpt-5.6-luna` with function tools and no `reasoning`
parameter: the API returned `reasoning_tokens: 65` while `UsageMetadata`
reported 0. With this change the count is carried through, and a full
multi-turn session reports it end to end.

Tests fail on 2 of 4 cases without the change and pass with it. The existing
`test_openai_account_responses_transport.py` suite still passes.

### Notes

- The `completion_tokens_details` spelling is accepted too, so providers
  returning the chat-completions shape through this path keep working.
- Adding `("output_tokens_details", "reasoning_tokens")` to
  `_extract_reasoning_tokens`'s path table would be worth doing separately, so
  both request paths agree. Happy to include it here instead if preferred.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #767
<!-- /bot1-related-issues -->
