### PR TITLE
fix(llm): stop sending `stop` to the Responses API

### DIFF
--- a/openjiuwen/core/foundation/llm/utils/responses_utils.py
+++ b/openjiuwen/core/foundation/llm/utils/responses_utils.py
@@ -68,7 +68,6 @@ def build_request_body(
         "temperature": temperature,
         "top_p": top_p,
         "max_output_tokens": max_tokens,
-        "stop": stop,
         "reasoning": reasoning,
     }
     for key, value in request_options.items():

--- a/tests/unit_tests/core/foundation/llm/test_responses_body_stop.py
+++ b/tests/unit_tests/core/foundation/llm/test_responses_body_stop.py
@@ -1,0 +1,34 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+from __future__ import annotations
+
+from openjiuwen.core.foundation.llm.schema.message import UserMessage
+from openjiuwen.core.foundation.llm.utils.responses_utils import build_request_body
+
+
+def test_stop_is_not_sent_to_the_responses_api():
+    """``/v1/responses`` has no ``stop`` parameter and rejects the request.
+
+    The endpoint answers ``Unknown parameter: 'stop'. Did you mean 'store'?``,
+    so a configured stop sequence turned every call into a 400.
+    """
+    body = build_request_body(
+        model="gpt-5.6-luna",
+        messages=[UserMessage(content="hi")],
+        stop="\n\n",
+    )
+
+    assert "stop" not in body
+
+
+def test_max_tokens_is_still_mapped_to_max_output_tokens():
+    """Guards the neighbouring mapping, which is correct and easy to disturb."""
+    body = build_request_body(
+        model="gpt-5.6-luna",
+        messages=[UserMessage(content="hi")],
+        max_tokens=256,
+    )
+
+    assert body["max_output_tokens"] == 256
+    assert "max_tokens" not in body


### PR DESCRIPTION
Paired: [GitHub #772](https://github.com/openJiuwen-ai/agent-core/pull/772) ↔ [GitCode !2413](https://gitcode.com/openJiuwen/agent-core/merge_requests/2413)

Fixes #768.

`build_request_body` wrote `stop` into the body verbatim while correctly
mapping `max_tokens` to `max_output_tokens` beside it. The Responses API has no
`stop` parameter and rejects the request:

```
400  Unknown parameter: 'stop'. Did you mean 'store'?
```

So any caller configuring a stop sequence turned **every** Responses call into a
400 — including `openai_account_model_client`, currently the only caller. It has
gone unnoticed because no caller sets one.

### Verification

Probed the endpoint directly for the parameter set it accepts; `stop` is
rejected, `max_output_tokens` is accepted.

New tests cover both the removal and the neighbouring `max_tokens` mapping,
which is correct and easy to disturb. The existing transport suite still
passes (15 passed together).

### Note

This removes the field rather than translating it, since the endpoint has no
equivalent today. Happy to map it instead if you would rather keep the
parameter meaningful for Responses callers.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #768
<!-- /bot1-related-issues -->
