### PR TITLE
fix(prompts): insert prompt attachments at a cache-stable position

### DIFF
--- a/openjiuwen/harness/deep_agent.py
+++ b/openjiuwen/harness/deep_agent.py
@@ -520,6 +520,7 @@ class DeepAgent(BaseAgent):
             new_react_config.context_engine_config = config.context_engine_config
         if config.kv_cache_affinity_config is not None:
             new_react_config.kv_cache_affinity_config = config.kv_cache_affinity_config
+            self._apply_attachment_placement(config.kv_cache_affinity_config)
         self._react_agent.configure(new_react_config)
         self._sync_prompt_builder_references()
         logger.info("[DeepAgent] Model configuration hot reloaded")
@@ -598,6 +599,16 @@ class DeepAgent(BaseAgent):
         self.system_prompt_builder = prompt_builder
         self._sync_prompt_builder_references()
         logger.info("[DeepAgent] System prompt hot reloaded")
+
+    def _apply_attachment_placement(self, kv_config: Any) -> None:
+        """Keep legacy tail placement when KV-cache affinity manages the tail.
+
+        The Ascend affinity flow evicts the attachment from the KV cache after
+        each request and its hooks expect it to be the final message; every
+        other path uses the cache-stable placement after the system messages.
+        """
+        if getattr(kv_config, "enable_kv_cache_affinity", False) is True:
+            self.prompt_attachment_manager.placement = "tail"
 
     def _sync_prompt_builder_references(self) -> None:
         """Push the current system_prompt_builder reference everywhere.
@@ -992,6 +1003,7 @@ class DeepAgent(BaseAgent):
             react_config.context_engine_config = cfg.context_engine_config
         if cfg.kv_cache_affinity_config is not None:
             react_config.kv_cache_affinity_config = cfg.kv_cache_affinity_config
+            self._apply_attachment_placement(cfg.kv_cache_affinity_config)
         react_config.workspace = cfg.workspace
         if cfg.sys_operation is not None:
             react_config.sys_operation_id = cfg.sys_operation.id

--- a/openjiuwen/harness/deep_agent.py
+++ b/openjiuwen/harness/deep_agent.py
@@ -601,14 +601,17 @@ class DeepAgent(BaseAgent):
         logger.info("[DeepAgent] System prompt hot reloaded")
 
     def _apply_attachment_placement(self, kv_config: Any) -> None:
-        """Keep legacy tail placement when KV-cache affinity manages the tail.
+        """Sync attachment placement with the KV-cache affinity setting.
 
         The Ascend affinity flow evicts the attachment from the KV cache after
-        each request and its hooks expect it to be the final message; every
-        other path uses the cache-stable placement after the system messages.
+        each request and its hooks expect it to be the final message, so it
+        keeps the legacy tail placement; every other path uses the cache-stable
+        placement after the system messages.  The sync is two-way: applying a
+        config with affinity disabled restores the stable placement rather
+        than leaving the manager stuck on tail after a hot reload.
         """
-        if getattr(kv_config, "enable_kv_cache_affinity", False) is True:
-            self.prompt_attachment_manager.placement = "tail"
+        enabled = getattr(kv_config, "enable_kv_cache_affinity", False) is True
+        self.prompt_attachment_manager.placement = "tail" if enabled else "stable"
 
     def _sync_prompt_builder_references(self) -> None:
         """Push the current system_prompt_builder reference everywhere.

--- a/openjiuwen/harness/prompts/prompt_attachment_manager.py
+++ b/openjiuwen/harness/prompts/prompt_attachment_manager.py
@@ -233,10 +233,17 @@ class PromptAttachmentContextWriter:
 class PromptAttachmentManager:
     """DeepAgent-private in-memory prompt attachment manager."""
 
-    def __init__(self, language: str = "en") -> None:
+    def __init__(self, language: str = "en", placement: str = "stable") -> None:
         self._items: dict[str, dict[str, PromptAttachment]] = {}
         self._lock = asyncio.Lock()
         self.language = language
+        # "stable": insert after the leading system messages, so every
+        # request's prompt stays a prefix of its successor and provider-side
+        # prefix caches keep extending across the conversation.
+        # "tail": legacy end-of-prompt placement, required by the Ascend
+        # KV-cache affinity flow, whose eviction hooks expect the attachment
+        # to be the final message (see kv_cache_hooks).
+        self.placement = placement
 
     def bind_context(self, ctx: Any) -> PromptAttachmentContextWriter:
         """Return a context-aware writer for rail prompt attachment migration."""
@@ -532,31 +539,44 @@ class PromptAttachmentManager:
             )
         return rendered
 
-    @staticmethod
     def inject_messages(
+        self,
         messages: list[BaseMessage],
         rendered_prompt_attachments: str,
     ) -> list[BaseMessage]:
-        """Insert attachments before any explicitly preserved trailing messages."""
+        """Insert attachments at the configured placement.
+
+        "stable" inserts after the leading system messages: the block is
+        re-rendered every request, but its position no longer moves, so each
+        request's prompt remains a prefix of the next and a provider-side
+        prefix cache keeps extending. "tail" preserves the legacy placement
+        before any explicitly preserved trailing messages.
+        """
 
         if not rendered_prompt_attachments:
             return list(messages)
 
-        tail_start = len(messages)
-        while tail_start > 0:
-            metadata = getattr(messages[tail_start - 1], "metadata", {}) or {}
-            if not bool(metadata.get(PROMPT_ATTACHMENT_PRESERVE_TAIL_METADATA_KEY)):
-                break
-            tail_start -= 1
+        if self.placement == "tail":
+            insert_at = len(messages)
+            while insert_at > 0:
+                metadata = getattr(messages[insert_at - 1], "metadata", {}) or {}
+                if not bool(metadata.get(PROMPT_ATTACHMENT_PRESERVE_TAIL_METADATA_KEY)):
+                    break
+                insert_at -= 1
+        else:
+            insert_at = 0
+            while insert_at < len(messages) and getattr(
+                messages[insert_at], "role", ""
+            ) == "system":
+                insert_at += 1
 
         # An attachment is request-scoped and not persisted in conversation
-        # history.  Preserve the marker even when upstream requires the
-        # attachment to be inserted before browser-state tail messages.
+        # history.
         attachment_message = UserMessage(
             content=rendered_prompt_attachments,
             metadata={KV_CACHE_EPHEMERAL_TAIL_METADATA: True},
         )
-        return [*messages[:tail_start], attachment_message, *messages[tail_start:]]
+        return [*messages[:insert_at], attachment_message, *messages[insert_at:]]
 
     def make_window_mutator(self, session_id: str) -> WindowMutator:
         """Build the ContextEngine final-window mutator."""

--- a/tests/unit_tests/harness/test_deep_agent.py
+++ b/tests/unit_tests/harness/test_deep_agent.py
@@ -871,6 +871,44 @@ def test_deep_agent_hot_reload_removes_and_restores_free_search(monkeypatch) -> 
             Runner.resource_mgr.remove_tool(tool.card.id)
 
 
+def test_attachment_placement_defaults_to_stable_without_affinity_config() -> None:
+    agent = create_deep_agent(
+        model=_create_dummy_model(),
+        auto_create_workspace=False,
+    )
+
+    assert agent.prompt_attachment_manager.placement == "stable"
+
+
+def test_attachment_placement_follows_kv_cache_affinity_across_reconfigure() -> None:
+    agent = create_deep_agent(
+        model=_create_dummy_model(),
+        kv_cache_affinity_config=KVCacheAffinityConfig(enable_kv_cache_affinity=True),
+        auto_create_workspace=False,
+    )
+    assert agent.prompt_attachment_manager.placement == "tail"
+
+    agent.configure(
+        DeepAgentConfig(
+            model=_create_dummy_model(),
+            kv_cache_affinity_config=KVCacheAffinityConfig(
+                enable_kv_cache_affinity=False
+            ),
+        )
+    )
+    assert agent.prompt_attachment_manager.placement == "stable"
+
+    agent.configure(
+        DeepAgentConfig(
+            model=_create_dummy_model(),
+            kv_cache_affinity_config=KVCacheAffinityConfig(
+                enable_kv_cache_affinity=True
+            ),
+        )
+    )
+    assert agent.prompt_attachment_manager.placement == "tail"
+
+
 def test_create_deep_agent_reuses_same_tool_instance_across_agents() -> None:
     tool = DummyTool("shared_tool_instance", tool_id="shared_tool_instance_id")
 

--- a/tests/unit_tests/harness/test_prompt_attachment_manager.py
+++ b/tests/unit_tests/harness/test_prompt_attachment_manager.py
@@ -8,7 +8,7 @@ import pytest
 from openjiuwen.core.context_engine.context.context import SessionModelContext
 from openjiuwen.core.context_engine.schema.config import ContextEngineConfig
 from openjiuwen.core.foundation.kv_cache import KV_CACHE_EPHEMERAL_TAIL_METADATA
-from openjiuwen.core.foundation.llm import SystemMessage, UserMessage
+from openjiuwen.core.foundation.llm import AssistantMessage, SystemMessage, UserMessage
 from openjiuwen.harness.prompts.prompt_attachment_manager import (
     PROMPT_ATTACHMENT_PRESERVE_TAIL_METADATA_KEY,
     PromptAttachment,
@@ -57,9 +57,10 @@ async def test_prompt_attachment_manager_collect_render_inject_and_update():
     injected = manager.inject_messages(original, rendered)
     assert original[-1].content == "query"
     assert len(injected) == len(original) + 1
-    assert injected[-2].content == "query"
-    assert isinstance(injected[-1], UserMessage)
-    assert injected[-1].content.startswith("<system-reminder>")
+    assert injected[0].content == "sys"
+    assert isinstance(injected[1], UserMessage)
+    assert injected[1].content.startswith("<system-reminder>")
+    assert injected[-1].content == "query"
 
     updated = await manager.update_by_id(runtime.id, PromptAttachmentUpdate(content="updated runtime"))
     assert updated.content == "updated runtime"
@@ -271,7 +272,7 @@ def test_prompt_attachment_manager_render_escapes_xml():
     assert "&lt;raw&gt;&amp;value" in rendered
 
 
-def test_prompt_attachment_manager_appends_attachment_message_after_multimodal_user_message():
+def test_prompt_attachment_manager_inserts_attachment_before_multimodal_user_message():
     manager = PromptAttachmentManager()
     original = [
         UserMessage(content=[
@@ -283,16 +284,16 @@ def test_prompt_attachment_manager_appends_attachment_message_after_multimodal_u
     injected = manager.inject_messages(original, "<system-reminder>attached</system-reminder>")
 
     assert original[-1].content[0]["text"] == "query"
-    assert injected[-2].content == original[-1].content
-    assert isinstance(injected[-1], UserMessage)
-    assert injected[-1].content == "<system-reminder>attached</system-reminder>"
+    assert injected[-1].content == original[-1].content
+    assert isinstance(injected[0], UserMessage)
+    assert injected[0].content == "<system-reminder>attached</system-reminder>"
     assert (
-        injected[-1].metadata[KV_CACHE_EPHEMERAL_TAIL_METADATA]
+        injected[0].metadata[KV_CACHE_EPHEMERAL_TAIL_METADATA]
         is True
     )
 
 
-def test_prompt_attachment_manager_appends_attachment_message_after_image_only_user_message():
+def test_prompt_attachment_manager_inserts_attachment_before_image_only_user_message():
     manager = PromptAttachmentManager()
     original = [
         UserMessage(content=[
@@ -302,13 +303,37 @@ def test_prompt_attachment_manager_appends_attachment_message_after_image_only_u
 
     injected = manager.inject_messages(original, "<system-reminder>attached</system-reminder>")
 
-    assert injected[-2].content == original[-1].content
-    assert isinstance(injected[-1], UserMessage)
-    assert injected[-1].content == "<system-reminder>attached</system-reminder>"
+    assert injected[-1].content == original[-1].content
+    assert isinstance(injected[0], UserMessage)
+    assert injected[0].content == "<system-reminder>attached</system-reminder>"
 
 
-def test_prompt_attachment_manager_inserts_attachment_before_preserved_tail():
+def test_prompt_attachment_manager_stable_placement_precedes_the_conversation():
     manager = PromptAttachmentManager()
+    state = UserMessage(
+        content="<browser_state>current</browser_state>",
+        metadata={PROMPT_ATTACHMENT_PRESERVE_TAIL_METADATA_KEY: True},
+    )
+    progress = UserMessage(
+        content='<browser_state_progress>{"page_change":"unchanged"}</browser_state_progress>',
+        metadata={PROMPT_ATTACHMENT_PRESERVE_TAIL_METADATA_KEY: True},
+    )
+    original = [UserMessage(content="query"), state, progress]
+
+    injected = manager.inject_messages(original, "<system-reminder>attached</system-reminder>")
+
+    assert [message.content for message in injected] == [
+        "<system-reminder>attached</system-reminder>",
+        "query",
+        state.content,
+        progress.content,
+    ]
+    assert injected[-2] is state
+    assert injected[-1] is progress
+
+
+def test_prompt_attachment_manager_tail_placement_keeps_legacy_order():
+    manager = PromptAttachmentManager(placement="tail")
     state = UserMessage(
         content="<browser_state>current</browser_state>",
         metadata={PROMPT_ATTACHMENT_PRESERVE_TAIL_METADATA_KEY: True},
@@ -329,6 +354,26 @@ def test_prompt_attachment_manager_inserts_attachment_before_preserved_tail():
     ]
     assert injected[-2] is state
     assert injected[-1] is progress
+
+
+def test_prompt_attachment_manager_keeps_request_prompts_prefix_stable():
+    """Each request's injected prompt must be a prefix of the next request's.
+
+    This is the property provider-side prefix caches bill by: with the
+    attachment at the tail, request n's prompt is never a prefix of request
+    n+1's, and the cache never extends past the static prefix.
+    """
+    manager = PromptAttachmentManager()
+    reminder = "<system-reminder>attached</system-reminder>"
+    first = [SystemMessage(content="sys"), UserMessage(content="q1")]
+    second = [*first, AssistantMessage(content="a1"), UserMessage(content="q2")]
+
+    injected_first = manager.inject_messages(first, reminder)
+    injected_second = manager.inject_messages(second, reminder)
+
+    assert [m.content for m in injected_second[: len(injected_first)]] == [
+        m.content for m in injected_first
+    ]
 
 
 def test_prompt_attachment_guidance_is_rendered_only_with_attachments():

--- a/tests/unit_tests/harness/tools/browser_move/test_browser_state_context_processor.py
+++ b/tests/unit_tests/harness/tools/browser_move/test_browser_state_context_processor.py
@@ -305,8 +305,10 @@ async def test_prompt_attachments_remain_before_browser_state_and_progress_tail(
     window = await context.get_context_window()
     messages = window.context_messages
 
-    assert "<system-reminder>" in messages[-3].content
-    assert "runtime attachment" in messages[-3].content
+    # Stable placement puts the attachment ahead of the conversation; the
+    # preserved browser-state messages still close the prompt.
+    assert "<system-reminder>" in messages[0].content
+    assert "runtime attachment" in messages[0].content
     assert messages[-2].name == "current_browser_state"
     assert messages[-1].name == "browser_state_progress"
 


### PR DESCRIPTION
Paired: [GitHub #796](https://github.com/openJiuwen-ai/agent-core/pull/796) ↔ [GitCode !2431](https://gitcode.com/openJiuwen/agent-core/merge_requests/2431)

Fixes #795.

`inject_messages` appends the rendered attachment block as the final user
message, and the block leaves that position before the next request — so no
request's prompt is ever a prefix of its successor, and provider-side prompt
caches only extend a cache entry when it is. Measured on the api-key path
(`gpt-5.6-luna`, jiuwenswarm 0.2.3 / openjiuwen 0.1.16): `cached_tokens`
stays pinned at the static prefix for entire sessions (`n_calls × 18,587`)
while `rendered_prompt_attachment_hash` never changes — the spend buys the
movement of an unchanged block, ~5× the input cost of comparable agents on
the same tasks. Details and probes in #795.

This PR makes the placement explicit on `PromptAttachmentManager`:

- `placement="stable"` (default): insert after the leading system messages.
  The conversation behind the block stays append-only, so each request
  extends the previous one's cache entry. The block still re-renders every
  call; changed content still reaches the model and still busts the cache
  once, which is the correct price.
- `placement="tail"`: the previous behaviour, kept for the Ascend KV-cache
  affinity flow — its eviction hooks require the attachment to be the final
  message (`kv_cache_hooks._is_attachment_tail_only_change`). `DeepAgent`
  selects it automatically when `enable_kv_cache_affinity` is on, so that
  path is unchanged (#674's design).

### Verification

- With this placement applied to 0.1.16, the same sessions measure a 99%
  per-call cache hit rate and 80.8% of a whole session's input tokens served
  from cache (cold call included), against sessions that previously re-read
  only the static prefix on every call.
- `tests/unit_tests/harness/test_prompt_attachment_manager.py`: existing
  cases updated to the stable order; new cases pin the legacy tail order
  under `placement="tail"` and the prefix-stability property itself (request
  n's injected prompt is a list prefix of request n+1's). 15/15 pass.
- Full `tests/unit_tests/harness`: 3178 passed, 1 pre-existing failure
  unrelated to this change
  (`test_resolve_deep_agent_parts_adds_rl_online_rail_from_env` fails
  identically on unmodified `develop`).

### Notes

- The `KV_CACHE_EPHEMERAL_TAIL_METADATA` stamp is kept on the injected
  message under both placements, so the affinity hooks see the marker they
  see today.
- The browser-state processor test now expects the attachment ahead of the
  conversation; the preserved `current_browser_state` / progress messages
  still close the prompt under both placements.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #674
- Fixes #795
<!-- /bot1-related-issues -->
