### PR TITLE
fix(rails): make opentelemetry imports optional in the rails import chain

### DIFF
--- a/openjiuwen/agent_evolving/trajectory/processor.py
+++ b/openjiuwen/agent_evolving/trajectory/processor.py
@@ -23,7 +23,22 @@ from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Any, Iterator, Mapping
 
-from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
+try:
+    from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
+except ImportError:  # pragma: no cover - exercised via the optional-otel test
+    # The OpenTelemetry SDK ships with the optional ``observability`` extra.
+    # Without it no observability spans are ever produced, so span capture is
+    # disabled: the processor stays importable and inert instead of breaking
+    # every ``openjiuwen.harness.rails`` import at module load time.
+    ReadableSpan = Any  # type: ignore[assignment,misc]
+
+    class SpanProcessor:  # type: ignore[no-redef]
+        """Minimal stand-in for ``opentelemetry.sdk.trace.SpanProcessor``."""
+
+    logging.getLogger(__name__).warning(
+        "opentelemetry-sdk is not installed; trajectory span capture is disabled. "
+        "Install the 'observability' extra (pip install 'openjiuwen[observability]') to enable it."
+    )
 
 from openjiuwen.agent_evolving.trajectory.model import Trajectory
 from openjiuwen.agent_evolving.trajectory.schema import TRAJECTORY_ID

--- a/openjiuwen/extensions/observability/span_context.py
+++ b/openjiuwen/extensions/observability/span_context.py
@@ -10,8 +10,26 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any, cast
 
-from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
-from opentelemetry.trace import Span
+try:
+    from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
+    from opentelemetry.trace import Span
+except ImportError:  # pragma: no cover - exercised via the optional-otel test
+    # OpenTelemetry ships with the optional ``observability`` extra.  Without
+    # it no spans are ever produced, so span tracking is disabled: the module
+    # stays importable and inert instead of breaking every importer (e.g.
+    # ``openjiuwen.harness.rails``) at module load time.
+    import logging as _stdlib_logging
+
+    ReadableSpan = Any  # type: ignore[assignment,misc]
+    Span = Any  # type: ignore[assignment,misc]
+
+    class SpanProcessor:  # type: ignore[no-redef]
+        """Minimal stand-in for ``opentelemetry.sdk.trace.SpanProcessor``."""
+
+    _stdlib_logging.getLogger(__name__).warning(
+        "opentelemetry is not installed; observability span tracking is disabled. "
+        "Install the 'observability' extra (pip install 'openjiuwen[observability]') to enable it."
+    )
 
 from openjiuwen.core.common.logging import logger
 from openjiuwen.core.foundation.llm.call_scope import get_current_llm_call_id

--- a/tests/unit_tests/extensions/observability/test_import_boundary.py
+++ b/tests/unit_tests/extensions/observability/test_import_boundary.py
@@ -33,3 +33,51 @@ shutdown_observability()
     )
 
     assert result.returncode == 0, result.stderr
+
+
+def test_rails_import_without_opentelemetry() -> None:
+    """The optional ``observability`` extra must not gate harness rail imports.
+
+    OpenTelemetry ships with the ``observability`` extra only, so importing
+    ``openjiuwen.harness.rails`` must survive its absence: span capture
+    degrades to inert processors with a warning instead of an ImportError.
+    """
+    project_root = Path(__file__).resolve().parents[4]
+    script = """
+import importlib.abc
+import sys
+
+
+class _BlockOpentelemetry(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "opentelemetry" or fullname.startswith("opentelemetry."):
+            raise ImportError(f"blocked for test: {fullname}")
+        return None
+
+
+sys.meta_path.insert(0, _BlockOpentelemetry())
+
+import openjiuwen.harness.rails  # noqa: F401
+from openjiuwen.agent_evolving.trajectory.processor import TrajectorySpanProcessor
+from openjiuwen.extensions.observability.span_context import ActiveSpanTracker
+
+assert not [name for name in sys.modules if name.startswith("opentelemetry")]
+
+processor = TrajectorySpanProcessor()
+subscription = processor.subscribe(include_span_categories={"llm"})
+assert processor.drain(subscription) == (None, ())
+ActiveSpanTracker()
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=project_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    combined = result.stdout + result.stderr
+    assert "trajectory span capture is disabled" in combined
+    assert "observability span tracking is disabled" in combined


### PR DESCRIPTION
Paired: [GitHub #858](https://github.com/openJiuwen-ai/agent-core/pull/858) ↔ [GitCode !2462](https://gitcode.com/openJiuwen/agent-core/merge_requests/2462)

## Problem

`openjiuwen.harness.rails` cannot be imported unless the `observability` extra is installed, even though the core dependencies declare no opentelemetry package at all. `pyproject.toml` puts `opentelemetry-api` and `opentelemetry-sdk` under the `observability` extra only, so a default install produces an import chain that raises `ImportError` at the first `import openjiuwen.harness.rails`.

Two top-level imports break it. Both were found by reproducing the failure, not by reading the tree:

| # | File:line | Import |
|---|---|---|
| 1 | `openjiuwen/agent_evolving/trajectory/processor.py:26` | `from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor` |
| 2 | `openjiuwen/extensions/observability/span_context.py:13-14` | `from opentelemetry.sdk.trace import ...` + `from opentelemetry.trace import Span` |

The second one only surfaces after the first is fixed, which is why it is easy to miss. Every other otel reference on the chain is already a lazy in-function import and needed no change.

## Approach

Both sites get the same `try/except ImportError` guard that this tree already uses elsewhere (for example `agent_teams/messager/pyzmq_backend.py`). The guarded symbols degrade safely because their uses are symmetric:

- `ReadableSpan` / `Span` appear only in annotations — both modules already have `from __future__ import annotations` — and as the first argument to `cast()`. They fall back to `Any`.
- `SpanProcessor` is the base class of `TrajectorySpanProcessor` and `ActiveSpanTracker`. In the upstream SDK it is a pure interface whose methods are all no-ops, and both subclasses override everything they use, so it falls back to a stub base class.

A single `logger.warning` fires when the packages are absent, naming the extra to install. Nothing is swallowed silently. In the degraded state no real spans can be produced anyway, since the span-producing code path itself requires opentelemetry; the processors stay constructible and `subscribe`/`drain` continue to behave.

## Test

Adds `test_rails_import_without_opentelemetry` to the existing import-boundary contract test, following the subprocess pattern of its neighbours in that file: a `MetaPathFinder` masks the entire `opentelemetry` namespace, then `import openjiuwen.harness.rails` must succeed, `sys.modules` must contain no otel module, the degraded processors must still subscribe/drain and construct, and both degradation warnings must appear in the output.

## Verification

Run against `develop` @ `4f2c29c`:

- `pytest tests/unit_tests/extensions/observability/test_import_boundary.py tests/unit_tests/agent_evolving/trajectory/test_processor.py` — **10 passed**
- `ruff check` clean on all three changed files
- End-to-end reproduction: with the whole `opentelemetry` namespace masked, `import openjiuwen.harness.rails` fails before the change and succeeds after, emitting both warnings

Diffstat: `processor.py` +16 −1, `span_context.py` +20 −2, `test_import_boundary.py` +48 −0.

## Note

One pre-existing failure is worth flagging so it is not mistaken for fallout from this change: `tests/unit_tests/extensions/observability/test_span_context.py` shows 3 failures in my environment, and it shows the same 3 failures on an unmodified tree. They come from a local otel api/sdk version mismatch (`TraceFlags.RANDOM_TRACE_ID` missing, sdk newer than api), unrelated to this patch.
