### PR TITLE
fix(agent-teams): validate structured output before capture

### DIFF
--- a/openjiuwen/agent_teams/tools/structured_output_tool.py
+++ b/openjiuwen/agent_teams/tools/structured_output_tool.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from typing import Any, AsyncIterator
 
+from jsonschema import validate as validate_json_schema
+
 from openjiuwen.agent_teams.tools.locales import Translator, make_translator
 from openjiuwen.core.foundation.tool import ToolCard
 from openjiuwen.core.foundation.tool.base import Tool
@@ -54,8 +56,9 @@ class StructuredOutputTool(Tool):
     Args:
         schema_json: The JSON Schema the engine requested for this ``agent()``
             call. Becomes the tool's ``input_params`` so the model's tool-use
-            layer constrains the arguments to the schema. ``None`` falls back to
-            a generic ``{"result": str}`` schema.
+            layer exposes the schema, while ``invoke`` performs authoritative
+            runtime validation. ``None`` falls back to a generic
+            ``{"result": str}`` schema.
         t: The language-bound translator used to resolve the description. When
             omitted a default (``cn``) translator is created.
         tool_id: Resource-manager id for the tool. Defaults to a stable id; when
@@ -84,7 +87,16 @@ class StructuredOutputTool(Tool):
         self.called: bool = False
 
     async def invoke(self, inputs: dict[str, Any], **kwargs: Any) -> ToolOutput:
-        """Capture the structured result and acknowledge the submission."""
+        """Validate and capture a schema-conforming structured result.
+
+        Tool schemas guide providers but do not guarantee valid arguments on
+        every OpenAI-compatible endpoint. Raising on invalid input routes the
+        validation error through the normal tool-exception path, where the
+        model can repair its payload on a later ReAct turn. State is latched
+        only after validation succeeds, so the finish rail cannot end a worker
+        with an invalid capture.
+        """
+        validate_json_schema(instance=inputs, schema=self.card.input_params)
         self.captured = inputs
         self.called = True
         return ToolOutput(success=True, data={"accepted": True})

--- a/tests/unit_tests/agent_teams/tools/test_structured_output_tool.py
+++ b/tests/unit_tests/agent_teams/tools/test_structured_output_tool.py
@@ -11,6 +11,9 @@ from __future__ import annotations
 import asyncio
 from types import SimpleNamespace
 
+import pytest
+from jsonschema import ValidationError
+
 from openjiuwen.agent_teams.tools.structured_output_tool import (
     StructuredOutputFinishRail,
     StructuredOutputTool,
@@ -49,6 +52,27 @@ def test_invoke_captures_arguments():
     assert out.success is True
     assert tool.called is True
     assert tool.captured == {"answer": "42"}
+
+
+def test_invoke_rejects_invalid_arguments_without_latching_state():
+    """Runtime validation leaves room for a later corrected submission."""
+    schema = {
+        "type": "object",
+        "properties": {"query_coverage": {"type": "object"}},
+        "required": ["query_coverage"],
+    }
+    tool = StructuredOutputTool(schema)
+
+    with pytest.raises(ValidationError, match="is not of type 'object'"):
+        asyncio.run(tool.invoke({"query_coverage": ""}))
+
+    assert tool.called is False
+    assert tool.captured is None
+
+    asyncio.run(tool.invoke({"query_coverage": {}}))
+
+    assert tool.called is True
+    assert tool.captured == {"query_coverage": {}}
 
 
 def test_default_schema_when_none():


### PR DESCRIPTION
Paired: [GitHub #860](https://github.com/openJiuwen-ai/agent-core/pull/860) ↔ [GitCode !2464](https://gitcode.com/openJiuwen/agent-core/merge_requests/2464)

# fix(agent-teams): validate structured output before capture

## 背景

`StructuredOutputTool` 会将 JSON Schema 暴露为工具参数，但 OpenAI-compatible provider 不一定在服务端严格执行该 schema。当 provider 返回不合法参数时，现有实现仍会设置 `called/captured`，`StructuredOutputFinishRail` 随后可能将无效提交当成完成状态。

## 修改

- 在捕获 structured output 前调用 `jsonschema.validate`。
- 只有校验成功后才设置 `called` 和 `captured`。
- 无效参数继续走现有工具异常路径，模型可在后续 ReAct 轮次修正并重新提交。

## 兼容性

- 所有符合 schema 的现有调用行为不变。
- 唯一行为变化是：以前会被误接受的无效工具参数现在抛出 `ValidationError`。

## 测试

```bash
pytest tests/unit_tests/agent_teams/tools/test_structured_output_tool.py -q
ruff check \
  openjiuwen/agent_teams/tools/structured_output_tool.py \
  tests/unit_tests/agent_teams/tools/test_structured_output_tool.py
```

结果：8 passed；Ruff passed。

