### PR TITLE
fix(team-workspace): decode mklink output with the OEM code page

### DIFF
--- a/openjiuwen/agent_teams/team_workspace/manager.py
+++ b/openjiuwen/agent_teams/team_workspace/manager.py
@@ -252,12 +252,25 @@ class TeamWorkspaceManager:
 
     @staticmethod
     def _create_windows_junction(target_path: str, link_path: str) -> None:
-        """Create a directory junction using mklink /J on Windows."""
+        """Create a directory junction using mklink /J on Windows.
+
+        ``cmd.exe`` emits its localized messages in the OEM code page, which is
+        not necessarily the encoding ``text=True`` would pick: on a system where
+        ``locale.getpreferredencoding(False)`` resolves to UTF-8 (Windows 11's
+        "Use Unicode UTF-8 worldwide language support", or Python UTF-8 mode)
+        the two disagree, and a non-ASCII failure message such as the Chinese
+        text for "the client does not hold the required privilege" raises
+        ``UnicodeDecodeError`` inside ``subprocess``'s reader thread rather than
+        surfacing as the intended ``OSError``. Decode with the OEM code page and
+        never let a decoding mismatch mask the real failure.
+        """
         cmd_path = os.path.join(os.environ.get("SystemRoot", r"C:\Windows"), "System32", "cmd.exe")
         result = subprocess.run(
             [cmd_path, "/c", "mklink", "/J", link_path, target_path],
             capture_output=True,
             text=True,
+            encoding="oem",
+            errors="replace",
             check=False,
             shell=False,
         )

--- a/tests/unit_tests/agent_teams/team_workspace/test_manager.py
+++ b/tests/unit_tests/agent_teams/team_workspace/test_manager.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import errno
 import os
+import sys
+import subprocess
 from types import SimpleNamespace
 
 import pytest
@@ -112,15 +114,8 @@ def test_mount_into_workspace_falls_back_to_junction_on_windows_1314(monkeypatch
         error.winerror = ERROR_PRIVILEGE_NOT_HELD
         raise error
 
-    def fake_run(command, capture_output, text, check, shell=False):
-        junction_calls.append(
-            {
-                "command": command,
-                "capture_output": capture_output,
-                "text": text,
-                "check": check,
-            }
-        )
+    def fake_run(command, **kwargs):
+        junction_calls.append({"command": command, **kwargs})
         return SimpleNamespace(returncode=0, stdout="ok", stderr="")
 
     monkeypatch.setattr(os, "symlink", fake_symlink)
@@ -135,6 +130,11 @@ def test_mount_into_workspace_falls_back_to_junction_on_windows_1314(monkeypatch
     assert junction_calls[0]["capture_output"] is True
     assert junction_calls[0]["text"] is True
     assert junction_calls[0]["check"] is False
+    # cmd.exe writes in the OEM code page; decoding it as whatever
+    # locale.getpreferredencoding(False) happens to be raises UnicodeDecodeError
+    # in subprocess's reader thread and masks the real failure.
+    assert junction_calls[0]["encoding"] == "oem"
+    assert junction_calls[0]["errors"] == "replace"
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows junction fallback only applies on Windows")
 @pytest.mark.level0
@@ -346,3 +346,48 @@ async def test_pull_push_history_noop_when_version_control_disabled(monkeypatch,
     assert await manager.push() is True
     assert await manager.get_history("artifacts/code/a.py") == []
     assert recorder.calls == []
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Junction creation only happens on Windows")
+def test_junction_decodes_oem_output_without_crashing():
+    """A localized cmd.exe failure must not be decoded as UTF-8.
+
+    ``cmd.exe`` writes its messages in the OEM code page. When
+    ``locale.getpreferredencoding(False)`` resolves to UTF-8 -- which happens
+    under Windows 11's "Use Unicode UTF-8 worldwide language support" and under
+    Python UTF-8 mode -- a bare ``text=True`` decodes those bytes as UTF-8 and
+    raises ``UnicodeDecodeError`` inside subprocess's reader thread, masking the
+    real failure. Reproduce the byte sequence and pin the decoding contract.
+    """
+    payload = b"\xb4\xed\xce\xf3"          # OEM (cp936) bytes; invalid UTF-8
+    script = "import sys; sys.stdout.buffer.write(%r); raise SystemExit(1)" % payload
+
+    with pytest.raises(UnicodeDecodeError):
+        payload.decode("utf-8")
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        encoding="oem",
+        errors="replace",
+        check=False,
+    )
+    assert result.returncode == 1
+    assert isinstance(result.stdout, str)
+    assert result.stdout != ""
+
+
+def test_junction_failure_surfaces_as_oserror(monkeypatch, tmp_path):
+    """Whatever the message decodes to, a failed mklink must raise OSError."""
+    from openjiuwen.agent_teams.team_workspace import manager as manager_module
+
+    def fake_run(command, **kwargs):
+        assert kwargs.get("errors") == "replace"
+        return SimpleNamespace(returncode=1, stdout="", stderr="privilege not held")
+
+    monkeypatch.setattr(manager_module.subprocess, "run", fake_run)
+    with pytest.raises(OSError) as excinfo:
+        manager_module.TeamWorkspaceManager._create_windows_junction(
+            str(tmp_path / "target"), str(tmp_path / "link"))
+    assert "privilege not held" in str(excinfo.value)


### PR DESCRIPTION
Paired: [GitHub #861](https://github.com/openJiuwen-ai/agent-core/pull/861) ↔ [GitCode !2465](https://gitcode.com/openJiuwen/agent-core/merge_requests/2465)

## Problem

`TeamWorkspaceManager._create_windows_junction` shells out to `cmd.exe /c mklink /J` with `capture_output=True, text=True` and neither `encoding=` nor `errors=`:

```python
result = subprocess.run(
    [cmd_path, "/c", "mklink", "/J", link_path, target_path],
    capture_output=True,
    text=True,
    check=False,
    shell=False,
)
```

`cmd.exe` writes its localized messages in the **OEM code page**, while `text=True` decodes with `locale.getpreferredencoding(False)`. Those are not the same thing, and on a machine where the preferred encoding resolves to UTF-8 — Windows 11's *Use Unicode UTF-8 for worldwide language support*, or Python UTF-8 mode — a non-ASCII failure message raises `UnicodeDecodeError` **inside subprocess's reader thread**. The intended `OSError` never surfaces; instead the caller sees a stack trace from a thread it does not own, and the real reason for the failure is lost.

This is not hypothetical. It reproduced during a long multi-agent team run on a Chinese-locale Windows 11 host:

```
Exception in thread Thread-3 (_readerthread):
Traceback (most recent call last):
  ...
  File "subprocess.py", line 1599, in _readerthread
    buffer.append(fh.read())
  File "<frozen codecs>", line 322, in decode
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb4 in position 292: invalid start byte
```

immediately followed by the `Symlink privilege unavailable on Windows; mounted ... via junction` log line. `0xb4` is a lead byte of the localized "the client does not hold the required privilege" text.

## Approach

Decode with the code page `cmd.exe` actually uses, and never let a decoding mismatch become a crash:

```python
encoding="oem",
errors="replace",
```

`_create_windows_junction` is Windows-only by construction, so the `oem` codec is always available on the path that runs it. `errors="replace"` guarantees that even an unexpected code page degrades to a readable message rather than masking the failure.

There is precedent for exactly this pattern in the sibling repository: `jiuwenswarm/agents/harness/common/tools/command_tools.py` picks an encoding per resolved shell and pairs it with `errors="replace"` for the same reason.

## Test

- **`test_junction_decodes_oem_output_without_crashing`** — spawns a real subprocess that writes OEM bytes, first asserting those bytes genuinely fail to decode as UTF-8, then asserting the patched parameters decode them without raising and return a non-empty string. This reproduces the failing condition rather than merely asserting on keyword arguments.
- **`test_junction_failure_surfaces_as_oserror`** — a failed `mklink` must raise `OSError` carrying the message.
- **`test_mount_into_workspace_falls_back_to_junction_on_windows_1314`** (existing) — its fake now accepts `**kwargs` and pins `encoding="oem"` / `errors="replace"`, so the regression cannot silently return.

`pytest tests/unit_tests/agent_teams/team_workspace/` → **27 passed** on `develop` @ `4f2c29c`. `ruff check` clean on both changed files.

Diffstat: `manager.py` +14 −1, `test_manager.py` +54 −9.

## A wider finding, deliberately left out of this PR

Scanning the tree for `subprocess.run` / `subprocess.Popen` calls that combine text mode with pipes but pass no `errors=`, I count **13 sites**, including:

- `openjiuwen/rsi/auto_harness/infra/github_cli.py` (2)
- `openjiuwen/harness/workspace/workspace.py`
- `openjiuwen/harness/tools/browser_move/drivers/managed_browser.py` (2)
- `openjiuwen/harness/cli/prompts/builder.py`
- `openjiuwen/extensions/sys_operation/sandbox/providers/jiuwenbox.py` (3)
- `openjiuwen/agent_evolving/evaluator/...` (3)

Each carries the same latent failure mode, but I have observed a crash in only one of them. I have kept this PR to the site with reproduced evidence rather than bundling twelve speculative edits; happy to follow up separately if maintainers would like the sweep.
