### PR TITLE
perf(pregel): cache selector signature and async shape at construction time

### DIFF
--- a/openjiuwen/core/graph/pregel/router.py
+++ b/openjiuwen/core/graph/pregel/router.py
@@ -28,16 +28,18 @@ class ConditionalRouter(IRouter):
 
     def __init__(self, selector: SelectorProtocol):
         self.selector = selector
+        self._accepts_state = "state" in inspect.signature(selector).parameters
+        self._is_async = asyncio.iscoroutinefunction(selector) or asyncio.iscoroutinefunction(
+            getattr(selector, "__call__", None)
+        )
 
     async def dispatch(self, source_node: str) -> List[Message]:
-        sig = inspect.signature(self.selector)
         kwargs = {}
 
-        if 'state' in sig.parameters:
+        if self._accepts_state:
             kwargs['state'] = None
 
-        if asyncio.iscoroutinefunction(self.selector) or asyncio.iscoroutinefunction(
-                getattr(self.selector, "__call__", None)):
+        if self._is_async:
             targets = await self.selector(**kwargs)
         else:
             targets = self.selector(**kwargs)

--- a/tests/unit_tests/core/graph/test_pregel.py
+++ b/tests/unit_tests/core/graph/test_pregel.py
@@ -2,6 +2,8 @@
 # Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
 
 import asyncio
+import inspect
+from unittest.mock import patch
 
 import pytest
 
@@ -29,6 +31,38 @@ from openjiuwen.core.graph.pregel.router import (
     StaticRouter,
 )
 from openjiuwen.core.session.checkpointer import CheckpointerFactory
+
+
+@pytest.mark.asyncio
+async def test_conditional_router_analyzes_selector_once():
+    def selector(state):
+        assert state is None
+        return "target"
+
+    with patch(
+        "openjiuwen.core.graph.pregel.router.inspect.signature",
+        wraps=inspect.signature,
+    ) as mock_signature:
+        router = ConditionalRouter(selector)
+        first = await router.dispatch("source")
+        second = await router.dispatch("source")
+
+    assert mock_signature.call_count == 1
+    assert [message.target for message in first] == ["target"]
+    assert [message.target for message in second] == ["target"]
+
+
+@pytest.mark.asyncio
+async def test_conditional_router_supports_async_callable_object():
+    class AsyncSelector:
+        async def __call__(self):
+            return ["first", "second"]
+
+    router = ConditionalRouter(AsyncSelector())
+
+    messages = await router.dispatch("source")
+
+    assert [message.target for message in messages] == ["first", "second"]
 
 
 @pytest.fixture


### PR DESCRIPTION
Paired: [GitHub #954](https://github.com/openJiuwen-ai/agent-core/pull/954) ↔ [GitCode !2527](https://gitcode.com/openJiuwen/agent-core/merge_requests/2527)

## Summary

Cache selector signature analysis and async detection at `ConditionalRouter` construction time instead of re-analyzing on every `dispatch()` call.

## Problem

`ConditionalRouter.dispatch()` calls `inspect.signature()` and `asyncio.iscoroutinefunction()` on every invocation. These reflection operations add overhead in hot routing loops.

## Solution

- `ConditionalRouter.__init__()` now pre-computes and caches:
  - `_accepts_state`: whether the selector accepts a `state` parameter
  - `_is_async`: whether the selector is async or an async callable object
- `dispatch()` reads cached attributes instead of re-analyzing

## Changes

- `openjiuwen/core/graph/pregel/router.py`: cache selector analysis at construction time
- `tests/unit_tests/core/graph/test_pregel.py`: add regression tests

## Tests

- All 58 existing tests pass
- `test_conditional_router_analyzes_selector_once`: asserts `inspect.signature` called exactly once
- `test_conditional_router_supports_async_callable_object`: covers async callable objects
