### PR TITLE
fix: 为 Agent 工具 HTTP 请求补充超时与响应状态校验

### DIFF
--- a/openjiuwen/core/single_agent/skills/remote_skill_util.py
+++ b/openjiuwen/core/single_agent/skills/remote_skill_util.py
@@ -88,7 +88,8 @@ class RemoteSkillUtil:
 
         if len(relative_directory.parts) == 0: # Fetch entire tree
             # NOTE: "recursive" only checks whether it is set or not. Remove the param to not use recursive.
-            resp = requests.get(url, headers=headers, params={"recursive": "492"})
+            resp = requests.get(url, headers=headers, params={"recursive": "492"}, timeout=10)
+            resp.raise_for_status()
             data = resp.json()
             if "message" in data:
                 raise Exception(data["message"])
@@ -102,7 +103,8 @@ class RemoteSkillUtil:
                 file["path"] = current_directory / file["path"]
             return files, data.get("truncated", False)
         else: # Search for relative_directory
-            resp = requests.get(url, headers=headers, params={})
+            resp = requests.get(url, headers=headers, params={}, timeout=10)
+            resp.raise_for_status()
             data = resp.json()
             if "message" in data:
                 raise GitHubError(data["message"])
@@ -150,7 +152,7 @@ class RemoteSkillUtil:
             headers["Authorization"] = f"Bearer {token}"
 
         url = f"https://api.github.com/repos/{tree.repo_owner}/{tree.repo_name}/contents/{file_path}"
-        resp = requests.get(url, headers=headers, params={"ref": tree.tree_ref})
+        resp = requests.get(url, headers=headers, params={"ref": tree.tree_ref}, timeout=10)
 
         if resp.status_code != 200:
             raise GitHubError(f"HTTP {resp.status_code} while downloading {file_path}")

--- a/openjiuwen/extensions/context_evolver/tool/wikipedia_tool.py
+++ b/openjiuwen/extensions/context_evolver/tool/wikipedia_tool.py
@@ -33,7 +33,7 @@ def search_wikipedia(query: str) -> str:
     
     try:
         # First, search for the page
-        response = requests.get(url, params=params, headers=headers)
+        response = requests.get(url, params=params, headers=headers, timeout=10)
         response.raise_for_status()
         search_results = response.json().get("query", {}).get("search", [])
         
@@ -54,7 +54,7 @@ def search_wikipedia(query: str) -> str:
             "exlimit": 1
         }
         
-        summary_response = requests.get(url, params=summary_params, headers=headers)
+        summary_response = requests.get(url, params=summary_params, headers=headers, timeout=10)
         summary_response.raise_for_status()
         
         pages = summary_response.json().get("query", {}).get("pages", {})


### PR DESCRIPTION
## 背景

`requests` 默认无超时（`timeout=None`）。`wikipedia_tool` 与 `remote_skill_util` 中的 5 处 HTTP 调用未设置 `timeout`，端点不可达/慢响应时 Agent 任务无限挂起；`remote_skill_util` 前两处在 `resp.json()` 前未校验 HTTP 状态码，非 200/非 JSON 响应直接抛未捕获异常。详见 issue #952。

## 问题影响

- **挂起**：请求无超时上限，网络异常时 Agent 任务被永久阻塞，无日志、无法恢复；
- **崩溃**：GitHub API 返回 5xx/HTML 时 `resp.json()` 抛 `ValueError`，远程技能安装路径任务中断。

## 变更内容

| 文件 | 修改点 | 说明 |
|------|--------|------|
| `openjiuwen/extensions/context_evolver/tool/wikipedia_tool.py` | 第 36、57 行 | 两处 `requests.get` 补充 `timeout=10` |
| `openjiuwen/core/single_agent/skills/remote_skill_util.py` | 第 91 行 | 补充 `timeout=10` + `resp.raise_for_status()` |
| 同上 | 第 105 行 | 补充 `timeout=10` + `resp.raise_for_status()` |
| 同上 | 第 153 行 | 补充 `timeout=10` |

## 修改细节

1. **统一超时**：所有相关调用补充 `timeout=10`，保证单次请求在 10s 内失败并抛出可读异常（`requests.exceptions.Timeout`），避免无限挂起；
2. **状态码校验**：`remote_skill_util.py` 前两处在 `resp.json()` 之前调用 `resp.raise_for_status()`，非 2xx 响应立即以带状态码的错误终止，不再进入 JSON 解析；
3. **保持原有错误语义**：`raise_for_status()` 抛出的 `HTTPError` 与原有 `GitHubError` 异常路径互不冲突；`wikipedia_tool.py` 原有 `except Exception` 兜底逻辑保持不变。

## 测试方法

| 用例 | 步骤 | 预期 |
|------|------|------|
| 超时生效 | 对不可达端点调用 `search_wikipedia` / `_list_github_files` | 10s 内抛出 `Timeout`，不无限挂起 |
| 状态码校验 | 让 GitHub API 返回 503（或代理拦截页） | `raise_for_status()` 抛 `HTTPError`，不进入 `resp.json()` |
| 正常路径 | 正常网络下调用上述工具 | 行为与修复前一致，无回归 |

验证建议：`uv run pytest tests/unit_tests/ -k "wikipedia or remote_skill"`（如有对应用例）。

## 关联 Issue

Closes #952

## 兼容性说明

- 仅新增关键字参数与一行状态校验，无接口签名变化，向后兼容；
- 超时值 10s 与仓库既有调用（`context_utils.py`、`audio.py`）量级一致。