### PR TITLE
fix(hitl): withdraw a pending interrupt no caller can answer

### DIFF
--- a/openjiuwen/core/single_agent/agents/react_agent.py
+++ b/openjiuwen/core/single_agent/agents/react_agent.py
@@ -91,6 +91,17 @@ _IMAGE_INPUT_SCAN_MAX_DEPTH = 8
 # few hundred milliseconds; the bar sits above that so an INFO line means a
 # genuine stall. Kept in step with ``SLOW_RAIL_CHAIN_SECONDS``.
 SLOW_INVOKE_PREP_SECONDS = 1.0
+# Written in place of the tool result when a pending confirmation is withdrawn
+# because the caller cannot answer it. It has to read as a refusal the model can
+# act on rather than as a transient failure, or the next iteration repeats the
+# call and suspends again on the same unanswerable request.
+_WITHDRAWN_INTERRUPT_TOOL_RESULT = (
+    "[Not executed] This tool call was waiting on an interactive confirmation that was "
+    "never answered, and the request has been withdrawn because the user sent an ordinary "
+    "message instead. Treat the call as declined: do not repeat it unless the user asks "
+    "for it again, and say that it is still waiting on their confirmation if that matters "
+    "to what they just asked."
+)
 _IMAGE_INPUT_UNSUPPORTED_ERROR_CODES = (
     "invalid_image_input",
     "image_input_unsupported",
@@ -1797,6 +1808,71 @@ class ReActAgent(BaseAgent):
         ctx.extra[RESUME_START_ITERATION_KEY] = resume_iteration + 1
         return None
 
+    @staticmethod
+    def _is_interrupt_answer(user_input: Any) -> bool:
+        """Whether a resume input is an answer to the pending interrupt.
+
+        Interrupt answers address the pending requests by id, so they arrive as
+        an InteractiveInput or the bare mapping behind one. Anything else -- a
+        plain chat message above all -- is the caller talking rather than
+        answering, which also says the transport it arrived over has no way to
+        answer an interrupt at all.
+        """
+        from openjiuwen.core.session import InteractiveInput
+        return isinstance(user_input, (InteractiveInput, dict))
+
+    async def _withdraw_unanswerable_interrupt(
+            self,
+            state: 'ToolInterruptionState',
+            user_input: Any,
+            ctx: AgentCallbackContext,
+            context: ModelContext,
+            session: Optional[Session],
+            *,
+            invoke_inputs: InvokeInputs,
+    ) -> int:
+        """Drop a pending interrupt the caller has shown it cannot answer.
+
+        A resume that raises the same interrupt again has made no progress, and
+        when the input was not an interrupt answer no later message can make any
+        either: each one is consumed by the same suspend, so the round ends
+        without reaching the model and returns neither output nor error. Left
+        alone the session stays that way until its state is discarded.
+
+        Close the interrupted calls off with a result the model can act on,
+        admit the message as an ordinary turn and hand the loop an iteration to
+        resume from, so the round answers instead of stalling in silence.
+
+        Returns:
+            The iteration the ReAct loop should resume from.
+        """
+        pending = state.interrupted_tools
+        logger.warning(
+            "Withdrawing a pending interrupt over %d tool call(s): the resume input is not "
+            "an interrupt answer, so waiting longer cannot resolve it. Continuing the round "
+            "as an ordinary message.",
+            len(pending),
+        )
+        self._hitl_handler.clear(session)
+        for entry in pending.values():
+            await context.add_messages(ToolMessage(
+                tool_call_id=entry.tool_call.id,
+                content=_WITHDRAWN_INTERRUPT_TOOL_RESULT,
+            ))
+
+        invoke_inputs.result = None
+        ctx.extra.pop(RESUME_START_ITERATION_KEY, None)
+        user_text = self._extract_user_text(user_input)
+        # The round is an ordinary turn again, so the message driving it is the
+        # one to remember, not the query the withdrawn interrupt came out of.
+        ctx.extra["_original_query"] = user_text
+        await self._admit_user_message(ctx, context, [user_text], source="resume")
+
+        # The interrupt was raised during ``state.iteration``, whose tool calls
+        # are now all answered. Resuming past the budget would leave the loop
+        # empty, which is the same silent round by another route.
+        return min(state.iteration + 1, max(self._config.max_iterations - 1, 0))
+
     def _extract_user_text(self, user_input: Any) -> str:
         """Extract plain text from user_input (supports InteractiveInput or str)."""
         from openjiuwen.core.session import InteractiveInput
@@ -2015,10 +2091,20 @@ class ReActAgent(BaseAgent):
                     
                     if is_tool_interruption:
                         # Tool Interrupt: not write UserMessage, recovery input is passed to Rail via ctx.extra
-                        await self._handle_resume(
+                        resume_result = await self._handle_resume(
                             interruption_state, user_input, ctx, context, session, invoke_inputs=invoke_inputs
                         )
-                        start_iteration = ctx.extra.pop(RESUME_START_ITERATION_KEY, 0)
+                        if resume_result is not None and not self._is_interrupt_answer(user_input):
+                            start_iteration = await self._withdraw_unanswerable_interrupt(
+                                interruption_state,
+                                user_input,
+                                ctx,
+                                context,
+                                session,
+                                invoke_inputs=invoke_inputs,
+                            )
+                        else:
+                            start_iteration = ctx.extra.pop(RESUME_START_ITERATION_KEY, 0)
                     else:
                         # Workflow Interrupt
                         await self._admit_user_message(

--- a/tests/unit_tests/agent/react_agent/interrupt/test_unanswerable_interrupt.py
+++ b/tests/unit_tests/agent/react_agent/interrupt/test_unanswerable_interrupt.py
@@ -1,0 +1,189 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+"""Rounds that arrive into an interrupt no caller can answer.
+
+A confirmation is raised for a request that came in over a transport with no way
+to send one back -- a plain chat relay, say. The prompt is unanswerable there, so
+every later message resumes the interrupt, raises it again and ends the round
+with neither output nor error. These cover the way out of that.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from openjiuwen.core.runner import Runner
+from openjiuwen.core.session import InteractiveInput
+from openjiuwen.core.single_agent.interrupt.state import INTERRUPTION_KEY
+
+from tests.unit_tests.agent.react_agent.interrupt.test_base import (
+    ActionTool,
+    AgentWithToolsConfig,
+    assert_answer_result,
+    assert_interrupt_result,
+    confirm_interrupt,
+    create_agent_with_tools,
+)
+from tests.unit_tests.fixtures.mock_llm import (
+    create_text_response,
+    create_tool_call_response,
+    MockLLMModel,
+)
+
+
+@pytest.mark.asyncio
+async def test_plain_message_into_interrupted_session_is_answered():
+    """A plain message withdraws the unanswerable interrupt and gets a reply.
+
+    Flow: trigger interrupt -> plain chat message -> answer, tool not executed.
+    """
+    os.environ.setdefault("LLM_SSL_VERIFY", "false")
+    await Runner.start()
+    try:
+        action_tool = ActionTool("action")
+        agent, _, trace_rail = await create_agent_with_tools(
+            AgentWithToolsConfig(
+                tools=[action_tool],
+                session_id_prefix="plain_message_resume",
+                rail_tool_names=["action"],
+                trace_tool_names=["action"],
+            )
+        )
+
+        mock_llm = MockLLMModel()
+        mock_llm.set_responses([
+            create_tool_call_response("action", '{"action": "test"}'),
+            create_text_response("The confirmation is still pending; here is what you asked."),
+        ])
+
+        with patch("openjiuwen.core.foundation.llm.model.Model.stream", side_effect=mock_llm.stream), \
+                patch("openjiuwen.core.foundation.llm.model.Model.invoke", side_effect=mock_llm.invoke):
+            first = await Runner.run_agent(
+                agent=agent,
+                inputs={"query": "Please execute test operation", "conversation_id": "unanswerable_1"},
+            )
+            assert_interrupt_result(first, expected_count=1)
+
+            second = await Runner.run_agent(
+                agent=agent,
+                inputs={"query": "what time is it?", "conversation_id": "unanswerable_1"},
+            )
+
+        assert_answer_result(second)
+        assert second.get("output"), "the round must produce assistant content, not silence"
+        assert trace_rail.get_execution_count("action") == 0, (
+            "the unconfirmed tool must not run just because the interrupt was withdrawn"
+        )
+    finally:
+        await Runner.stop()
+
+
+@pytest.mark.asyncio
+async def test_withdrawn_interrupt_does_not_capture_later_rounds():
+    """The session is usable again: a third message runs a normal round too."""
+    os.environ.setdefault("LLM_SSL_VERIFY", "false")
+    await Runner.start()
+    try:
+        action_tool = ActionTool("action")
+        agent, session, _ = await create_agent_with_tools(
+            AgentWithToolsConfig(
+                tools=[action_tool],
+                session_id_prefix="withdrawn_not_sticky",
+                rail_tool_names=["action"],
+            )
+        )
+
+        mock_llm = MockLLMModel()
+        mock_llm.set_responses([
+            create_tool_call_response("action", '{"action": "test"}'),
+            create_text_response("First reply"),
+            create_text_response("Second reply"),
+        ])
+
+        with patch("openjiuwen.core.foundation.llm.model.Model.stream", side_effect=mock_llm.stream), \
+                patch("openjiuwen.core.foundation.llm.model.Model.invoke", side_effect=mock_llm.invoke):
+            # Rounds share one session object so the stored interrupt state is
+            # readable from the test rather than only from inside the agent.
+            await Runner.run_agent(
+                agent=agent,
+                inputs={"query": "Please execute test operation"},
+                session=session,
+            )
+            assert session.get_state(INTERRUPTION_KEY) is not None, (
+                "the first round must leave a pending interrupt for the rest to withdraw"
+            )
+            second = await Runner.run_agent(
+                agent=agent,
+                inputs={"query": "never mind that"},
+                session=session,
+            )
+            third = await Runner.run_agent(
+                agent=agent,
+                inputs={"query": "and one more thing"},
+                session=session,
+            )
+
+        assert_answer_result(second)
+        assert_answer_result(third)
+        assert session.get_state(INTERRUPTION_KEY) is None, (
+            "no interrupt state may survive a withdrawal"
+        )
+    finally:
+        await Runner.stop()
+
+
+@pytest.mark.asyncio
+async def test_structured_answer_still_holds_the_interrupt_open():
+    """An answer that misses its request keeps waiting rather than withdrawing.
+
+    A caller sending InteractiveInput can answer interrupts, so an answer that
+    resolves nothing -- a stale or mistyped request id -- is a retry, not a sign
+    that the prompt is unanswerable.
+    """
+    os.environ.setdefault("LLM_SSL_VERIFY", "false")
+    await Runner.start()
+    try:
+        action_tool = ActionTool("action")
+        agent, _, trace_rail = await create_agent_with_tools(
+            AgentWithToolsConfig(
+                tools=[action_tool],
+                session_id_prefix="structured_answer_holds",
+                rail_tool_names=["action"],
+                trace_tool_names=["action"],
+            )
+        )
+
+        mock_llm = MockLLMModel()
+        mock_llm.set_responses([
+            create_tool_call_response("action", '{"action": "test"}'),
+            create_text_response("Action completed"),
+        ])
+
+        with patch("openjiuwen.core.foundation.llm.model.Model.stream", side_effect=mock_llm.stream), \
+                patch("openjiuwen.core.foundation.llm.model.Model.invoke", side_effect=mock_llm.invoke):
+            first = await Runner.run_agent(
+                agent=agent,
+                inputs={"query": "Please execute test operation", "conversation_id": "unanswerable_3"},
+            )
+            interrupt_ids, _ = assert_interrupt_result(first, expected_count=1)
+            pending_id = interrupt_ids[0]
+
+            stale = InteractiveInput()
+            stale.update("stale-request-id", {"approved": True, "feedback": "Confirm"})
+            second = await Runner.run_agent(
+                agent=agent,
+                inputs={"query": stale, "conversation_id": "unanswerable_3"},
+            )
+            assert second.get("result_type") == "interrupt"
+            assert pending_id in second.get("interrupt_ids", [])
+
+            third = await Runner.run_agent(
+                agent=agent,
+                inputs={"query": confirm_interrupt(pending_id), "conversation_id": "unanswerable_3"},
+            )
+
+        assert_answer_result(third)
+        assert trace_rail.get_execution_count("action") == 1
+    finally:
+        await Runner.stop()


### PR DESCRIPTION
Paired: [GitHub #960](https://github.com/openJiuwen-ai/agent-core/pull/960) ↔ [GitCode !2530](https://gitcode.com/openJiuwen/agent-core/merge_requests/2530)

**What type of PR is this?**

/kind bug

**Which issue(s) this PR fixes**:

Fixes #959

#959 is filed alongside this request and carries the reproduction, the mechanism and the
affected version range. It also names #250, which reports the same defect and was opened
and closed by the sync bot three seconds apart with no human action since; #250 should not
be closed on this merge, because it additionally covers a stream cancelled mid-round
leaving a half-written interruption state, which this change does not address.

The report is #250, mirrored from issue 1011 on `openJiuwen/agent-core` at GitCode, where
the original is open and assigned. It names the same trigger — a HITL interrupt followed
by an ordinary message rather than a confirmation — traces it to the same resume path in
`_inner_invoke`, and independently identifies the empty-`range()` case described below.
One detail in it needs correcting from the evidence here: the failure is not log-silent,
an ERROR is emitted and is simply indistinguishable from the one a healthy first suspend
emits. One extends it: the report names 0.1.14 and confirms `develop` carries the same
logic, and the defective block is in fact byte-identical in every tag from
`v0.1.15.post2` through `v0.1.17.post1` as well.

That report must stay open after this merges. It also covers a second route into the same
silence — a stream cancelled mid-round leaving a half-written interruption state persisted
— which this change does not touch. The state on the GitHub mirror is not a guide either:
it reads as closed because it was created and closed three seconds apart by the mirroring
bot on 2026-07-31 and has not moved since, while the GitCode original stayed open.

Related but **not** fixed here, and not to be closed by this merge:

- #470 is a different resume-path defect: restoring a partial set of HITL tool answers
  wrongly resumes all interrupted tools. It concerns a caller that *can* answer.
- #501 is the `agent_teams` analogue — a lost `pending_resume` marker on team
  pause/resume. Different package, different mechanism.
- #831, problem 4, points at the same `_inner_invoke` region but reports rail state lost
  across the `ctx` rebuild, not a round that never runs.

**What does this PR do / why do we need it**:

A tool that raises `ToolInterruptException` suspends the round and stores the pending
request in session state. The next message resumes it: the interrupted tool calls run
again, the rail inspects the resume input, and a rail that cannot read that input as an
answer raises the same interrupt once more. `_handle_resume` returns an interrupt result,
`invoke_inputs.result` is set from it, and the ReAct loop is skipped entirely — the round
ends without ever reaching the model.

Whether that is correct depends on what the resume input was, and the tool-interrupt
branch of `_inner_invoke` does not look. When the resume input was a structured answer
that resolved nothing — a stale or mistyped request id — re-arming the interrupt is
right: the prompt is still outstanding and the caller can send a correct answer next.
When it was an ordinary chat message it is a trap, because an interrupt answer has to
address the pending requests by id, so a caller that sends plain text has no answer to
send on this turn or on any later one. Every subsequent message meets the same suspend,
is consumed by it, and produces no assistant content and no error result.

Neither the returned result nor the log tells that state apart from a session that is
legitimately waiting. The round returns the same interrupt result a first suspend returns,
and the only ERROR emitted — `Callback execution aborted: before_tool_call - Tool
execution interrupted` — is character-for-character the line that first suspend emits. The only
lines that differ are the `Resuming tool interrupt` line every resume logs and an INFO
reporting `raw_input_type=str` rather than `None` — neither something an operator would
know to look for.

**The change.** Distinguish the two cases by the shape of the resume input. An interrupt
answer arrives as `InteractiveInput`, or as the bare mapping behind one; anything else is
the caller talking rather than answering. Only in the second case, and only when the
resume has already come back with the interrupt re-raised, withdraw it instead of
re-arming it:

- clear the stored interruption state, which `_handle_resume` has just re-saved through
  the interrupt handler's `commit_interrupt`;
- close each interrupted tool call off with a `ToolMessage` that reads as a refusal rather
  than as a transient failure, so the next iteration does not repeat the call and suspend
  again on the same unanswerable request;
- drop the interrupt result, admit the message as an ordinary user turn, and record it as
  the query the round is answering rather than the older query the withdrawn interrupt
  came out of;
- hand the loop the iteration to resume from, clamped below the iteration budget — the
  interrupt may have been raised on the last permitted iteration, and starting past the
  budget would leave `range(start_iteration, max_iterations)` empty, ending the round on
  `Max iterations reached without completion` rather than on an answer. The clamp is on
  the withdrawal path only; the ordinary resume path still pops `start_iteration`
  unbounded, so the empty-`range()` case #250 also describes is closed for a withdrawal
  and left as it is everywhere else.

The round then answers, the session is usable again, and the model is told that the
confirmation went unanswered, so it can say so if that matters to what was just asked
instead of silently retrying the call.

**Why this belongs in the agent rather than in the host.** A host can also discard a
paused round — on an explicit session reset, say — and that is a useful control, but it is
a different one. It requires someone to notice that the session is stuck and to ask for
the reset, and the defining property of this failure is that nobody can tell: no error
result, no rendered prompt, and a log line that a healthy pending confirmation produces
just the same. It also assumes a caller with a reset to issue, which the callers this
affects — plain relays that can deliver text and nothing else — do not have.

The agent also already holds both halves of the decision: it knows a resume has been
attempted and has produced no progress, and it knows the shape of the input that produced
it. A host is handed the interrupt result alone, so to reach the same conclusion it has to
keep its own record of what it sent and of the previous round's `interrupt_ids` and
compare the two — bookkeeping every host would have to repeat, and that a plain relay has
nowhere to keep.

**What is deliberately not changed.** A caller that can answer keeps the current behaviour
in full: a structured answer that resolves nothing still holds the interrupt open, because
for that caller it is a retry rather than a dead end. Nothing withdraws an interrupt that
has never been resumed, and no unconfirmed tool is executed as a consequence of a
withdrawal — the calls are closed off as declined, not run. The classification is
conservative in the same direction: a mapping resume input is treated as an answer, so an
unfamiliar structured input holds the interrupt open rather than dropping it.

### Adjacent, not overlapping

PR #789 (GitCode !2424), `fix(swarm): 中断+新query 不再续跑上一轮暂停回合 / 成员残缺 tool_call`,
is the host-side half of this and is complementary rather than competing: it clears a
team's `pending_resume` when the session is explicitly reset, and touches `agent_teams`
and `core/runner/team_runner.py` only, so it shares no file and no mechanism with this
change. The two together cover both the case where someone can ask for a reset and the
case where nobody can tell there is anything to reset.

A companion request, `fix(hitl): carry a delegated sub-agent's pause out and its answer
back`, corrects the delegated sub-agent interrupt path. It shares no file with this
change, but the two meet at one point and the merge order is visible in the result. This
change writes one refusal `ToolMessage` per entry in the interruption state's
`interrupted_tools`, and `ToolInterruptHandler._collect_interrupts` puts a paused
sub-agent's envelope there, keyed by the delegating call's id. On `develop` today
`AbilityManager._execute_single_tool_call` has already written a `ToolMessage` under that
same id at the moment the sub-agent paused, so this change on its own leaves two messages
sharing one `tool_call_id` whenever a withdrawn interrupt came from a delegated sub-agent
— the first carrying the sub-agent's question, the second this refusal. That companion
request removes the first of the two; with it applied, or merged first, the id is spent
exactly once. Merging this one alone still trades a permanently silent session for a
duplicated id on the sub-agent path, which is the better of the two, but it is the reason
to prefer the pair.

**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

A standalone three-round script — suspend on a confirmation, then two ordinary chat
messages, against the repository's in-tree mock model client and no network — shows the
change end to end. On `develop` at `dce36fc8` all three rounds return
`result_type == "interrupt"` with `output` `None`, one model call is made across the
three, the interruption state is still stored when the script ends, and the guarded tool
has run zero times. On this branch round 1 still suspends, rounds 2 and 3 return
`result_type == "answer"` with the model's replies, three model calls are made, the
interruption state is gone, and the guarded tool has still run zero times — the
withdrawal declines the call rather than executing it.

Three tests are added, in `tests/unit_tests/agent/react_agent/interrupt/test_unanswerable_interrupt.py`.

The first drives the reported failure end to end: a round suspends on a confirmation, a
plain chat message follows, and the round is asserted to produce assistant content — not
merely to avoid an error — with the unconfirmed tool asserted never to have executed. The
second sends two further plain messages into the same session and asserts both are
answered and that no interruption state survives in the session; the three rounds share
one session object so the stored state is read from the test rather than inferred. The
third covers the case that must not change: a structured answer carrying a request id that
resolves nothing leaves the interrupt pending, and a correct answer afterwards still runs
the tool.

The first two fail against the unmodified source, and on their assertions rather than at
import or setup — the rounds return interrupt results with no output. They pass with the
change. The third passes on both sides, which is what makes it a guard rather than a
regression test.

`tests/` was run in full on this branch and on its merge base, and the two failure sets
compared name by name: they are identical. The same 165 tests fail on both sides and the
same 7 modules fail to collect — 172 entries in all — none of them under
`openjiuwen/core/single_agent/` or `tests/unit_tests/agent/`. The branch passes 16845
against the base's 16842, the difference being exactly the three tests added here, and no
test that passes on the base fails on the branch.

The residual failures and collection errors are environmental rather than upstream's: they
come from a local database file this environment cannot open, from optional dependencies
that are absent — `pulsar` for the message-queue modules, and `prompt_toolkit` for the
seven CLI modules that fail to collect — and from tests that assume an event loop already
running in the main thread. All three are present unchanged on the base, which is why the comparison is
by name rather than by count, and why no absolute count is offered as evidence on its own.

No performance work is claimed or needed: the added path runs only on a resume that has
already failed to make progress, and adds one state clear plus one `ToolMessage` per
interrupted call. The ordinary resume path is unchanged.

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

> Three boxes are left unticked rather than ticked untruthfully.
> **Design**: this has had no Maintainer design review yet. The classification rule — resume
> input shape decides whether an interrupt is re-armed or withdrawn — is the part most worth
> arguing with, and is described above so that it can be.
> **Interface**: no external interface changes. Everything added is private to `ReActAgent`
> (`_is_interrupt_answer`, `_withdraw_unanswerable_interrupt`, one module-level constant);
> no public name is added, removed or repurposed, and no signature changes. Nothing to
> submit for interface review.
> **Document**: no documentation changes. The behaviour being corrected is not described in
> the website documentation — the tool-interrupt resume path is documented only by its
> docstrings, which are updated in the diff. Nothing to submit to the Doc repository.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->


<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #250
- Fixes #470
- Fixes #501
- Fixes #831
- Fixes #959
<!-- /bot1-related-issues -->
