### PR TITLE
fix(hitl): carry a delegated sub-agent's pause out and its answer back

### DIFF
--- a/openjiuwen/core/single_agent/ability_manager.py
+++ b/openjiuwen/core/single_agent/ability_manager.py
@@ -37,7 +37,10 @@ from openjiuwen.core.single_agent.schema.agent_card import AgentCard
 from openjiuwen.core.workflow import WorkflowCard
 from openjiuwen.core.single_agent.interrupt.exception import ToolInterruptException
 from openjiuwen.core.session.agent import create_agent_session
-from openjiuwen.core.single_agent.interrupt.state import INTERRUPT_AUTO_CONFIRM_KEY
+from openjiuwen.core.single_agent.interrupt.state import (
+    INTERRUPT_AUTO_CONFIRM_KEY,
+    is_interrupt_envelope,
+)
 from openjiuwen.core.single_agent.kv_cache import kv_cache_child_session
 
 # Ability type definition
@@ -1272,7 +1275,7 @@ class AbilityManager:
             session: Session,
             tag=None,
             callback_context: Optional[AgentCallbackContext] = None,
-    ) -> Tuple[Any, ToolMessage]:
+    ) -> Tuple[Any, Optional[ToolMessage]]:
         tool_name = tool_call.name
 
         mcp_tool_scope = self._resolve_mcp_tool_scope(tool_name)
@@ -1473,6 +1476,14 @@ class AbilityManager:
                     tool_call,
                     error_msg,
                 ) from e
+
+        # An interrupt envelope is a pending question, not a result: emit no
+        # ToolMessage for it, as an interrupted workflow and a
+        # ToolInterruptException already do above. The answer arrives on
+        # resume under this same tool_call_id, so writing the envelope now
+        # would leave two messages sharing one id, the first the question.
+        if is_interrupt_envelope(result):
+            return result, None
 
         # Build ToolMessage for successful execution.
         content = self._build_tool_message_content(result)

--- a/openjiuwen/core/single_agent/interrupt/handler.py
+++ b/openjiuwen/core/single_agent/interrupt/handler.py
@@ -22,10 +22,15 @@ from openjiuwen.core.single_agent.interrupt.response import (
     InterruptRequest,
     ToolCallInterruptRequest,
 )
-from openjiuwen.core.single_agent.interrupt.state import INTERRUPTION_KEY, RESUME_USER_INPUT_KEY
+from openjiuwen.core.single_agent.interrupt.state import (
+    INTERRUPTION_KEY,
+    RESUME_USER_INPUT_KEY,
+    SUB_AGENT_RESUME_INPUT_KEY,
+)
 from openjiuwen.core.single_agent.interrupt.state import (
     ToolInterruptEntry,
     ToolInterruptionState,
+    is_interrupt_envelope,
     RESUME_START_ITERATION_KEY, INTERRUPT_AUTO_CONFIRM_KEY,
 )
 from openjiuwen.core.single_agent.rail.base import AgentCallbackContext, InvokeInputs
@@ -85,16 +90,7 @@ class ToolInterruptHandler:
     @staticmethod
     def _is_sub_agent_interrupt(result: Any) -> bool:
         """Check if result is a sub-agent interrupt dict."""
-        if isinstance(result, tuple) and len(result) >= 1:
-            tool_result = result[0]
-        else:
-            tool_result = result
-
-        return (
-                isinstance(tool_result, dict)
-                and tool_result.get("result_type") == "interrupt"
-                and "interrupt_ids" in tool_result
-        )
+        return is_interrupt_envelope(result)
 
     @staticmethod
     def _process_sub_agent_interrupt(
@@ -409,7 +405,13 @@ class ToolInterruptHandler:
         except (json.JSONDecodeError, TypeError):
             args = {}
 
+        # An agent registered directly as an ability is re-invoked with these
+        # arguments, and reads the answer from "query".
         args["query"] = user_input
+        # A tool that delegates to an agent reads its own argument names and
+        # never sees "query", so it cannot tell a resume from a first call
+        # unless the answer is repeated under a key it knows.
+        args[SUB_AGENT_RESUME_INPUT_KEY] = user_input
 
         tool_call.arguments = args
         return tool_call

--- a/openjiuwen/core/single_agent/interrupt/state.py
+++ b/openjiuwen/core/single_agent/interrupt/state.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 from dataclasses import field
-from typing import Dict
+from typing import Any, Dict
 from pydantic import BaseModel
 
 from openjiuwen.core.foundation.llm import AssistantMessage
@@ -12,8 +12,35 @@ from openjiuwen.core.single_agent.interrupt.response import InterruptRequest
 
 INTERRUPTION_KEY = "__react_agent_interruption__"
 RESUME_USER_INPUT_KEY = "_resume_user_input"
+# Argument key carrying the user's answer back into the delegating tool when a
+# sub-agent interrupt is resumed. Underscore-prefixed so it cannot collide with
+# a model-supplied argument. Written by ToolInterruptHandler, read by TaskTool;
+# both sides import this name so the contract cannot drift.
+SUB_AGENT_RESUME_INPUT_KEY = "_sub_agent_resume_input"
 INTERRUPT_AUTO_CONFIRM_KEY = "__interrupt_auto_confirm__"
 RESUME_START_ITERATION_KEY = "_resume_start_iteration"
+
+
+def is_interrupt_envelope(result: Any) -> bool:
+    """Return True when ``result`` is the dict an agent returns when it pauses.
+
+    The envelope is the shape produced by ``build_interrupt_result``: it carries
+    ``result_type == "interrupt"`` together with the ids of the pending
+    interrupts. A tool that wraps an agent hands this dict back verbatim, so it
+    reaches the caller as an ordinary tool result and has to be told apart from
+    a real one.
+
+    A ``(tool_result, tool_message)`` tuple is accepted as well and inspected by
+    its first element, so call sites holding either form can share one check.
+    """
+    if isinstance(result, tuple) and len(result) >= 1:
+        result = result[0]
+
+    return (
+            isinstance(result, dict)
+            and result.get("result_type") == "interrupt"
+            and "interrupt_ids" in result
+    )
 
 
 class BaseInterruptionState(BaseModel):

--- a/openjiuwen/harness/deep_agent.py
+++ b/openjiuwen/harness/deep_agent.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import copy
 import dataclasses
+import hashlib
 import os
 import sys
 import uuid
@@ -234,6 +235,41 @@ _DEFAULT_DIRECT_TOOL_NAMES = frozenset(
 _ROUND_BOUNDARY = object()
 
 FreshInputContextFactory = Callable[[], AbstractAsyncContextManager[None]]
+
+
+def _sub_agent_card_for_session(card: AgentCard, subsession_id: str) -> AgentCard:
+    """Return ``card`` with an id that is reproducible for this sub-session.
+
+    A sub-agent's persisted state is namespaced under ``session.agent_id()``,
+    which for this path is the agent card's id. That includes the
+    ``ToolInterruptionState`` parked when the sub-agent stops to ask the user
+    something, and the conversation itself.
+
+    A spec's card is minted with a fresh ``uuid4`` every time the parent agent
+    is built, so a delegation that pauses for an answer and is resumed once the
+    parent has been rebuilt looks for its parked state under an id nothing was
+    ever written to. Finding none, the sub-agent treats the answer as a new
+    request and starts over with no history, which loses the work already done
+    and never asks the question again.
+
+    Deriving the id from the sub-session id keeps it distinct per delegation --
+    the only thing the random id was there to guarantee -- while making it
+    reproducible for the rebuild that resumes one. Callers that derive further
+    ids from it, such as the sys_operation registration, already resolve
+    get-or-create and so tolerate the repeat.
+
+    Args:
+        card: The spec's card, left unmodified.
+        subsession_id: Session id of the delegation this card is built for.
+
+    Returns:
+        A copy of ``card`` whose id is a 32-character hex token derived from
+        the sub-session id and the card name.
+    """
+    digest = hashlib.sha256(
+        f"{subsession_id}\x00{card.name}".encode("utf-8", errors="ignore")
+    ).hexdigest()[:32]
+    return card.model_copy(update={"id": digest})
 
 
 def _render_identity_prompt(prompt_builder: SystemPromptBuilder, language: str) -> str:
@@ -1472,7 +1508,7 @@ class DeepAgent(BaseAgent):
 
         create_kwargs = {
             "model": spec.model or self._deep_config.model,
-            "card": spec.agent_card,
+            "card": _sub_agent_card_for_session(spec.agent_card, subsession_id),
             "system_prompt": spec.system_prompt,
             "tools": spec.tools,
             "mcps": spec.mcps,

--- a/openjiuwen/harness/tools/subagent/task_tool.py
+++ b/openjiuwen/harness/tools/subagent/task_tool.py
@@ -12,14 +12,20 @@ import uuid
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, AsyncIterator, Collection, List, Optional
 
-if TYPE_CHECKING:
-    from openjiuwen.harness.deep_agent import DeepAgent
-
+from openjiuwen.core.common.constants.constant import INTERACTION
 from openjiuwen.core.common.exception.codes import StatusCode
 from openjiuwen.core.common.exception.errors import build_error
 from openjiuwen.core.common.logging import logger
 from openjiuwen.core.foundation.tool import Input, Output, Tool, ToolCard
 from openjiuwen.core.session.agent import Session
+from openjiuwen.core.session.interaction.interaction import InteractionOutput
+from openjiuwen.core.session.stream.base import OutputSchema
+from openjiuwen.core.single_agent.interrupt.handler import ToolInterruptHandler
+from openjiuwen.core.single_agent.interrupt.response import InterruptRequest
+from openjiuwen.core.single_agent.interrupt.state import (
+    SUB_AGENT_RESUME_INPUT_KEY,
+    is_interrupt_envelope,
+)
 from openjiuwen.core.single_agent.rail.base import (
     bind_usage_delegation,
     build_usage_delegation_attribution,
@@ -38,6 +44,9 @@ from openjiuwen.harness.subagent_lifecycle import (
     prepare_subagent_task_resources,
 )
 from openjiuwen.harness.tools.base_tool import ToolOutput
+
+if TYPE_CHECKING:
+    from openjiuwen.harness.deep_agent import DeepAgent
 
 try:
     from openjiuwen.harness.tools.browser_move.playwright_runtime.browser_logging import (
@@ -71,6 +80,21 @@ def _summarize_task_description(task_description: Any) -> dict[str, Any]:
     }
 
 
+def _is_interrupt_schema(chunk: Any) -> bool:
+    """Return True when ``chunk`` is one ``state`` schema of an interrupt envelope.
+
+    ``write_interrupt_to_stream`` writes those schemas out verbatim, so they
+    arrive as ``OutputSchema`` rather than the plain dicts the rest of the
+    stream loop reads.
+    """
+    if not isinstance(chunk, OutputSchema) or chunk.type != INTERACTION:
+        return False
+    payload = chunk.payload
+    if not isinstance(payload, InteractionOutput):
+        return False
+    return isinstance(payload.value, InterruptRequest)
+
+
 async def _run_subagent_with_observable_stream(
     subagent: Any,
     inputs: dict[str, Any],
@@ -83,6 +107,16 @@ async def _run_subagent_with_observable_stream(
     chunks stay inside this task tool and only the terminal answer is returned
     to the parent agent.  Third-party test/adaptor agents that only implement
     ``invoke`` retain their existing behavior.
+
+    A subagent that stops to ask the user something emits no terminal answer at
+    all: ``ReActAgent`` writes the ``state`` schemas of its interrupt envelope
+    to the stream one at a time and nothing else.  Those schemas are collected
+    here and the envelope is rebuilt from them, because a pause reconstructed
+    as an answer is an empty success reported for a question nobody was asked.
+    Only schemas carrying an ``InterruptRequest`` are collected, which is what
+    the caller's interrupt collection reads; an interaction chunk carrying
+    anything else belongs to a workflow's own interrupt protocol and is left
+    exactly as it is handled today.
     """
     invoke_kwargs = {"session": session} if session is not None else {}
     stream = getattr(subagent, "stream", None)
@@ -91,12 +125,17 @@ async def _run_subagent_with_observable_stream(
 
     output_parts: list[str] = []
     terminal_result: dict[str, Any] | None = None
+    interrupt_schemas: list[OutputSchema] = []
     async for chunk in stream(inputs, **invoke_kwargs):
         chunk_type = getattr(chunk, "type", None)
         payload = getattr(chunk, "payload", None)
         if isinstance(chunk, dict):
             chunk_type = chunk.get("type", chunk_type)
             payload = chunk.get("payload", payload)
+        if _is_interrupt_schema(chunk):
+            # Exactly what build_interrupt_result put in the envelope's ``state``.
+            interrupt_schemas.append(chunk)
+            continue
         if not isinstance(payload, dict):
             continue
         if chunk_type == "llm_output":
@@ -113,6 +152,12 @@ async def _run_subagent_with_observable_stream(
             if isinstance(content, str):
                 terminal_result["output"] = content
 
+    if terminal_result is None and interrupt_schemas:
+        # ``interrupt_ids`` are the inner ids the payloads already carry, so
+        # the rebuilt envelope is the one the subagent returned from invoke.
+        return ToolInterruptHandler.build_interrupt_result(
+            [(schema.payload.id, schema) for schema in interrupt_schemas]
+        )
     if terminal_result is None:
         terminal_result = {
             "output": "".join(output_parts),
@@ -144,6 +189,9 @@ class _SubagentInputContext:
     parent_invocation_id: str | None
     affinity_enabled: bool
     browser_query: _BrowserQueryContext | None
+    # Set only when ToolInterruptHandler is replaying this call to deliver the
+    # user's answer to a paused subagent; ``None`` on a first invocation.
+    resume_input: Any = None
 
 
 class TaskTool(Tool):
@@ -195,6 +243,7 @@ class TaskTool(Tool):
         parent_session_id: str,
         subagent_type: str,
         resume_task_id: str = "",
+        task_description: Any = "",
     ) -> str:
         normalized_type = str(subagent_type or "").strip()
         normalized_resume_id = str(resume_task_id or "").strip()
@@ -206,7 +255,15 @@ class TaskTool(Tool):
         if kv_cache_subagent_lifecycle.is_sticky_subagent_type(normalized_type):
             # Deterministic ID so the session can be resumed on a FAIL → fix → re-verify loop.
             return f"{parent_session_id}_sub_{normalized_type}"
-        return f"{parent_session_id}_sub_{normalized_type}_{uuid.uuid4().hex[:8]}"
+        # Derived from the task rather than random: a delegation that pauses
+        # for user input is re-invoked with the same arguments, and a fresh
+        # random suffix would send that replay to a brand new subagent while
+        # the interrupted one stays parked and unreachable. Distinct tasks
+        # still get distinct sessions; identical ones now share one.
+        digest = hashlib.sha256(
+            str(task_description or "").encode("utf-8", errors="ignore")
+        ).hexdigest()[:8]
+        return f"{parent_session_id}_sub_{normalized_type}_{digest}"
 
     @staticmethod
     def _extract_browser_result(result: Any, output: Any) -> dict[str, Any]:
@@ -648,8 +705,19 @@ class TaskTool(Tool):
         task_description: Any,
         context: _SubagentInputContext,
     ) -> dict[str, Any]:
+        # On a resume the answer takes the place of the task description: the
+        # subagent finds its parked interruption state under this same
+        # conversation_id and feeds the answer to handle_resume, rather than
+        # starting the original task over. The session id itself stays derived
+        # from the task description, so the replay lands where the first call
+        # did.
+        query = (
+            context.resume_input
+            if context.resume_input is not None
+            else task_description
+        )
         subagent_inputs: dict[str, Any] = {
-            "query": task_description,
+            "query": query,
             "conversation_id": context.sub_session_id,
         }
         if context.browser_query is not None:
@@ -771,7 +839,8 @@ class TaskTool(Tool):
         parent_session: Session,
         browser_query: _BrowserQueryContext | None,
         affinity_enabled: bool,
-    ) -> ToolOutput:
+        resume_input: Any = None,
+    ) -> ToolOutput | dict[str, Any]:
         succeeded = False
         child_session: Session | None = None
         parent_subject = current_execution_subject()
@@ -824,6 +893,7 @@ class TaskTool(Tool):
                         parent_invocation_id=parent_invocation_id,
                         affinity_enabled=affinity_enabled,
                         browser_query=browser_query,
+                        resume_input=resume_input,
                     ),
                 )
                 if child_session is not None:
@@ -841,6 +911,12 @@ class TaskTool(Tool):
                     session=child_session,
                 )
                 succeeded = True
+                if is_interrupt_envelope(result):
+                    # Hand the envelope back unchanged: flattening it into
+                    # ``output`` drops ``result_type`` and ``interrupt_ids``,
+                    # so the parent reports an empty success while the
+                    # subagent waits for an answer nobody is asked for.
+                    return result
                 return self._build_task_output(
                     result,
                     normalized_type=normalized_type,
@@ -886,7 +962,7 @@ class TaskTool(Tool):
                     )
                     await child_session.post_run()
 
-    async def invoke(self, inputs: Input, **kwargs) -> ToolOutput:
+    async def invoke(self, inputs: Input, **kwargs) -> ToolOutput | dict[str, Any]:
         """Execute task by delegating to a subagent.
 
         Args:
@@ -894,7 +970,8 @@ class TaskTool(Tool):
             **kwargs: Additional parameters, including 'session' for parent session context.
 
         Returns:
-            subagent's final result.
+            The subagent's final result, or the raw interrupt envelope when the
+            subagent paused to ask the user something.
 
         Raises:
             ToolError: If subagent creation or execution fails.
@@ -909,6 +986,9 @@ class TaskTool(Tool):
         normalized_type, task_description, resume_task_id, browser_capabilities = (
             self._parse_invocation_inputs(inputs)
         )
+        # Present only when ToolInterruptHandler is replaying this call to
+        # deliver the user's answer to a paused subagent.
+        resume_input = inputs.get(SUB_AGENT_RESUME_INPUT_KEY)
         runtime_parent_session_id = parent_session.get_session_id()
         affinity_enabled = kv_cache_subagent_lifecycle.affinity_enabled(self.parent_agent)
         parent_cache_id = runtime_parent_session_id
@@ -934,6 +1014,7 @@ class TaskTool(Tool):
                 runtime_parent_session_id,
                 normalized_type,
                 str(resume_task_id or ""),
+                task_description,
             )
         except ValueError as exc:
             raise build_error(
@@ -983,6 +1064,7 @@ class TaskTool(Tool):
             parent_session=parent_session,
             browser_query=browser_query,
             affinity_enabled=affinity_enabled,
+            resume_input=resume_input,
         )
 
     async def stream(self, inputs: Input, **kwargs) -> AsyncIterator[Output]:

--- a/tests/unit_tests/core/single_agent/test_ability_manager_interrupt_envelope.py
+++ b/tests/unit_tests/core/single_agent/test_ability_manager_interrupt_envelope.py
@@ -1,0 +1,156 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Unit tests for interrupt-envelope handling in ``AbilityManager``.
+
+A tool that wraps an agent hands the caller the interrupt envelope verbatim
+when that agent pauses: a ``dict`` carrying ``result_type == "interrupt"`` and
+``interrupt_ids``. The envelope is a pending question, not an answer, so it
+must not become a ``ToolMessage`` — otherwise the question text is written into
+the caller's context under the tool_call_id that the real answer will later
+claim, and two messages end up sharing one id.
+
+Two neighbouring paths already behave this way: an interrupted workflow returns
+``(workflow_output, None)`` from ``_run_workflow``, and a
+``ToolInterruptException`` yields ``(exception, None)`` in ``execute``.
+
+An ordinary ``dict`` result is unaffected and still yields a ``ToolMessage``.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Tuple
+
+from openjiuwen.core.foundation.llm import ToolCall, ToolMessage
+from openjiuwen.core.foundation.tool import LocalFunction, ToolCard
+from openjiuwen.core.runner import Runner
+from openjiuwen.core.single_agent.ability_manager import AbilityManager
+from openjiuwen.core.single_agent.interrupt.handler import ToolInterruptHandler
+from openjiuwen.core.single_agent.interrupt.state import is_interrupt_envelope
+from openjiuwen.core.single_agent.rail.base import AgentCallbackContext
+
+INTERRUPT_ENVELOPE: Dict[str, Any] = {
+    "result_type": "interrupt",
+    "state": [],
+    "interrupt_ids": ["inner-1"],
+}
+
+PLAIN_DICT_RESULT: Dict[str, Any] = {"output": "42", "status": "ok"}
+
+
+def _dict_tool(name: str, payload: Dict[str, Any]) -> LocalFunction:
+    """A tool whose invoke returns ``payload`` as a bare dict."""
+    card = ToolCard(id=name, name=name, description=f"{name} desc", properties={})
+
+    async def _func(**_):  # noqa: ANN202
+        return payload
+
+    return LocalFunction(card=card, func=_func)
+
+
+def _tool_call(name: str) -> ToolCall:
+    return ToolCall(id=f"tc-{name}", type="function", name=name, arguments="{}")
+
+
+class _NoRails:
+    """Callback manager that registers no rails, so BEFORE/AFTER fire cheaply."""
+
+    async def execute(self, *_args, **_kwargs) -> None:
+        return None
+
+
+class _StubAgent:
+    """Minimal stand-in for the agent that owns the callback context."""
+
+    agent_callback_manager = _NoRails()
+
+
+async def _execute(tools: List[LocalFunction]) -> List[Tuple[Any, ToolMessage]]:
+    """Register ``tools`` and run one ``execute`` round over all of them."""
+    await Runner.start()
+    am = AbilityManager(owner_id="interrupt-envelope-test")
+    try:
+        for tool in tools:
+            am.add_ability(tool.card, tool)
+        ctx = AgentCallbackContext(agent=_StubAgent(), inputs=None, config=None, session=None)
+        return await am.execute(
+            ctx=ctx,
+            tool_call=[_tool_call(tool.card.name) for tool in tools],
+            session=None,
+            parallel_tool_calls=False,
+        )
+    finally:
+        for tool in tools:
+            am.remove_ability(tool.card.name)
+        await Runner.stop()
+
+
+def test_predicate_matches_the_handler_spelling() -> None:
+    """The shared predicate and the handler agree on one envelope shape."""
+    assert is_interrupt_envelope(INTERRUPT_ENVELOPE) is True
+    assert ToolInterruptHandler._is_sub_agent_interrupt(INTERRUPT_ENVELOPE) is True
+
+    # Non-envelopes: plain dict, wrong result_type, and no interrupt_ids.
+    assert is_interrupt_envelope(PLAIN_DICT_RESULT) is False
+    assert is_interrupt_envelope({"result_type": "answer", "interrupt_ids": []}) is False
+    assert is_interrupt_envelope({"result_type": "interrupt"}) is False
+    assert is_interrupt_envelope(None) is False
+    assert is_interrupt_envelope("result_type=interrupt") is False
+
+    # A (tool_result, tool_message) tuple is inspected by its first element,
+    # which is how ``_collect_interrupts`` feeds it.
+    assert is_interrupt_envelope((INTERRUPT_ENVELOPE, None)) is True
+    assert is_interrupt_envelope((PLAIN_DICT_RESULT, None)) is False
+
+
+def test_interrupt_envelope_produces_no_tool_message() -> None:
+    """An interrupt envelope yields ``(envelope, None)``.
+
+    This mirrors the ``ToolInterruptException`` branch, which also appends no
+    ToolMessage. The envelope itself must still reach the caller as the tool
+    result so ``ToolInterruptHandler`` can collect the pending interrupt.
+    """
+    results = asyncio.run(_execute([_dict_tool("pauses", INTERRUPT_ENVELOPE)]))
+
+    assert len(results) == 1
+    tool_result, tool_message = results[0]
+    assert tool_message is None, (
+        f"interrupt envelope produced a ToolMessage: {tool_message!r}"
+    )
+    assert tool_result == INTERRUPT_ENVELOPE
+    # The handler must still recognise it, or the interrupt is silently lost.
+    assert ToolInterruptHandler._is_sub_agent_interrupt(tool_result) is True
+
+
+def test_plain_dict_result_still_produces_a_tool_message() -> None:
+    """Regression guard: only the envelope is exempt, not every dict."""
+    results = asyncio.run(_execute([_dict_tool("answers", PLAIN_DICT_RESULT)]))
+
+    assert len(results) == 1
+    tool_result, tool_message = results[0]
+    assert tool_message is not None
+    assert tool_message.tool_call_id == "tc-answers"
+    assert str(tool_message.content) == str(PLAIN_DICT_RESULT)
+    assert tool_result == PLAIN_DICT_RESULT
+
+
+def test_envelope_and_plain_dict_in_one_round() -> None:
+    """A mixed round exempts only the envelope's call, by tool_call_id."""
+    results = asyncio.run(
+        _execute(
+            [
+                _dict_tool("mixed_pauses", INTERRUPT_ENVELOPE),
+                _dict_tool("mixed_answers", PLAIN_DICT_RESULT),
+            ]
+        )
+    )
+
+    assert len(results) == 2
+    assert results[0][1] is None
+    assert results[1][1] is not None
+    assert results[1][1].tool_call_id == "tc-mixed_answers"
+
+    # What the ReAct loop does with these results: it appends only the
+    # non-None messages, so the envelope leaves no trace in the context.
+    appended = [msg for _, msg in results if msg is not None]
+    assert len(appended) == 1
+    assert "interrupt" not in str(appended[0].content)

--- a/tests/unit_tests/harness/test_deep_agent_sub_agent_identity.py
+++ b/tests/unit_tests/harness/test_deep_agent_sub_agent_identity.py
@@ -1,0 +1,98 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Unit tests for the identity a delegated sub-agent persists its state under."""
+
+from __future__ import annotations
+
+import re
+
+from openjiuwen.core.single_agent.schema.agent_card import AgentCard
+from openjiuwen.harness.deep_agent import _sub_agent_card_for_session
+from openjiuwen.harness.factory import _inject_general_purpose_subagent
+
+
+def _card(name: str = "general-purpose") -> AgentCard:
+    return AgentCard(name=name, description="desc")
+
+
+def test_identity_survives_a_parent_rebuild() -> None:
+    """A resumed delegation must find the state its first run wrote.
+
+    The parent agent is rebuilt between the two runs, so a card minted per
+    build strands the parked interruption state under an unreachable id.
+    """
+    first = _sub_agent_card_for_session(_card(), "parent_sub_general-purpose_ab12cd34")
+    second = _sub_agent_card_for_session(_card(), "parent_sub_general-purpose_ab12cd34")
+
+    assert first.id == second.id
+
+
+def test_identity_separates_distinct_sub_sessions() -> None:
+    """Concurrent delegations keep the isolation the random id gave them."""
+    first = _sub_agent_card_for_session(_card(), "parent_sub_general-purpose_ab12cd34")
+    second = _sub_agent_card_for_session(_card(), "parent_sub_general-purpose_ef56ab78")
+
+    assert first.id != second.id
+
+
+def test_identity_separates_distinct_sub_agent_types() -> None:
+    """Two types sharing a sub-session id still get separate state."""
+    first = _sub_agent_card_for_session(_card("general-purpose"), "parent_sub")
+    second = _sub_agent_card_for_session(_card("code"), "parent_sub")
+
+    assert first.id != second.id
+
+
+def test_identity_keeps_the_hex_shape_of_the_id_it_replaces() -> None:
+    """Consumers that treat the id as an opaque hex token are unaffected."""
+    card = _sub_agent_card_for_session(_card(), "parent_sub_general-purpose_ab12cd34")
+
+    assert re.fullmatch(r"[0-9a-f]{32}", card.id)
+
+
+def test_identity_does_not_mutate_the_shared_spec_card() -> None:
+    """The spec is reused for every delegation, so it must not be rewritten."""
+    spec_card = _card()
+    original_id = spec_card.id
+
+    _sub_agent_card_for_session(spec_card, "parent_sub_general-purpose_ab12cd34")
+
+    assert spec_card.id == original_id
+
+
+def test_identity_preserves_the_rest_of_the_card() -> None:
+    """Only the id is derived; name and description still describe the agent."""
+    card = _sub_agent_card_for_session(_card(), "parent_sub_general-purpose_ab12cd34")
+
+    assert card.name == "general-purpose"
+    assert card.description == "desc"
+
+
+def test_injected_general_purpose_spec_is_the_unstable_source() -> None:
+    """Records why the identity has to be derived rather than taken as given.
+
+    The injected spec mints a fresh card per parent build; without deriving
+    from the sub-session id, the state namespace moves with it.
+    """
+    def _build() -> AgentCard:
+        specs = _inject_general_purpose_subagent(
+            subagents=None,
+            add_general_purpose_agent=True,
+            resolved_language="en",
+            system_prompt="sp",
+            tools=None,
+            mcps=None,
+            model=None,
+            skills=None,
+            rails=None,
+            workspace=None,
+        )
+        return specs[0].agent_card
+
+    first, second = _build(), _build()
+
+    assert first.id != second.id
+    assert (
+        _sub_agent_card_for_session(first, "parent_sub_general-purpose_ab12cd34").id
+        == _sub_agent_card_for_session(second, "parent_sub_general-purpose_ab12cd34").id
+    )

--- a/tests/unit_tests/harness/tools/test_task_tool_interrupt.py
+++ b/tests/unit_tests/harness/tools/test_task_tool_interrupt.py
@@ -1,0 +1,90 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Unit tests for TaskTool surfacing sub-agent interrupts to its caller."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from openjiuwen.core.foundation.tool import ToolCard
+from openjiuwen.core.session.agent import Session
+from openjiuwen.core.single_agent.interrupt.handler import ToolInterruptHandler
+from openjiuwen.core.single_agent.schema.agent_card import AgentCard
+from openjiuwen.harness.tools.subagent.task_tool import TaskTool
+
+
+def _interrupt_envelope() -> dict:
+    """The dict shape an agent returns from ``commit_interrupt``."""
+    return {
+        "result_type": "interrupt",
+        "state": [],
+        "interrupt_ids": ["inner_call_1"],
+    }
+
+
+class _FakeSubAgent:
+    """Subagent returning a scripted result and recording its inputs."""
+
+    def __init__(self, result: dict) -> None:
+        self.card = AgentCard(id="sub", name="sub", description="sub")
+        self._result = result
+        self.inputs: list[dict] = []
+
+    async def invoke(self, inputs: dict) -> dict:
+        self.inputs.append(dict(inputs))
+        return self._result
+
+
+def _make_tool(subagent: _FakeSubAgent) -> TaskTool:
+    """A TaskTool whose parent has KV-cache affinity switched off."""
+    parent = SimpleNamespace(
+        deep_config=SimpleNamespace(model=None, kv_cache_affinity_config=None),
+        create_subagent=lambda *_args, **_kwargs: subagent,
+    )
+    return TaskTool(ToolCard(id="task_tool", name="task_tool", description="task"), parent)
+
+
+async def _invoke(subagent: _FakeSubAgent):
+    return await _make_tool(subagent).invoke(
+        {"subagent_type": "code", "task_description": "run task"},
+        session=Session(session_id="parent_session"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_interrupt_result_is_passed_through_unflattened() -> None:
+    """The envelope reaches the caller intact, not as an empty success."""
+    result = await _invoke(_FakeSubAgent(_interrupt_envelope()))
+
+    assert result == _interrupt_envelope()
+    assert result["result_type"] == "interrupt"
+    assert result["interrupt_ids"] == ["inner_call_1"]
+
+
+@pytest.mark.asyncio
+async def test_interrupt_result_is_recognised_by_the_interrupt_handler() -> None:
+    """The producer emits exactly the shape the consuming handler tests for."""
+    result = await _invoke(_FakeSubAgent(_interrupt_envelope()))
+
+    assert ToolInterruptHandler._is_sub_agent_interrupt(result) is True
+
+
+@pytest.mark.asyncio
+async def test_normal_result_is_unaffected() -> None:
+    """A completed subagent still returns a flattened successful ToolOutput."""
+    result = await _invoke(_FakeSubAgent({"output": "done"}))
+
+    assert result.success is True
+    assert result.data == {"output": "done", "agent_id": "sub"}
+    assert ToolInterruptHandler._is_sub_agent_interrupt(result) is False
+
+
+@pytest.mark.asyncio
+async def test_partial_interrupt_shape_is_not_treated_as_an_interrupt() -> None:
+    """A result without ``interrupt_ids`` is a normal result, not an interrupt."""
+    result = await _invoke(_FakeSubAgent({"result_type": "interrupt", "output": "done"}))
+
+    assert result.success is True
+    assert result.data["output"] == "done"

--- a/tests/unit_tests/harness/tools/test_task_tool_resume_input.py
+++ b/tests/unit_tests/harness/tools/test_task_tool_resume_input.py
@@ -1,0 +1,118 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Unit tests for the resume-input contract between the interrupt handler and TaskTool."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from openjiuwen.core.foundation.llm.schema.tool_call import ToolCall
+from openjiuwen.core.foundation.tool import ToolCard
+from openjiuwen.core.session.agent import Session
+from openjiuwen.core.single_agent.interrupt.handler import ToolInterruptHandler
+from openjiuwen.core.single_agent.interrupt.state import SUB_AGENT_RESUME_INPUT_KEY
+from openjiuwen.core.single_agent.schema.agent_card import AgentCard
+from openjiuwen.harness.tools.subagent.task_tool import TaskTool
+
+
+class _FakeSubAgent:
+    """Subagent recording the inputs it is invoked with."""
+
+    def __init__(self) -> None:
+        self.card = AgentCard(id="sub", name="sub", description="sub")
+        self.inputs: list[dict] = []
+
+    async def invoke(self, inputs: dict) -> dict:
+        self.inputs.append(dict(inputs))
+        return {"output": "done"}
+
+
+def _make_tool(subagent: _FakeSubAgent) -> TaskTool:
+    parent = SimpleNamespace(
+        deep_config=SimpleNamespace(model=None, kv_cache_affinity_config=None),
+        create_subagent=lambda *_args, **_kwargs: subagent,
+    )
+    return TaskTool(ToolCard(id="task_tool", name="task_tool", description="task"), parent)
+
+
+def _resume_tool_call(user_input) -> ToolCall:
+    tool_call = ToolCall(
+        id="call_1",
+        type="function",
+        name="task_tool",
+        arguments='{"subagent_type": "code", "task_description": "run task"}',
+    )
+    return ToolInterruptHandler._build_sub_agent_resume_tool_call(tool_call, user_input)
+
+
+def test_handler_writes_the_answer_under_the_shared_key() -> None:
+    """The handler hands the answer over under the agreed argument name."""
+    user_input = {"action": "allow_once"}
+
+    resumed = _resume_tool_call(user_input)
+
+    assert resumed.arguments[SUB_AGENT_RESUME_INPUT_KEY] == user_input
+
+
+def test_handler_still_answers_agent_abilities_through_query() -> None:
+    """An agent registered as an ability keeps reading the answer from "query"."""
+    user_input = {"action": "allow_once"}
+
+    resumed = _resume_tool_call(user_input)
+
+    assert resumed.arguments["query"] == user_input
+
+
+def test_handler_preserves_the_original_arguments() -> None:
+    """The replayed call still identifies which delegation it is resuming."""
+    resumed = _resume_tool_call({"action": "allow_once"})
+
+    assert resumed.arguments["subagent_type"] == "code"
+    assert resumed.arguments["task_description"] == "run task"
+
+
+@pytest.mark.asyncio
+async def test_resume_key_round_trips_into_the_subagent_query() -> None:
+    """What the handler writes is what TaskTool forwards to the subagent."""
+    subagent = _FakeSubAgent()
+    user_input = {"action": "allow_once"}
+    resumed = _resume_tool_call(user_input)
+
+    await _make_tool(subagent).invoke(
+        resumed.arguments, session=Session(session_id="parent_session")
+    )
+
+    # The answer replaces the task description, so the subagent resumes its
+    # parked turn instead of starting the original task over.
+    assert subagent.inputs[0]["query"] == user_input
+
+
+@pytest.mark.asyncio
+async def test_call_without_resume_input_still_sends_the_task_description() -> None:
+    """The first, uninterrupted call is unaffected by the resume contract."""
+    subagent = _FakeSubAgent()
+
+    await _make_tool(subagent).invoke(
+        {"subagent_type": "code", "task_description": "run task"},
+        session=Session(session_id="parent_session"),
+    )
+
+    assert subagent.inputs[0]["query"] == "run task"
+
+
+@pytest.mark.asyncio
+async def test_resumed_call_reaches_the_interrupted_sub_session() -> None:
+    """The resumed delegation targets the session holding the parked state."""
+    subagent = _FakeSubAgent()
+    tool = _make_tool(subagent)
+    session = Session(session_id="parent_session")
+
+    await tool.invoke(
+        {"subagent_type": "code", "task_description": "run task"}, session=session
+    )
+    await tool.invoke(_resume_tool_call({"action": "allow_once"}).arguments, session=session)
+
+    first, second = subagent.inputs
+    assert first["conversation_id"] == second["conversation_id"]

--- a/tests/unit_tests/harness/tools/test_task_tool_resume_reaches_parked_state.py
+++ b/tests/unit_tests/harness/tools/test_task_tool_resume_reaches_parked_state.py
@@ -1,0 +1,242 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Unit tests for a resumed delegation reaching the sub-agent that is waiting.
+
+An approved interrupt has to continue the paused sub-agent, not start an
+identical one. The sub-agent finds its parked ``ToolInterruptionState`` through
+the session state it persists, which is namespaced by session id *and* agent
+id, so both have to survive the pause. ``_SubAgentStateStore`` below mirrors
+that two-part namespace, which is what the delegation is asserted against.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from openjiuwen.core.foundation.llm import AssistantMessage
+from openjiuwen.core.foundation.llm.schema.tool_call import ToolCall
+from openjiuwen.core.foundation.tool import ToolCard
+from openjiuwen.core.session.agent import Session
+from openjiuwen.core.single_agent.interrupt.handler import ToolInterruptHandler
+from openjiuwen.core.single_agent.interrupt.state import (
+    INTERRUPTION_KEY,
+    ToolInterruptEntry,
+    ToolInterruptionState,
+)
+from openjiuwen.core.single_agent.schema.agent_card import AgentCard
+from openjiuwen.harness.deep_agent import _sub_agent_card_for_session
+from openjiuwen.harness.tools.subagent.task_tool import TaskTool
+
+_SPEC_CARD_NAME = "general-purpose"
+_TASK = "audit the deployment scripts"
+
+
+def _interrupt_envelope() -> dict:
+    return {"result_type": "interrupt", "state": [], "interrupt_ids": ["inner_bash"]}
+
+
+def _parked_state() -> ToolInterruptionState:
+    """The state a sub-agent leaves behind when it stops to ask a question."""
+    inner_call = ToolCall(
+        id="inner_bash", type="function", name="bash", arguments='{"command": "ls"}'
+    )
+    state = ToolInterruptionState(
+        ai_message=AssistantMessage(content="", tool_calls=[inner_call]),
+        iteration=5,
+        original_query=_TASK,
+    )
+    state.interrupted_tools = {
+        "inner_bash": ToolInterruptEntry(tool_call=inner_call, is_sub_agent=False)
+    }
+    return state
+
+
+class _SubAgentStateStore:
+    """Persisted sub-agent state, namespaced the way AgentStorage namespaces it."""
+
+    def __init__(self) -> None:
+        self.blobs: dict[tuple[str, str], dict] = {}
+
+    def load(self, session_id: str, agent_id: str) -> dict:
+        return self.blobs.setdefault((session_id, agent_id), {})
+
+    def namespaces(self) -> list[tuple[str, str]]:
+        return sorted(self.blobs)
+
+
+class _FakeSubAgent:
+    """Sub-agent that resumes from parked state, or starts over when it finds none.
+
+    Stands in for the ReAct loop's own resume dispatch: it looks for an
+    interruption under its own namespace and either continues the paused run or
+    treats the input as a brand new request.
+    """
+
+    def __init__(self, card, store: _SubAgentStateStore, interrupt_again: bool = False) -> None:
+        self.card = card
+        self._store = store
+        self._interrupt_again = interrupt_again
+        self.runs: list[dict] = []
+
+    async def invoke(self, inputs: dict) -> dict:
+        session_id = inputs["conversation_id"]
+        state = self._store.load(session_id, self.card.id)
+        parked = state.get(INTERRUPTION_KEY)
+
+        if parked is not None:
+            # Resume: the answer is delivered to the tool that was waiting.
+            state[INTERRUPTION_KEY] = None
+            self.runs.append({"mode": "resume", "query": inputs["query"]})
+            if self._interrupt_again:
+                state[INTERRUPTION_KEY] = _parked_state()
+                return _interrupt_envelope()
+            return {"output": "audit complete"}
+
+        # No parked state: a fresh run over whatever arrived as the query.
+        self.runs.append({"mode": "start", "query": inputs["query"]})
+        state[INTERRUPTION_KEY] = _parked_state()
+        return _interrupt_envelope()
+
+
+class _ParentAgent:
+    """Parent whose sub-agent card is derived exactly as create_subagent derives it.
+
+    A new instance stands for the parent being rebuilt, which is what happens
+    between a question being asked and its answer arriving.
+    """
+
+    def __init__(self, store: _SubAgentStateStore, interrupt_again: bool = False) -> None:
+        self.deep_config = SimpleNamespace(model=None, kv_cache_affinity_config=None)
+        self._store = store
+        self._interrupt_again = interrupt_again
+        # Minted per build, exactly as the injected general-purpose spec is.
+        self._spec_card = AgentCard(name=_SPEC_CARD_NAME, description="gp")
+        self.subagents: list[_FakeSubAgent] = []
+
+    def create_subagent(self, subagent_type: str, subsession_id: str, **_kwargs):
+        card = _sub_agent_card_for_session(self._spec_card, subsession_id)
+        subagent = _FakeSubAgent(card, self._store, self._interrupt_again)
+        self.subagents.append(subagent)
+        return subagent
+
+
+def _tool(parent: _ParentAgent) -> TaskTool:
+    return TaskTool(ToolCard(id="task_tool", name="task_tool", description="task"), parent)
+
+
+def _resume_arguments(user_input) -> dict:
+    """The arguments the handler replays a paused delegation with."""
+    tool_call = ToolCall(
+        id="call_1",
+        type="function",
+        name="task_tool",
+        arguments=f'{{"subagent_type": "{_SPEC_CARD_NAME}", "task_description": "{_TASK}"}}',
+    )
+    return ToolInterruptHandler._build_sub_agent_resume_tool_call(
+        tool_call, user_input
+    ).arguments
+
+
+async def _ask_then_answer(store, answer, interrupt_again: bool = False):
+    """Run the delegation, then resume it from a rebuilt parent."""
+    session = Session(session_id="parent_session")
+
+    asking_parent = _ParentAgent(store)
+    first = await _tool(asking_parent).invoke(
+        {"subagent_type": _SPEC_CARD_NAME, "task_description": _TASK}, session=session
+    )
+
+    # The answer arrives on a new turn, against a freshly built parent.
+    answering_parent = _ParentAgent(store, interrupt_again=interrupt_again)
+    second = await _tool(answering_parent).invoke(_resume_arguments(answer), session=session)
+
+    return asking_parent, answering_parent, first, second
+
+
+@pytest.mark.asyncio
+async def test_the_first_run_parks_its_state_and_surfaces_the_question() -> None:
+    """The behaviour being protected: the interrupt still reaches the caller."""
+    store = _SubAgentStateStore()
+    asking_parent, _, first, _ = await _ask_then_answer(store, {"approved": True})
+
+    assert ToolInterruptHandler._is_sub_agent_interrupt(first) is True
+    assert asking_parent.subagents[0].runs[0]["mode"] == "start"
+
+
+@pytest.mark.asyncio
+async def test_resumed_delegation_reaches_the_same_sub_session() -> None:
+    """Both runs address one session, so one parked state is in play."""
+    store = _SubAgentStateStore()
+    asking_parent, answering_parent, _, _ = await _ask_then_answer(store, {"approved": True})
+
+    assert len(store.namespaces()) == 1
+
+
+@pytest.mark.asyncio
+async def test_resumed_delegation_reaches_the_same_sub_agent_identity() -> None:
+    """The rebuilt parent must address the identity holding the parked state."""
+    store = _SubAgentStateStore()
+    asking_parent, answering_parent, _, _ = await _ask_then_answer(store, {"approved": True})
+
+    assert asking_parent.subagents[0].card.id == answering_parent.subagents[0].card.id
+
+
+@pytest.mark.asyncio
+async def test_resumed_delegation_resumes_instead_of_restarting() -> None:
+    """An approval continues the paused work rather than repeating it."""
+    store = _SubAgentStateStore()
+    _, answering_parent, _, _ = await _ask_then_answer(store, {"approved": True})
+
+    resumed_run = answering_parent.subagents[0].runs[0]
+    assert resumed_run["mode"] == "resume"
+    # Re-running the task from scratch loses the work already done, and is
+    # worse than pausing, because the approval appears to have been honoured.
+    assert resumed_run["query"] != _TASK
+
+
+@pytest.mark.asyncio
+async def test_resume_consumes_the_parked_interruption_state() -> None:
+    """The answer clears the state, so nothing stays parked behind the turn."""
+    store = _SubAgentStateStore()
+    _, answering_parent, _, _ = await _ask_then_answer(store, {"approved": True})
+
+    (namespace,) = store.namespaces()
+    assert store.blobs[namespace][INTERRUPTION_KEY] is None
+
+
+@pytest.mark.asyncio
+async def test_resume_delivers_the_answer_to_the_waiting_sub_agent() -> None:
+    """The user's decision, not the original task, is what the resume carries."""
+    store = _SubAgentStateStore()
+    answer = {"approved": True, "auto_confirm": False, "feedback": ""}
+    _, answering_parent, _, _ = await _ask_then_answer(store, answer)
+
+    assert answering_parent.subagents[0].runs[0]["query"] == answer
+
+
+@pytest.mark.asyncio
+async def test_completed_resume_returns_the_sub_agent_result() -> None:
+    """A resumed run that finishes reports its output to the parent."""
+    store = _SubAgentStateStore()
+    _, _, _, second = await _ask_then_answer(store, {"approved": True})
+
+    assert second.success is True
+    assert second.data["output"] == "audit complete"
+
+
+@pytest.mark.asyncio
+async def test_second_interrupt_in_the_resumed_run_still_surfaces() -> None:
+    """A resumed run that pauses again asks again, rather than going quiet."""
+    store = _SubAgentStateStore()
+    _, answering_parent, _, second = await _ask_then_answer(
+        store, {"approved": True}, interrupt_again=True
+    )
+
+    # The question has to come from the continued run, not from a restart that
+    # happens to stop at the same tool: a restart asks about work already
+    # approved once.
+    assert answering_parent.subagents[0].runs[0]["mode"] == "resume"
+    assert ToolInterruptHandler._is_sub_agent_interrupt(second) is True
+    assert second["interrupt_ids"] == ["inner_bash"]

--- a/tests/unit_tests/harness/tools/test_task_tool_streamed_pause_round_trip.py
+++ b/tests/unit_tests/harness/tools/test_task_tool_streamed_pause_round_trip.py
@@ -1,0 +1,423 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""End-to-end cover for a delegated pause and the answer that resumes it.
+
+The other files in this change each pin one link of the round trip. This one
+runs the whole of it against a subagent that exposes ``stream``, which is what
+every ``DeepAgent`` subagent exposes and therefore what ``TaskTool`` actually
+delegates to: ``_run_subagent_with_observable_stream`` prefers the streaming
+path and only falls back to ``invoke`` for an adaptor that has no ``stream``.
+
+That distinction is the whole point of the file. A pause never reaches
+``TaskTool.invoke`` as a return value on the streaming path -- ``ReActAgent``
+writes the envelope's ``state`` schemas to the stream and emits no terminal
+answer -- so a test whose subagent only implements ``invoke`` exercises a path
+no delegation takes and cannot see the envelope being dropped.
+
+Every step that shapes the envelope is production code: the agent-side write
+(``ReActAgent._write_invoke_result_to_stream``), the tool-side rebuild
+(``_run_subagent_with_observable_stream``), the caller-side collection
+(``ToolInterruptHandler.build_interrupt_state`` and ``build_interrupt_result``)
+and the replay that carries the answer back
+(``ToolInterruptHandler._build_sub_agent_resume_tool_call``). Only the stream
+transport and the subagent's own turn are doubled.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any, Optional
+
+import pytest
+
+from openjiuwen.core.common.constants.constant import INTERACTION
+from openjiuwen.core.foundation.llm import AssistantMessage
+from openjiuwen.core.foundation.llm.schema.tool_call import ToolCall
+from openjiuwen.core.foundation.tool import ToolCard
+from openjiuwen.core.session.agent import Session
+from openjiuwen.core.session.interaction.interaction import InteractionOutput
+from openjiuwen.core.session.stream.base import OutputSchema
+from openjiuwen.core.single_agent.agents.react_agent import ReActAgent
+from openjiuwen.core.single_agent.interrupt.handler import ToolInterruptHandler
+from openjiuwen.core.single_agent.interrupt.response import ToolCallInterruptRequest
+from openjiuwen.core.single_agent.interrupt.state import (
+    INTERRUPTION_KEY,
+    ToolInterruptEntry,
+    ToolInterruptionState,
+)
+from openjiuwen.core.single_agent.schema.agent_card import AgentCard
+from openjiuwen.harness.tools.subagent.task_tool import (
+    TaskTool,
+    _run_subagent_with_observable_stream,
+)
+
+try:  # pragma: no cover - exercised by whichever tree the test runs on
+    from openjiuwen.harness.deep_agent import _sub_agent_card_for_session
+except ImportError:  # pragma: no cover
+    def _sub_agent_card_for_session(card: AgentCard, subsession_id: str) -> AgentCard:
+        """Stand in for the derivation when the tree under test has none.
+
+        Returning the spec's card unchanged is exactly what ``create_subagent``
+        does without it, so the test measures the round trip on either tree
+        rather than failing to import on one of them.
+        """
+        return card
+
+
+_SPEC_CARD_NAME = "general-purpose"
+_TASK = "audit the deployment scripts"
+_QUESTION = "run `rm -rf build`?"
+_INNER_CALL_ID = "inner_bash"
+_OUTER_CALL_ID = "call_task_tool_1"
+_ANSWER = {"approved": True, "auto_confirm": False, "feedback": ""}
+
+
+def _inner_tool_call() -> ToolCall:
+    return ToolCall(
+        id=_INNER_CALL_ID,
+        type="function",
+        name="bash",
+        arguments='{"command": "rm -rf build"}',
+    )
+
+
+def _sub_agent_interrupt_result() -> dict:
+    """The envelope a paused ReAct turn returns, built by the real constructor."""
+    request = ToolCallInterruptRequest(
+        message=_QUESTION,
+        tool_call_id=_INNER_CALL_ID,
+        tool_name="bash",
+        tool_args={"command": "rm -rf build"},
+    )
+    payload = OutputSchema(
+        type=INTERACTION,
+        index=0,
+        payload=InteractionOutput(id=_INNER_CALL_ID, value=request),
+    )
+    return ToolInterruptHandler.build_interrupt_result([(_INNER_CALL_ID, payload)])
+
+
+def _parked_state() -> ToolInterruptionState:
+    """The state the subagent leaves in its own session when it pauses."""
+    inner_call = _inner_tool_call()
+    state = ToolInterruptionState(
+        ai_message=AssistantMessage(content="", tool_calls=[inner_call]),
+        iteration=3,
+        original_query=_TASK,
+    )
+    state.interrupted_tools = {
+        _INNER_CALL_ID: ToolInterruptEntry(tool_call=inner_call, is_sub_agent=False)
+    }
+    return state
+
+
+class _StateStore:
+    """Persisted agent state, namespaced by session id *and* agent id.
+
+    Both halves have to survive the pause for the answer to find the parked
+    state: the session id is what ``TaskTool`` derives per delegation, the
+    agent id is what the subagent's card carries.
+    """
+
+    def __init__(self) -> None:
+        self.blobs: dict[tuple[str, str], dict] = {}
+
+    def load(self, session_id: str, agent_id: str) -> dict:
+        return self.blobs.setdefault((session_id, agent_id), {})
+
+    def namespaces(self) -> list[tuple[str, str]]:
+        return sorted(self.blobs)
+
+
+class _RecordingStream:
+    """Stands in for the session's stream transport, keeping chunks verbatim.
+
+    ``OutputSchema.payload`` is typed ``Any``, so the real writer hands the
+    schema through unchanged; the schemas are what matter here, not the queue.
+    """
+
+    def __init__(self) -> None:
+        self.chunks: list = []
+
+    async def write_stream(self, data) -> None:
+        self.chunks.append(data)
+
+
+class _StreamingSubAgent:
+    """A subagent shaped like ``DeepAgent``: it has ``stream``, so ``TaskTool`` uses it.
+
+    Its turn either pauses -- parking state under its own namespace and
+    returning an interrupt envelope -- or resumes the parked turn. Whichever it
+    is, the result leaves through the real ``ReActAgent`` stream writer.
+    """
+
+    def __init__(self, card: AgentCard, store: _StateStore) -> None:
+        self.card = card
+        self._store = store
+        self.runs: list[dict] = []
+
+    async def _turn(self, inputs: dict) -> dict:
+        blob = self._store.load(inputs["conversation_id"], self.card.id)
+        if blob.get(INTERRUPTION_KEY) is not None:
+            blob[INTERRUPTION_KEY] = None
+            self.runs.append({"mode": "resume", "query": inputs["query"]})
+            return {"output": "build directory removed", "result_type": "answer"}
+
+        self.runs.append({"mode": "start", "query": inputs["query"]})
+        blob[INTERRUPTION_KEY] = _parked_state()
+        return _sub_agent_interrupt_result()
+
+    async def invoke(self, inputs: dict) -> dict:
+        return await self._turn(inputs)
+
+    async def stream(self, inputs: dict):
+        result = await self._turn(inputs)
+        recorder = _RecordingStream()
+        writer = ReActAgent.__new__(ReActAgent)
+        writer._hitl_handler = ToolInterruptHandler(writer)
+        await writer._write_invoke_result_to_stream(result, recorder)
+        for chunk in recorder.chunks:
+            yield chunk
+
+
+class _ParentAgent:
+    """A parent build. A second instance stands for the parent being rebuilt.
+
+    The spec's card is minted fresh per build, exactly as the injected
+    general-purpose spec's is, so a card id that is not derived from the
+    sub-session cannot survive the rebuild that delivers the answer.
+    """
+
+    def __init__(self, store: _StateStore) -> None:
+        self.deep_config = SimpleNamespace(model=None, kv_cache_affinity_config=None)
+        self._store = store
+        self._spec_card = AgentCard(name=_SPEC_CARD_NAME, description="gp")
+        self.subagents: list[_StreamingSubAgent] = []
+
+    def create_subagent(self, subagent_type: str, subsession_id: str, **_kwargs):
+        subagent = _StreamingSubAgent(
+            _sub_agent_card_for_session(self._spec_card, subsession_id), self._store
+        )
+        self.subagents.append(subagent)
+        return subagent
+
+
+def _tool(parent: _ParentAgent) -> TaskTool:
+    return TaskTool(ToolCard(id="task_tool", name="task_tool", description="task"), parent)
+
+
+def _delegating_tool_call() -> ToolCall:
+    return ToolCall(
+        id=_OUTER_CALL_ID,
+        type="function",
+        name="task_tool",
+        arguments=(
+            f'{{"subagent_type": "{_SPEC_CARD_NAME}", "task_description": "{_TASK}"}}'
+        ),
+    )
+
+
+@dataclass
+class _RoundTrip:
+    """What each stage of the round trip produced, so a test can assert on it.
+
+    ``caller_interrupt`` and everything after it are ``None`` when the pause
+    never reached the caller: there is then no delegating call to replay and no
+    answer to route back, which is the defect this file exists to catch rather
+    than a reason to stop the run.
+    """
+
+    asking_parent: _ParentAgent
+    tool_result: Any
+    caller_interrupt: Optional[dict] = None
+    parked_state: Optional[ToolInterruptionState] = None
+    answering_parent: Optional[_ParentAgent] = None
+    final: Any = None
+
+
+async def _round_trip(store: _StateStore) -> _RoundTrip:
+    """Delegate, surface the pause to the caller, answer it, resume the subagent."""
+    session = Session(session_id="parent_session")
+    delegating_call = _delegating_tool_call()
+
+    # 1. The parent delegates and the subagent stops to ask.
+    asking_parent = _ParentAgent(store)
+    tool_result = await _tool(asking_parent).invoke(
+        {"subagent_type": _SPEC_CARD_NAME, "task_description": _TASK},
+        session=session,
+    )
+    trip = _RoundTrip(asking_parent=asking_parent, tool_result=tool_result)
+
+    # 2. The caller's ReAct loop collects that result and commits an interrupt.
+    handler = ToolInterruptHandler(SimpleNamespace())
+    parked_state, payloads = handler.build_interrupt_state(
+        results=[(tool_result, None)],
+        tool_calls=[delegating_call],
+        ai_message=AssistantMessage(content="", tool_calls=[delegating_call]),
+        iteration=1,
+    )
+    if parked_state is None:
+        return trip
+    trip.parked_state = parked_state
+    trip.caller_interrupt = ToolInterruptHandler.build_interrupt_result(payloads)
+
+    # 3. The user answers. The handler replays the delegating call it parked.
+    replayed = ToolInterruptHandler._build_sub_agent_resume_tool_call(
+        parked_state.interrupted_tools[_OUTER_CALL_ID].tool_call, _ANSWER
+    )
+
+    # 4. The answer arrives on a later turn, against a rebuilt parent.
+    trip.answering_parent = _ParentAgent(store)
+    trip.final = await _tool(trip.answering_parent).invoke(
+        replayed.arguments, session=session
+    )
+    return trip
+
+
+@pytest.mark.asyncio
+async def test_streamed_pause_reaches_the_caller() -> None:
+    """Out: the question the subagent raised is the one the caller surfaces."""
+    store = _StateStore()
+    trip = await _round_trip(store)
+
+    assert trip.caller_interrupt is not None, (
+        "the caller collected no interrupt from the delegation: the pause was "
+        f"flattened into an ordinary result on the way out ({trip.tool_result!r})"
+    )
+    assert ToolInterruptHandler._is_sub_agent_interrupt(trip.caller_interrupt) is True
+    assert trip.caller_interrupt["interrupt_ids"] == [_INNER_CALL_ID]
+
+    (surfaced,) = trip.caller_interrupt["state"]
+    assert surfaced.payload.value.message == _QUESTION
+
+
+@pytest.mark.asyncio
+async def test_caller_parks_the_delegating_call_as_a_sub_agent_interrupt() -> None:
+    """The caller records which of its own tool calls is waiting, and for what."""
+    store = _StateStore()
+    trip = await _round_trip(store)
+
+    assert trip.parked_state is not None, (
+        "no interruption state was parked for the delegating call, so nothing "
+        "would be replayed when the user answers"
+    )
+    entry = trip.parked_state.interrupted_tools[_OUTER_CALL_ID]
+    assert entry.is_sub_agent is True
+    assert entry.tool_call.name == "task_tool"
+    assert list(entry.interrupt_requests) == [_INNER_CALL_ID]
+
+
+@pytest.mark.asyncio
+async def test_the_answer_reaches_the_sub_agent_that_asked() -> None:
+    """Back: the resumed run is the parked one, and it carries the answer."""
+    store = _StateStore()
+    trip = await _round_trip(store)
+
+    assert trip.answering_parent is not None, (
+        "the pause never reached the caller, so no answer was routed back into "
+        "the subagent that asked"
+    )
+    assert len(store.namespaces()) == 1, (
+        "the replay addressed a different (session id, agent id) namespace than "
+        f"the pause did: {store.namespaces()}"
+    )
+    assert (
+        trip.asking_parent.subagents[0].card.id
+        == trip.answering_parent.subagents[0].card.id
+    )
+
+    resumed = trip.answering_parent.subagents[0].runs[0]
+    assert resumed["mode"] == "resume", (
+        "the replay started a fresh run instead of continuing the paused one"
+    )
+    assert resumed["query"] == _ANSWER
+
+
+@pytest.mark.asyncio
+async def test_the_resumed_delegation_reports_the_completed_work() -> None:
+    """The round trip ends as an ordinary success once the answer lands."""
+    store = _StateStore()
+    trip = await _round_trip(store)
+
+    assert trip.final is not None, "the round trip stopped before the resume"
+    assert trip.final.success is True
+    assert trip.final.data["output"] == "build directory removed"
+
+
+@pytest.mark.asyncio
+async def test_the_pause_leaves_the_sub_agent_state_parked_until_answered() -> None:
+    """Nothing consumes the parked state before the answer arrives."""
+    store = _StateStore()
+    session = Session(session_id="parent_session")
+    parent = _ParentAgent(store)
+
+    await _tool(parent).invoke(
+        {"subagent_type": _SPEC_CARD_NAME, "task_description": _TASK},
+        session=session,
+    )
+
+    (namespace,) = store.namespaces()
+    assert store.blobs[namespace][INTERRUPTION_KEY] is not None
+
+
+class _ChunkSubAgent:
+    """Subagent whose stream yields exactly the chunks it is given."""
+
+    def __init__(self, chunks: list) -> None:
+        self.card = AgentCard(name=_SPEC_CARD_NAME, description="gp")
+        self._chunks = chunks
+
+    async def invoke(self, inputs: dict) -> dict:
+        raise AssertionError("invoke must not be used when stream is available")
+
+    async def stream(self, inputs: dict):
+        for chunk in self._chunks:
+            yield chunk
+
+
+@pytest.mark.asyncio
+async def test_a_streamed_answer_is_still_an_answer() -> None:
+    """The completion path is unchanged: an answer chunk still wins."""
+    subagent = _ChunkSubAgent(
+        [
+            OutputSchema(type="llm_output", index=0, payload={"content": "working"}),
+            OutputSchema(
+                type="answer",
+                index=1,
+                payload={"output": "done", "result_type": "answer"},
+            ),
+        ]
+    )
+
+    result = await _run_subagent_with_observable_stream(
+        subagent, {"query": _TASK, "conversation_id": "sub"}
+    )
+
+    assert result == {"output": "done", "result_type": "answer"}
+    assert ToolInterruptHandler._is_sub_agent_interrupt(result) is False
+
+
+@pytest.mark.asyncio
+async def test_an_interaction_that_is_not_an_interrupt_request_is_not_a_pause() -> None:
+    """A workflow's own interaction chunk keeps the behaviour it has today.
+
+    Only the HITL interrupt protocol is rebuilt here. An interaction carrying
+    something else belongs to the workflow interrupt path, which returns a
+    differently shaped envelope and is not part of this round trip.
+    """
+    subagent = _ChunkSubAgent(
+        [
+            OutputSchema(
+                type=INTERACTION,
+                index=0,
+                payload=InteractionOutput(id="node_1", value={"form": "fill me in"}),
+            )
+        ]
+    )
+
+    result = await _run_subagent_with_observable_stream(
+        subagent, {"query": _TASK, "conversation_id": "sub"}
+    )
+
+    assert ToolInterruptHandler._is_sub_agent_interrupt(result) is False

--- a/tests/unit_tests/harness/tools/test_task_tool_sub_session_id.py
+++ b/tests/unit_tests/harness/tools/test_task_tool_sub_session_id.py
@@ -1,0 +1,119 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Unit tests for the sub-session id TaskTool assigns to a delegation."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from openjiuwen.harness.tools.subagent.task_tool import TaskTool
+
+
+def test_sub_session_id_is_stable_for_the_same_delegation() -> None:
+    """A replayed call must land on the session the first call created.
+
+    A resumed delegation arrives with the same arguments; a fresh random
+    suffix would point it at a new subagent and strand the parked state.
+    """
+    first = TaskTool._build_sub_session_id(
+        "parent_session", "code", task_description="run task"
+    )
+    second = TaskTool._build_sub_session_id(
+        "parent_session", "code", task_description="run task"
+    )
+
+    assert first == second
+
+
+def test_sub_session_id_separates_distinct_tasks() -> None:
+    """Unrelated delegations of one type still get isolated sessions."""
+    first = TaskTool._build_sub_session_id(
+        "parent_session", "code", task_description="task one"
+    )
+    second = TaskTool._build_sub_session_id(
+        "parent_session", "code", task_description="task two"
+    )
+
+    assert first != second
+
+
+def test_sub_session_id_separates_distinct_parents() -> None:
+    """Two parent sessions never share a subagent session."""
+    first = TaskTool._build_sub_session_id(
+        "parent_a", "code", task_description="run task"
+    )
+    second = TaskTool._build_sub_session_id(
+        "parent_b", "code", task_description="run task"
+    )
+
+    assert first != second
+
+
+def test_sub_session_id_keeps_its_established_shape() -> None:
+    """The id keeps the ``<parent>_sub_<type>_<8 hex>`` form consumers match on."""
+    sub_session_id = TaskTool._build_sub_session_id(
+        "parent_session", "code", task_description="run task"
+    )
+
+    assert re.fullmatch(r"parent_session_sub_code_[0-9a-f]{8}", sub_session_id)
+
+
+def test_sticky_sub_session_id_is_unchanged() -> None:
+    """Sticky types keep the bare deterministic id they already had."""
+    sub_session_id = TaskTool._build_sub_session_id(
+        "parent_session", "verification_agent", task_description="run task"
+    )
+
+    assert sub_session_id == "parent_session_sub_verification_agent"
+
+
+def test_missing_task_description_still_yields_a_valid_id() -> None:
+    """An absent description degrades to a constant suffix, not a crash."""
+    sub_session_id = TaskTool._build_sub_session_id("parent_session", "code")
+
+    assert re.fullmatch(r"parent_session_sub_code_[0-9a-f]{8}", sub_session_id)
+
+
+def test_explicit_resume_id_outranks_the_derived_suffix() -> None:
+    """A caller naming its session is obeyed, whatever the description holds.
+
+    The derived suffix and an explicitly resumed session are two answers to
+    the same question, so the precedence between them has to be pinned: the
+    id the caller names is returned verbatim and the description is ignored.
+    """
+    resume_id = "parent_session_sub_browser_agent_1234abcd"
+
+    sub_session_id = TaskTool._build_sub_session_id(
+        "parent_session",
+        "browser_agent",
+        resume_id,
+        task_description="a description that would hash to something else",
+    )
+
+    assert sub_session_id == resume_id
+
+
+def test_derived_suffix_applies_when_no_resume_id_is_given() -> None:
+    """Omitting the resume id leaves the description deriving the suffix."""
+    first = TaskTool._build_sub_session_id(
+        "parent_session", "browser_agent", "", task_description="browse a page"
+    )
+    second = TaskTool._build_sub_session_id(
+        "parent_session", "browser_agent", "", task_description="browse a page"
+    )
+
+    assert first == second
+    assert re.fullmatch(r"parent_session_sub_browser_agent_[0-9a-f]{8}", first)
+
+
+def test_resume_id_from_another_parent_is_rejected() -> None:
+    """The caller cannot name a session belonging to a different parent."""
+    with pytest.raises(ValueError):
+        TaskTool._build_sub_session_id(
+            "another_parent",
+            "browser_agent",
+            "parent_session_sub_browser_agent_1234abcd",
+            task_description="run task",
+        )


### PR DESCRIPTION
Paired: [GitHub #962](https://github.com/openJiuwen-ai/agent-core/pull/962) ↔ [GitCode !2531](https://gitcode.com/openJiuwen/agent-core/merge_requests/2531)

**What type of PR is this?**

/kind bug

**Which issue(s) this PR fixes**:

Fixes #961

Related but not fixed here. #831 concerns `ask` decisions raised and answered within one agent — whether the switch can be turned off, how the interrupt is accounted for, how the decision comes back, and rail state lost when `ctx` is rebuilt across an invoke; this change concerns what happens to such a decision once the agent raising it is a *delegated* sub-agent. #470 concerns which entries of `interrupted_tools` a resume replays; this change is about a delegation that never gets an entry there at all, and about a replay that cannot be told from a first call once it does. #806 adds the opt-in `subagent_spawn` family with its own `send_input` lifecycle, which is a different code path and is not touched here. #656 and #657 propose consolidating the sub-agent construction paths; placing the card fix at the single `create_subagent` choke point is what lets such a consolidation carry it along. None of the four should be closed on this merge.

**What does this PR do / why do we need it**:

A sub-agent that stops to ask the user something returns an interrupt envelope rather than a finished result. Five defects sit on the path that envelope has to travel out to the user and on the path the answer takes back — the envelope is flattened into an empty success by the delegating tool, the pending question is written into the caller's context as if it were a tool result, the sub-session id is not reproducible across the replay that delivers the answer, the replayed call cannot tell itself apart from a first call, and the sub-agent's persistence identity is minted fresh on every parent build. The linked issue carries the evidence: the mechanism for each, the shipped defaults that make `task_tool` the affected path, a runnable reproduction that exhibits all five, and the affected release range.

The first of the five has had two loci since this request was rebased onto the current `develop`. `0377afe2`, `fix(observability): preserve realtime subagent trajectories`, landed after the branch was first cut and put a stream bridge in front of the sub-agent, which destroys the envelope before `TaskTool` ever sees one. Correcting `TaskTool` alone is now a no-op on every delegation a `DeepAgent` actually makes. Both are corrected; the section below sets out why.

The five are corrected together because they are one round trip and the end-to-end behaviour is right only when all five are. The branch is a single commit, so there is no per-commit split to follow. Each section below states what changes and why that answer rather than another.

---

### The envelope now leaves the delegating tool

`TaskTool` returns the envelope unchanged when the sub-agent pauses, instead of reading `output` off it. `ToolInterruptHandler` already implements the receiving half and already tests for this exact dict shape, so the envelope only has to reach it intact.

**The envelope has to survive one step more to get there, and on the current base it did not.** `_run_subagent_with_observable_stream`, added by `0377afe2`, drives a sub-agent's `stream` rather than its `invoke` whenever one exists — and every `DeepAgent` sub-agent has one, so this is the path every delegation takes; the `invoke` fallback is reached only by a third-party adaptor that has no `stream`. That bridge rebuilds an invoke-style result from the chunks it observes and knows two shapes: an `answer` chunk, and an accumulation of `llm_output` content when no answer arrives. A pause is neither. `ReActAgent._write_invoke_result_to_stream` writes an interrupt result's `state` schemas to the stream as `__interaction__` chunks and emits no terminal answer for it at all, so the bridge fell through to its empty-answer default, `{'output': '', 'result_type': 'answer'}`, and the envelope was destroyed one layer below `TaskTool`.

The bridge now collects those schemas and rebuilds the envelope from them through `ToolInterruptHandler.build_interrupt_result`, the same constructor the sub-agent's own `commit_interrupt` used, so what `TaskTool` receives is what the sub-agent returned. `interrupt_ids` are the inner ids the payloads already carry, which is how the rebuild is exact rather than approximate. Only schemas whose value is an `InterruptRequest` are collected: an interaction chunk carrying anything else belongs to a workflow's own interrupt protocol, which has a differently shaped envelope and is left exactly as it is handled today.

**Why in the bridge rather than in the agent.** The alternative is to have `DeepAgent.stream` or `ReActAgent.stream` yield the terminal interrupt result so the bridge has an `answer`-shaped chunk to read. That changes the streaming contract for every consumer of an agent stream, not only this delegation, and a pause is deliberately *not* an answer on that stream — the CLI renderer and the team monitor both read `__interaction__` chunks as the pause. Completing the bridge, which exists precisely to reconstruct an invoke-style result from a stream, keeps the change on the delegation path. This is the point of the change most worth a maintainer's disagreement, and it is listed under the unticked Design box below.

The KV-cache lifecycle is deliberately left as it stands: `finish_subagent` still runs from the `finally` block for a pause exactly as for a completion, and it offloads only for a sticky sub-agent type and evicts everything else, so a paused non-sticky delegation's cache is evicted and the resume re-warms it — on this branch as on `develop`. That is a cost rather than a correctness problem, and keeping a cache alive for a pause that may never be answered is its own question. Cache affinity does not disturb the reproducible id this change depends on: when it is enabled, `kv_cache_subagent_lifecycle.scope_sub_session_id` appends `_scope_<sha256(parent_cache_id)[:12]>` to the derived id, which is a deterministic function of the parent cache id, so the replay that carries the answer back resolves to the same sub-session the pause was parked under.

### The sub-session id now identifies the delegation

The non-sticky suffix is a digest of the id of the model-visible tool call the delegation runs under, rather than a fresh `uuid4`. `ToolInterruptHandler` replays that same call to deliver an answer, so the replay lands on the session the first call created, while two concurrent delegations remain two calls and keep the separate sessions the random suffix gave them. Sticky types already had a deterministic id and are untouched, and the id keeps its established `<parent>_sub_<type>_<8 hex>` shape.

`AbilityManager` supplies the id on the same opt-in footing as the callback context it already passes to a tool declaring `accepts_tool_callback_context`: a tool is handed it only if it sets `accepts_tool_call_id` to literally `True`. Ordinary and third-party tools keep their existing invocation contract, and an object that answers every attribute lookup (a test double or a proxy) is not handed a keyword it cannot take. A call dispatched outside the ability manager receives no id. Such a call cannot be replayed either, so there is nothing to make reproducible and the established random suffix still applies.

This replaces an earlier derivation from the task description, and the reason is worth recording. That derivation was reproducible across the replay too, but it collapsed two delegations with the same description in one parent session onto a single sub-session. On the current `develop` that is not hypothetical. `test_deep_agent_terminal_stream.py::test_real_browser_rail_stream_reaches_tasktool`, added by `7e7879d5` after this branch was first cut, parametrizes six runs of one description under one parent session. The shared sub-session then passed the `completed` run's evidence into the `partial` run, which reported `completed`. The earlier description of this change named `tool_call_id` as the better derivation and left the choice open. That test settles it.

`4cd577e1`, `fix(browser): improve runtime progress and recovery`, gave `_build_sub_session_id` a caller-supplied `resume_task_id`, by which a browser delegation hands its sub-session id back as a resume handle. That path is untouched, and a handle already issued still wins outright, because a caller naming its session is answered before any suffix is derived.

### The resumed call can now tell itself apart from a first call

The user's answer is repeated under a dedicated argument key, `SUB_AGENT_RESUME_INPUT_KEY = "_sub_agent_resume_input"`, and the delegating tool forwards it as the sub-agent's query so the sub-agent resumes its parked turn. Both sides import the one constant, so the two halves cannot drift apart. `query` keeps being set, leaving the resume path of agent abilities unchanged.

**Why a new key rather than reusing `query`.** `query` is an ordinary argument name a model can emit. A `task_tool` call that happened to carry one would be taken for a resume, and the tool would deliver a model-authored string to a sub-agent as though a user had approved something. The underscore prefix keeps the resume key clear of any model-supplied argument name and cannot collide. The release-branch change reuses `query`; that works, and this is the difference.

### The sub-agent's persistence identity is now reproducible

The sub-agent's card id is derived from the sub-session id and the card name, which makes it reproducible for the rebuild that resumes a delegation. It stays an opaque 32-character hex token.

**What that changes about separation, and in which direction.** The spec's random id was minted once per parent build and shared by every delegation of that type, so two concurrent delegations wrote their state under one agent id. The derived id is per sub-session instead — stricter than what it replaces for delegations with different tasks, and equal to it for the identical-task case noted above.

**Why in `create_subagent` rather than in the injected spec.** The spec's card is one source of the problem but not the only one: any spec built afresh per parent build has it, and a caller-supplied `SubAgentConfig` does not. Deriving at the point where a sub-agent is actually created covers all of them with one rule and does not require a spec author to know about it. It is also the choke point #656 and #657 propose consolidating around.

**The cost.** `factory.py` composes the `sys_operation` id as `{card.name}_{card.id}` and resolves get-or-create, so a repeated derivation is expected there rather than a duplicate; the flip side is that distinct sub-sessions now mint distinct registrations where they previously shared one, and nothing bounds how many accumulate over a long-lived parent.

### No `ToolMessage` is emitted for a pending question

An envelope now yields `(result, None)` from `AbilityManager._execute_single_tool_call`, which is how the surrounding paths already treat a pause: an interrupted workflow returns `(workflow_output, None)` from `_run_workflow`, and a `ToolInterruptException` is turned into `(result, None)` in `execute`, both leaving the tool call open until the answer arrives. The envelope still reaches the caller as the tool result; only the message is withheld.

**No consumer requires the message.** Exactly one place writes it into the caller's `ModelContext`, `ReActAgent._execute_tool_call`, and it already skips a `None` there. Of the other places that take the pair apart, the interrupt collection path, the multimodal-result builder and the browser runtime's result observer read the tool result and discard the message slot; the progressive tool rail's `tool_call` wrapper, which dispatches a searched deferred tool back through the ability manager, reads the message's `content` through a defaulted `getattr`; and the only two `AbilityManager` subclasses, `P2PAbilityManager` and `SessionMemoryAbilityManager`, merge the pair into their own result lists without reading it.

**The annotation.** `_execute_single_tool_call`'s return type widens from `Tuple[Any, ToolMessage]` to `Tuple[Any, Optional[ToolMessage]]`. It was already wrong before this change: the method delegates to `_run_workflow`, the definition immediately above it, which returns `(workflow_output, None)` for a workflow reporting `INPUT_REQUIRED` and is annotated `Optional` for that reason. The widening corrects an annotation that was already inaccurate rather than recording only the path added here. `_railed_execute_single_tool_call`, which passes that pair straight through, still declares the narrower type; it is left as it stands so the change keeps to the interrupt path, and nothing depends on the annotation at runtime.

**Where the shape check lives.** Once, as `is_interrupt_envelope` beside the resume key in `interrupt.state`, imported by the delegating tool, the ability manager and the handler alike. `ToolInterruptHandler._is_sub_agent_interrupt` keeps its name as a thin delegate so no caller has to change.

---

### Relation to the work already on a release branch

`5297c25a` (GitCode !2478 / GitHub #884, merged into `br_0.1.16.post2.hotfix`) fixes three of these five and meets a fourth by other means. It has not reached `develop`. #1023 forward-ports it — the same `_pending_subagents` dict, the same `tool_call_id` derivation and the same `tool_call_id` threading through `AbilityManager` — but onto `dev-stable`, which has diverged from `develop` in both directions and is not an ancestor of it, so that port does not reach this base either. Of the five defects here, #1023 fixes the flattened envelope and the unreproducible sub-session id, meets the resume-discrimination one by keeping the paused sub-agent in the per-instance dict instead of a dedicated key, and leaves the card id and the spurious `ToolMessage` untouched; it changes no `deep_agent.py` and no `ToolMessage`. The issue records that inventory. Where the two approaches differ, they differ as follows, and a maintainer who prefers the other approach can forward-port it instead — the defects are fixed either way.

- **Surfacing the envelope from `TaskTool`** — the same fix in both.
- A reproducible sub-session id: `tool_call_id` in both. This change adopted the derivation `5297c25a` reached first.
- **The resume key** — `query` there, a dedicated underscore-prefixed key here. Argued above.
- **Reaching the parked sub-agent** — a per-instance `_pending_subagents` dict there, a reproducible card id here. The dict holds the live sub-agent object, so it works only within one process and one parent instance; a derived card id needs no live object, survives a parent rebuild and a restart, and holds nothing open while a pause goes unanswered. The issue records why that difference matters.
- **Withholding the `ToolMessage`** — not addressed there. That change touches `ability_manager.py` only to thread `tool_call_id` into both `tool.invoke` call sites, and its own new test asserts that a bare dict result still produces a `ToolMessage`.

That change also routes an interrupt result through the task loop, turning a `TASK_COMPLETION` payload into `TASK_INTERACTION` and resolving the round future from `TaskLoopEventHandler`. This request has no equivalent. That is an orthogonal addition rather than a substitute for anything here, and nothing here conflicts with it.

### Why the synchronous delegation path

`task_tool` is what `SubagentRail` registers when neither `enable_subagent_runtime` nor `enable_async_subagent` is set, which is what a library caller gets without asking; the issue sets out the flag defaults and the two in-repo factories that opt out. That is why its interrupt path is worth having correct. The `ToolMessage` fix is the one of the five that is not mode-specific, since it sits a layer below in the ability manager.

### Not addressed here

- Surfacing a sub-agent interrupt through the task loop, which the release-branch change above adds. Left out to keep this change to the delegation path itself.
- Carrying a paused evolution reviewer's question out through `EvolveReviewTaskTool` in `agent_evolving/tools/skill.py`. That is the only place besides `create_task_tool` that constructs a `TaskTool`, and it does not carry an envelope onward: it reads `success` off whatever its inner `TaskTool` returns, so a dict raises `AttributeError` there, which the method's own `except Exception` turns into a failed `ToolOutput` — the type its unchanged `-> ToolOutput` annotation still describes. That is not made worse here, because on `develop` a paused reviewer is flattened inside `TaskTool` and does not reach the ability manager either. Fixing it would mean passing the envelope on and forwarding the resume key into the task description that tool composes itself.
- The `subagent_runtime` tools have their own `send_input` lifecycle and are not touched.
- A pause raised underneath the progressive tool rail's `tool_call` wrapper. That wrapper calls `AbilityManager.execute` itself and wraps the single result it gets in a `ToolOutput`, so neither a `ToolInterruptException` nor an interrupt envelope reaches the caller as an interrupt from that path; the wrapper reports `success=True` and carries the pause in `data["result"]`. It is a second dispatch route into the same method rather than part of the delegation path this change follows, and it behaves identically before and after: the envelope was buried in the same `ToolOutput` when a `ToolMessage` was still built for it.

### Adjacent, not overlapping

`fix(harness): gate sub-agent tool calls with the parent's permissions`, filed alongside this one, forwards the parent's `permissions` and `permission_host` into a sub-agent's config so that a sub-agent's tool calls are gated by the parent's policy. Neither request depends on the other to be correct, but each is weaker alone, and the relationship is worth stating plainly: gating a sub-agent is what makes it stop and ask, and a sub-agent that stops to ask returns the envelope this change exists to carry. Merged on its own, that one turns "the sub-agent runs ungated" into "the sub-agent's approval request is silently swallowed" — better than ungated, but not the end state. Merged on its own, this one carries every other delegated pause, and has nothing to carry on the permission path until a rail is mounted there to raise one. The two also both edit the `create_kwargs` dict that `DeepAgent` builds for a sub-agent — this one the `card` entry on its third line, that one two new entries at its end, fifty-nine lines further down — and both orders apply cleanly on the `develop` tip this is based on.

`fix(hitl): withdraw a pending interrupt no caller can answer`, also filed alongside this one, meets the withheld-`ToolMessage` defect from the other side. It writes one refusal `ToolMessage` per entry in the interruption state's `interrupted_tools`, and `_collect_interrupts` puts a paused sub-agent's envelope there under the delegating call's id. On `develop` that id already carries the `ToolMessage` this change withholds, so that request on its own reaches the duplicate-`tool_call_id` transcript by a second route. With this change applied the id is spent exactly once. Neither is wrong without the other on its own path; together they are the pair that keeps the id clean.

**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

Forty-five tests added, in seven files, one group per defect, one for the interaction between them, and one for the whole round trip:

- the envelope leaving `TaskTool` intact, and `_is_sub_agent_interrupt` recognising it (four);
- the sub-session id being reproducible across a replay of one tool call, two calls staying separate, an unsupplied call id keeping the established random suffix, and a sticky type keeping its established id (nine);
- the resume key reaching the delegating tool and being forwarded as the sub-agent's query (six);
- the sub-agent card id being derived from the sub-session id, and a caller-supplied spec keeping its own (seven);
- the resume reaching the parked state under the rebuilt parent (eight);
- `_execute_single_tool_call` returning the envelope with no `ToolMessage`, while an ordinary result still produces one (four);
- the whole round trip against a sub-agent that exposes `stream`, which is the only kind a delegation ever gets: the question reaching the caller, the caller parking the delegating call, the answer reaching the sub-agent that asked, the resumed delegation reporting its work, and two controls holding the completion path and the workflow interaction path unchanged (seven).

That last file is new to this rebase and closes a real gap. The other six double a sub-agent with `invoke` alone, so they exercise the bridge's fallback and pass whether or not the streaming path drops the envelope — a purely textual resolution of the conflict passes all thirty-eight of them and still leaves a delegated pause invisible. Every step that shapes the envelope in the new file is production code: the agent-side write, the tool-side rebuild, the caller-side collection, and the replay that carries the answer back; only the stream transport and the sub-agent's own turn are doubled.

**Against the unmodified source these do not all fail equally usefully, and the split is worth stating rather than rounding.** Of the forty-five, twenty are collectable on the base at all; the other twenty-five import `is_interrupt_envelope`, `SUB_AGENT_RESUME_INPUT_KEY` or `_sub_agent_card_for_session`, which do not exist there, so their four modules error at collection rather than failing an assertion. Those twenty-five establish the contract rather than discriminating behaviour. The new round-trip file deliberately imports none of them, so it runs on both trees and fails on its own assertions.

Of the twenty that are collectable, fourteen fail and six pass:

- **Six fail on a plain assertion**, and the failure is exactly the defect. Two are the direct ones: `TaskTool` returns `ToolOutput(success=True, data={'output': '', 'agent_id': 'sub'})` where the envelope was expected, and `_is_sub_agent_interrupt` returns `False` for it. Four are the round trip: the caller collects no interrupt from the delegation, nothing is parked for the delegating call, no answer is routed back into the sub-agent that asked, and the resume never runs.
- **Eight fail on a `TypeError`**, because `_build_sub_session_id` on the base takes no `task_description`. That records a changed contract rather than the behaviour behind it.
- **Six pass on both trees**, as they should: a completed delegation still flattening to `output`, a partial dict not being taken for an envelope, a two-argument call with no task description still yielding a well-formed id, a streamed answer still being an answer, an interaction that is not an `InterruptRequest` still not being a pause, and the sub-agent parking its own state either way.

The base run is `14 failed, 6 passed, 4 errors`.

So of the five defects, the added tests now demonstrate the end-to-end behaviour outright — the round-trip file fails on the base in both directions, out and back — demonstrate the flattened envelope at its own locus as well, catch the unreproducible sub-session id only as a changed signature, and cannot speak to the spurious `ToolMessage` on the base at all: `test_ability_manager_interrupt_envelope.py` imports `is_interrupt_envelope` at module level and errors before any assertion runs. Covering that one against unmodified source is what the reproduction below is for.

**The reported reproduction.** The script in the linked issue takes the other route: it probes each of the five at its own locus and needs none of the names this change adds, so it runs on both trees unchanged. On `develop` at `dce36fc8`, where it was reported, it reports all five defects and exits non-zero on its final assertion; on the branch as first cut all five report as expected and it exits 0. Both runs were made from inside the respective checkouts so that the tree under test is the one imported.

One limit of it is worth stating now that the base has moved. Its `FakeSubAgent` implements `invoke` and not `stream`, so its first check exercises the bridge's fallback and cannot see the flattening `0377afe2` added on the streaming path. It therefore still reports the same five defects at their own loci, but it is no longer sufficient on its own for the first of them. The round-trip test file is what covers that locus.

**Full suite.** `tests/` was run on this branch and on a clean checkout of the base it now sits on, `1e143347`, with the same command and in the same environment, and compared test by test rather than by totals:

- 42 tests fail on the base and the same 42 fail on the branch, identical by name: none added, none fixed;
- 12 tests error on each side, the same 12 by name, all in `tests/system_tests/agent_evolving/agent_rl/online/`;
- the passing count rises from 17856 to 17901, by exactly the forty-five tests added.

Three directories were excluded from both runs because the environment lacks the extras they need: `tests/cli`, `tests/unit_tests/agent_teams/cli` and `tests/unit_tests/agent_evolving/agent_rl/online`. Nothing this change touches is under any of them, and both runs excluded the same three.

The comparison is by name because those absolutes are host-dependent and will differ in CI: on the machine used here the failures come from tests that share fixed-name paths under the system temporary directory with concurrent processes and from observability tests that assume a single run in flight. None of them is touched by this change.

**Performance and reliability.** No measurable cost. Two SHA-256 digests over short strings are computed per delegation — one for the sub-session id, in place of a `uuid4`, and one for the card id — on a path that already constructs a whole agent. Nothing is added to any per-tool-call path beyond one dict-shape test, and nothing to any stream chunk beyond one type comparison that fails first for every chunk that is not an interaction. Reliability moves in one direction on the paths that were already working: a completed delegation flattens as before, an ordinary tool result still produces a `ToolMessage`, and a sticky sub-agent's session id is unchanged.

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

Notes on the unticked boxes:

- **Design** — not yet reviewed by a Maintainer. Three points most want it. First, whether rebuilding the interrupt envelope inside `_run_subagent_with_observable_stream` is the right layer, or whether the agent's stream should surface a pause as a terminal result of its own. The argument for the bridge is given above; the argument against is that the bridge infers a return value from chunks, so an agent that changed how it writes a pause to the stream would silently stop pausing delegations again. A named terminal chunk would make that impossible, at the cost of a change to the streaming contract. Second, what the non-sticky sub-session suffix should be derived from: a digest of the task description, as here, or `tool_call_id`, as on the release branch. The trade is set out above and either answer fixes the defect; the browser resume handle added by `4cd577e1` is the concrete cost of the digest, and a maintainer who weighs it heavily should ask for `tool_call_id`. Third, deriving the sub-agent's card id from the sub-session id, which changes what that id separates; the direction and the cost are stated above so they can be disagreed with.
- **Interface** — no documented external interface changes, with three signatures noted for the record so a reviewer can judge that rather than take it.
  - `TaskTool._build_sub_session_id` gains a fourth parameter with a default, after the `resume_task_id` added by `4cd577e1`, so existing calls still work unchanged.
  - `AbilityManager._execute_single_tool_call`'s return annotation widens to `Tuple[Any, Optional[ToolMessage]]`. That records what the method could already return before this change and corrects an annotation that was inaccurate.
  - `TaskTool.invoke`'s return annotation widens to `ToolOutput | dict[str, Any]`, and this one is a genuinely new return shape rather than a correction: on the pause path it now returns the envelope where it previously returned a `ToolOutput`. Two places construct a `TaskTool`. `create_task_tool` registers it as a tool, so its caller is `AbilityManager`, and both it and `ToolInterruptHandler` are updated here to expect the dict. The other is `EvolveReviewTaskTool`, whose handling is described under *Not addressed here* — it is no worse off than before, but it is the one caller a reviewer should look at.
  - `_run_subagent_with_observable_stream` keeps its signature and its documented purpose, and can now return an interrupt-shaped dict where it previously always returned an answer-shaped one. It is module-private and has exactly one caller, `TaskTool.invoke`, which is updated here.

  None of these four is part of the documented public API, and no API annotation needs refreshing.
- **Document** — no official-website material is submitted, because none becomes inaccurate. No documented behaviour changes: what changes is that a documented pause is delivered where it previously was not. If the Doc repository would rather state the sub-agent interrupt round trip explicitly, a section can be written on request.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #470
- Fixes #656
- Fixes #657
- Fixes #806
- Fixes #831
- Fixes #961
<!-- /bot1-related-issues -->
