### PR TITLE
fix(harness): gate sub-agent tool calls with the parent's permissions

### DIFF
--- a/openjiuwen/harness/deep_agent.py
+++ b/openjiuwen/harness/deep_agent.py
@@ -1442,7 +1442,42 @@ class DeepAgent(BaseAgent):
             "enable_plan_mode": spec.enable_plan_mode,
             "parallel_tool_calls": spec.parallel_tool_calls,
             "restrict_to_work_dir": spec.restrict_to_work_dir or self._deep_config.restrict_to_work_dir,
+            # A sub-agent acts on this agent's behalf, over the same files and
+            # the same shell, so the same policy gates it. Without these two
+            # keys its config carries no permissions dict,
+            # ``_queue_pending_rails`` builds no PermissionInterruptRail for
+            # it, and every tool call it makes runs ungated however strict this
+            # agent's policy is.
+            #
+            # The host travels with the policy because it is where the product
+            # decides how the policy is enforced, not only whether: the channel
+            # an ASK is put to a user over, whether checks run at all, and
+            # where an "always allow" is written. A sub-agent holding the
+            # policy alone falls back to the built-in confirm-interrupt flow
+            # and answers from a policy that no longer tracks the product's.
+            #
+            # Both are passed by reference -- the rail deep-copies the policy
+            # at construction and the host keeps no per-agent state, so one
+            # instance serves both agents.
+            "permissions": self._deep_config.permissions,
+            "permission_host": self._deep_config.permission_host,
         }
+
+        # ``spec.factory_kwargs`` is splatted into the same call as
+        # ``create_kwargs``, and ``create_deep_agent`` takes both keys above
+        # through ``**config_kwargs`` rather than as named parameters, so an
+        # operator may already have set either one there.  A key in both dicts
+        # is a duplicate keyword argument, not an override, and would raise
+        # TypeError on a configuration that worked before these two were
+        # inherited here.  The operator's entry is a deliberate choice about
+        # this one sub-agent, so it wins, and inheritance fills in only what
+        # they left unset -- the silent gap this forwarding exists to close.
+        # Dropping the keys by name rather than merging the two dicts keeps a
+        # collision on any other key the loud TypeError it has always been.
+        spec_factory_kwargs = spec.factory_kwargs or {}
+        for inherited_key in ("permissions", "permission_host"):
+            if inherited_key in spec_factory_kwargs:
+                create_kwargs.pop(inherited_key, None)
 
         if spec.factory_name:
             normalized_factory = (spec.factory_name or "").strip().lower()

--- a/tests/unit_tests/harness/test_subagent_permission_propagation.py
+++ b/tests/unit_tests/harness/test_subagent_permission_propagation.py
@@ -1,0 +1,485 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""A sub-agent is gated by the same tool permission policy as its parent.
+
+``DeepAgent._queue_pending_rails`` builds the PermissionInterruptRail from
+``config.permissions`` and ``config.permission_host``. ``create_subagent``
+assembles the sub-agent's config itself, so unless it forwards those two the
+sub-agent's config holds only what the spec's own ``factory_kwargs`` set. For a
+spec that sets neither -- which is every spec that does not know to -- no rail
+is built and its tool calls run ungated however strict the parent's policy is.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from openjiuwen.core.foundation.llm import Model, ModelClientConfig, ModelRequestConfig
+from openjiuwen.core.single_agent.schema.agent_card import AgentCard
+from openjiuwen.harness.factory import create_deep_agent
+from openjiuwen.harness.rails.security.tool_security_rail import PermissionInterruptRail
+from openjiuwen.harness.schema.config import SubAgentConfig
+from openjiuwen.harness.security.host import (
+    PermissionConfirmationRequest,
+    ToolPermissionHost,
+)
+from openjiuwen.harness.security.models import PermissionConfirmResponse
+
+pytestmark = pytest.mark.level0
+
+CODE_AGENT_FACTORY_NAME = "code_agent"
+
+
+def _fake_model() -> Model:
+    return Model(
+        model_client_config=ModelClientConfig(
+            client_provider="openai",
+            api_key="fake-key-for-subagent-permissions",
+            api_base="http://localhost:0",
+            verify_ssl=False,
+        ),
+        model_config=ModelRequestConfig(model="fake-subagent-permissions"),
+    )
+
+
+def _enabled_permissions() -> dict[str, Any]:
+    return {"enabled": True, "tools": {"read_file": "ask", "bash": "ask"}}
+
+
+def _plain_spec(name: str = "worker") -> SubAgentConfig:
+    """A spec with no factory_name, so create_subagent uses create_deep_agent."""
+    return SubAgentConfig(
+        agent_card=AgentCard(name=name, description=f"{name} under test"),
+        system_prompt="Do the delegated work.",
+    )
+
+
+def _build_parent(tmp_path: Path, **config_kwargs: Any):
+    return create_deep_agent(
+        _fake_model(),
+        card=AgentCard(name="parent", description="parent under test"),
+        system_prompt="parent prompt",
+        workspace=str(tmp_path / "parent_workspace"),
+        subagents=[_plain_spec()],
+        language="en",
+        **config_kwargs,
+    )
+
+
+def _permission_rails(agent: Any) -> list[PermissionInterruptRail]:
+    """Return the permission rails queued on ``agent``."""
+    return [r for r in agent._pending_rails if isinstance(r, PermissionInterruptRail)]
+
+
+def _only_permission_rail(agent: Any) -> PermissionInterruptRail:
+    """The single permission rail on ``agent``, asserted rather than indexed."""
+    rails = _permission_rails(agent)
+    assert len(rails) == 1, f"expected one permission rail, got {len(rails)}"
+    return rails[0]
+
+
+def test_subagent_mounts_permission_rail_when_parent_has_one(tmp_path) -> None:
+    """The gate the parent runs behind also applies to work it delegates."""
+    parent = create_deep_agent(
+        _fake_model(),
+        card=AgentCard(name="parent", description="parent under test"),
+        system_prompt="parent prompt",
+        workspace=str(tmp_path / "parent_workspace"),
+        subagents=[_plain_spec()],
+        language="en",
+        permissions=_enabled_permissions(),
+    )
+    assert _permission_rails(parent), "parent should mount a rail for this policy"
+
+    sub = parent.create_subagent("worker", "sub_session_id")
+
+    assert _permission_rails(sub), "sub-agent mounted no permission rail"
+
+
+def test_subagent_permission_policy_matches_the_parent(tmp_path) -> None:
+    """The sub-agent is gated by the same rules, not by weaker defaults."""
+    permissions = _enabled_permissions()
+    parent = _build_parent(tmp_path, permissions=permissions)
+
+    sub = parent.create_subagent("worker", "sub_session_id")
+
+    assert sub._deep_config.permissions == permissions
+    rail = _only_permission_rail(sub)
+    assert rail._static_config["tools"] == permissions["tools"]
+
+
+def test_subagent_mounts_no_permission_rail_when_parent_has_none(tmp_path) -> None:
+    """No policy anywhere means no rail anywhere; nothing is invented."""
+    parent = _build_parent(tmp_path)
+    assert parent._deep_config.permissions is None
+
+    sub = parent.create_subagent("worker", "sub_session_id")
+
+    assert sub._deep_config.permissions is None
+    assert _permission_rails(sub) == []
+
+
+@pytest.mark.asyncio
+async def test_subagent_rail_reaches_the_host_confirmation_callback(tmp_path) -> None:
+    """The callback that puts a permission question in front of a user.
+
+    Without the host the sub-agent still has a way to ask: the rail falls
+    through to the built-in ``ConfirmInterruptRail`` interrupt. What it loses is
+    the channel the product answers permission questions on, so the question is
+    raised over a protocol the host is not listening to.
+    ``build_permission_interrupt_rail`` may rebuild the host to fill in
+    ``resolve_workspace_dir``, so identity is asserted on the callback rather
+    than on the host object.
+    """
+    asked: list[str] = []
+
+    async def _confirm(request: PermissionConfirmationRequest) -> PermissionConfirmResponse:
+        asked.append(request.auto_confirm_key)
+        return PermissionConfirmResponse(approved=True)
+
+    host = ToolPermissionHost(request_permission_confirmation=_confirm)
+    parent = _build_parent(tmp_path, permissions=_enabled_permissions(), permission_host=host)
+
+    sub = parent.create_subagent("worker", "sub_session_id")
+
+    rail = _only_permission_rail(sub)
+    assert rail._host.request_permission_confirmation is _confirm
+
+    response = await rail._host.request_permission_confirmation(
+        PermissionConfirmationRequest(
+            ctx=None,
+            tool_call=None,
+            result=None,
+            auto_confirm_key="read_file",
+        )
+    )
+    assert response.approved is True
+    assert asked == ["read_file"], "the sub-agent's question never reached the host"
+
+
+def test_subagent_shares_the_parent_host_object(tmp_path) -> None:
+    """One host instance serves both agents; it holds no per-agent state."""
+    host = ToolPermissionHost(resolve_workspace_dir=lambda: tmp_path)
+    parent = _build_parent(tmp_path, permissions=_enabled_permissions(), permission_host=host)
+
+    sub = parent.create_subagent("worker", "sub_session_id")
+
+    assert sub._deep_config.permission_host is host
+    assert _only_permission_rail(sub)._host is host
+
+
+def test_subagent_cannot_mutate_the_parent_policy_through_its_rail(tmp_path) -> None:
+    """The rail deep-copies the policy, so the two agents cannot corrupt each other."""
+    permissions = _enabled_permissions()
+    parent = _build_parent(tmp_path, permissions=permissions)
+
+    sub = parent.create_subagent("worker", "sub_session_id")
+
+    rail = _only_permission_rail(sub)
+    rail._static_config["tools"]["bash"] = "allow"
+
+    assert permissions["tools"]["bash"] == "ask"
+    assert parent._deep_config.permissions["tools"]["bash"] == "ask"
+
+
+# --- permissions off: behaviour must be identical to before ----------------
+
+
+def test_permissions_disabled_mounts_no_rail_on_the_subagent(tmp_path) -> None:
+    """``enabled: false`` is the deployed setting; it must stay inert."""
+    parent = _build_parent(tmp_path, permissions={"enabled": False, "tools": {"bash": "ask"}})
+    assert _permission_rails(parent) == []
+
+    sub = parent.create_subagent("worker", "sub_session_id")
+
+    assert _permission_rails(sub) == []
+
+
+def test_permissions_disabled_leaves_the_subagent_rail_set_unchanged(tmp_path) -> None:
+    """The rails a sub-agent gets with permissions off are the ones it got before.
+
+    Compared against a parent holding no permissions key at all, which is the
+    pre-change shape of every sub-agent config.
+    """
+    off = _build_parent(tmp_path, permissions={"enabled": False})
+    absent = _build_parent(tmp_path)
+
+    sub_off = off.create_subagent("worker", "sub_session_id")
+    sub_absent = absent.create_subagent("worker", "sub_session_id")
+
+    assert [type(r) for r in sub_off._pending_rails] == [
+        type(r) for r in sub_absent._pending_rails
+    ]
+
+
+def test_permissions_absent_forwards_none_to_the_subagent_factory(tmp_path) -> None:
+    """Nothing new is handed to a factory when the parent holds no policy."""
+    spec = SubAgentConfig(
+        agent_card=AgentCard(name="reviewer", description="reviewer"),
+        system_prompt="Review strictly.",
+        factory_name=CODE_AGENT_FACTORY_NAME,
+    )
+    parent = create_deep_agent(
+        _fake_model(),
+        card=AgentCard(name="parent", description="parent under test"),
+        system_prompt="parent prompt",
+        workspace=str(tmp_path / "parent_workspace"),
+        subagents=[spec],
+        language="en",
+    )
+    factory_result = object()
+
+    with patch(
+        "openjiuwen.harness.subagents.code_agent.create_code_agent",
+        return_value=factory_result,
+    ) as mock_factory:
+        assert parent.create_subagent("reviewer", "sub_session_id") is factory_result
+
+    call_kwargs = mock_factory.call_args.kwargs
+    assert call_kwargs["permissions"] is None
+    assert call_kwargs["permission_host"] is None
+
+
+# --- uniform across every sub-agent type ------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("factory_name", "patch_target"),
+    [
+        ("code_agent", "openjiuwen.harness.subagents.code_agent.create_code_agent"),
+        (
+            "research_agent",
+            "openjiuwen.harness.subagents.research_agent.create_research_agent",
+        ),
+        (
+            "browser_agent",
+            "openjiuwen.harness.subagents.browser_agent.create_browser_agent",
+        ),
+        (
+            "mobile_gui_agent",
+            "openjiuwen.harness.subagents.mobile_gui_agent.create_mobile_gui_agent",
+        ),
+    ],
+)
+def test_every_subagent_factory_receives_the_parent_permissions(
+    tmp_path, factory_name: str, patch_target: str
+) -> None:
+    """Every factory forwards ``**config_kwargs`` into ``create_deep_agent``."""
+    permissions = _enabled_permissions()
+    host = ToolPermissionHost(resolve_workspace_dir=lambda: tmp_path)
+    spec = SubAgentConfig(
+        agent_card=AgentCard(name="worker", description="worker"),
+        system_prompt="Do the delegated work.",
+        factory_name=factory_name,
+    )
+    parent = create_deep_agent(
+        _fake_model(),
+        card=AgentCard(name="parent", description="parent under test"),
+        system_prompt="parent prompt",
+        workspace=str(tmp_path / "parent_workspace"),
+        subagents=[spec],
+        language="en",
+        permissions=permissions,
+        permission_host=host,
+    )
+    factory_result = object()
+
+    with patch(patch_target, return_value=factory_result) as mock_factory:
+        assert parent.create_subagent("worker", "sub_session_id") is factory_result
+
+    call_kwargs = mock_factory.call_args.kwargs
+    assert call_kwargs["permissions"] is permissions
+    assert call_kwargs["permission_host"] is host
+
+
+# --- collision with the operator's own factory_kwargs -----------------------
+#
+# ``create_subagent`` splats ``create_kwargs`` and ``spec.factory_kwargs`` into
+# one call, and ``create_deep_agent`` takes both keys through ``**config_kwargs``
+# rather than as named parameters. An operator could therefore already set
+# either of them in ``factory_kwargs``, and did so to configure a sub-agent's
+# policy at all before the parent's was inherited. Naming a key in both dicts is
+# a duplicate keyword argument, not an override, so it must not reach the call.
+
+
+def _operator_permissions() -> dict[str, Any]:
+    """A policy an operator wrote for one sub-agent, distinct from the parent's."""
+    return {"enabled": True, "tools": {"bash": "deny"}}
+
+
+def test_factory_kwargs_permissions_does_not_raise_on_the_inherited_key(tmp_path) -> None:
+    """The operator's own ``permissions`` entry must still construct."""
+    spec = SubAgentConfig(
+        agent_card=AgentCard(name="worker", description="worker"),
+        system_prompt="Do the delegated work.",
+        factory_kwargs={"permissions": _operator_permissions()},
+    )
+    parent = create_deep_agent(
+        _fake_model(),
+        card=AgentCard(name="parent", description="parent under test"),
+        system_prompt="parent prompt",
+        workspace=str(tmp_path / "parent_workspace"),
+        subagents=[spec],
+        language="en",
+        permissions=_enabled_permissions(),
+    )
+
+    sub = parent.create_subagent("worker", "sub_session_id")
+
+    assert sub._deep_config.permissions == _operator_permissions()
+
+
+def test_factory_kwargs_permissions_wins_when_the_parent_holds_no_policy(tmp_path) -> None:
+    """The key is present in ``create_kwargs`` whether or not a policy exists.
+
+    A parent with no policy forwards ``permissions=None``, which collides just
+    as a real policy would, so this path must be pinned separately.
+    """
+    spec = SubAgentConfig(
+        agent_card=AgentCard(name="worker", description="worker"),
+        system_prompt="Do the delegated work.",
+        factory_kwargs={"permissions": _operator_permissions()},
+    )
+    parent = create_deep_agent(
+        _fake_model(),
+        card=AgentCard(name="parent", description="parent under test"),
+        system_prompt="parent prompt",
+        workspace=str(tmp_path / "parent_workspace"),
+        subagents=[spec],
+        language="en",
+    )
+    assert parent._deep_config.permissions is None
+
+    sub = parent.create_subagent("worker", "sub_session_id")
+
+    assert sub._deep_config.permissions == _operator_permissions()
+    assert _permission_rails(sub), "the operator's policy should still mount a rail"
+
+
+def test_factory_kwargs_permission_host_wins_over_the_inherited_host(tmp_path) -> None:
+    """``permission_host`` collides on the same terms and resolves the same way."""
+    parent_host = ToolPermissionHost(resolve_workspace_dir=lambda: tmp_path)
+    operator_host = ToolPermissionHost(resolve_workspace_dir=lambda: tmp_path)
+    spec = SubAgentConfig(
+        agent_card=AgentCard(name="worker", description="worker"),
+        system_prompt="Do the delegated work.",
+        factory_kwargs={"permission_host": operator_host},
+    )
+    parent = create_deep_agent(
+        _fake_model(),
+        card=AgentCard(name="parent", description="parent under test"),
+        system_prompt="parent prompt",
+        workspace=str(tmp_path / "parent_workspace"),
+        subagents=[spec],
+        language="en",
+        permissions=_enabled_permissions(),
+        permission_host=parent_host,
+    )
+
+    sub = parent.create_subagent("worker", "sub_session_id")
+
+    assert sub._deep_config.permission_host is operator_host
+
+
+def test_factory_kwargs_permissions_alone_still_inherits_the_parent_host(tmp_path) -> None:
+    """The two keys are dropped independently, so a partial override inherits the rest."""
+    parent_host = ToolPermissionHost(resolve_workspace_dir=lambda: tmp_path)
+    spec = SubAgentConfig(
+        agent_card=AgentCard(name="worker", description="worker"),
+        system_prompt="Do the delegated work.",
+        factory_kwargs={"permissions": _operator_permissions()},
+    )
+    parent = create_deep_agent(
+        _fake_model(),
+        card=AgentCard(name="parent", description="parent under test"),
+        system_prompt="parent prompt",
+        workspace=str(tmp_path / "parent_workspace"),
+        subagents=[spec],
+        language="en",
+        permissions=_enabled_permissions(),
+        permission_host=parent_host,
+    )
+
+    sub = parent.create_subagent("worker", "sub_session_id")
+
+    assert sub._deep_config.permissions == _operator_permissions()
+    assert sub._deep_config.permission_host is parent_host
+
+
+@pytest.mark.parametrize(
+    ("factory_name", "patch_target"),
+    [
+        ("code_agent", "openjiuwen.harness.subagents.code_agent.create_code_agent"),
+        (
+            "research_agent",
+            "openjiuwen.harness.subagents.research_agent.create_research_agent",
+        ),
+        (
+            "browser_agent",
+            "openjiuwen.harness.subagents.browser_agent.create_browser_agent",
+        ),
+        (
+            "mobile_gui_agent",
+            "openjiuwen.harness.subagents.mobile_gui_agent.create_mobile_gui_agent",
+        ),
+    ],
+)
+def test_factory_kwargs_permissions_does_not_collide_on_any_factory(
+    tmp_path, factory_name: str, patch_target: str
+) -> None:
+    """Every factory branch splats the same two dicts, including the browser copy."""
+    operator_permissions = _operator_permissions()
+    spec = SubAgentConfig(
+        agent_card=AgentCard(name="worker", description="worker"),
+        system_prompt="Do the delegated work.",
+        factory_name=factory_name,
+        factory_kwargs={"permissions": operator_permissions},
+    )
+    parent = create_deep_agent(
+        _fake_model(),
+        card=AgentCard(name="parent", description="parent under test"),
+        system_prompt="parent prompt",
+        workspace=str(tmp_path / "parent_workspace"),
+        subagents=[spec],
+        language="en",
+        permissions=_enabled_permissions(),
+    )
+    factory_result = object()
+
+    with patch(patch_target, return_value=factory_result) as mock_factory:
+        assert parent.create_subagent("worker", "sub_session_id") is factory_result
+
+    call_kwargs = mock_factory.call_args.kwargs
+    assert call_kwargs["permissions"] is operator_permissions
+
+
+def test_a_factory_kwargs_collision_on_another_key_still_raises(tmp_path) -> None:
+    """Only these two keys are reconciled; every other collision stays loud.
+
+    ``system_prompt`` has always been both a ``create_kwargs`` key and a named
+    parameter of ``create_deep_agent``, so naming it in ``factory_kwargs`` has
+    always raised. Merging the two dicts instead would have turned that, and
+    every collision like it, into a silent override.
+    """
+    spec = SubAgentConfig(
+        agent_card=AgentCard(name="worker", description="worker"),
+        system_prompt="Do the delegated work.",
+        factory_kwargs={"system_prompt": "an overriding prompt"},
+    )
+    parent = create_deep_agent(
+        _fake_model(),
+        card=AgentCard(name="parent", description="parent under test"),
+        system_prompt="parent prompt",
+        workspace=str(tmp_path / "parent_workspace"),
+        subagents=[spec],
+        language="en",
+        permissions=_enabled_permissions(),
+    )
+
+    with pytest.raises(TypeError, match="system_prompt"):
+        parent.create_subagent("worker", "sub_session_id")


### PR DESCRIPTION
Paired: [GitHub #964](https://github.com/openJiuwen-ai/agent-core/pull/964) ↔ [GitCode !2532](https://gitcode.com/openJiuwen/agent-core/merge_requests/2532)

**What type of PR is this?**

/kind bug

**Which issue(s) this PR fixes**:

Fixes #963

Related but not fixed here. #831 concerns `ask` decisions that *are* raised — whether the switch can be turned off, how the interrupt is accounted for, how the decision comes back, and rail state lost across the `ctx` rebuild; this change concerns `ask` decisions that were never raised at all, because no rail existed on the sub-agent to raise them. The last section below, on a delegated ASK that reaches the built-in interrupt rather than the host, is squarely in #831's territory and is not addressed here. #866 restructures where policy is composed and what the engine consumes; this change is upstream of that — the composed policy simply never reached the sub-agent's config — and the two do not conflict, though that rework should carry this forwarding along. #656 and #657 propose consolidating the sub-agent construction paths; placing the fix at the single `create_subagent` choke point is what lets such a consolidation carry it along instead of needing it re-applied. None of the three should be closed on this merge.

**What does this PR do / why do we need it**:

`DeepAgent` mounts its `PermissionInterruptRail` in `_queue_pending_rails`, built from `config.permissions` and `config.permission_host`. `create_subagent` assembles the sub-agent's config from scratch and forwarded neither, so a sub-agent's policy was whatever the spec's own `SubAgentConfig.factory_kwargs` happened to carry — and for a spec that does not set it there, which is every spec written without knowing that it must, the config held no `permissions` key at all. With none, `_queue_pending_rails` builds no rail, and the sub-agent's tool calls run ungated however strict the parent's policy is. The gap dates from `7475e8ce`, which added the rail and wired it into `DeepAgent` without touching the sub-agent construction path beside it.

The escape is the whole policy rather than a subset of tools, because the rail is built with `tool_names=None` and checks every tool name: the built-in shell rules that apply on `permissions.enabled: true` alone, the operator's own `tools` map, `rules` and `approval_overrides`, and `file_guard`'s per-path decisions. It is not a case an operator has to opt into either — no spec registered in `openjiuwen/harness/manifest/harness_elements.py` sets these keys, so on the source as shipped every built-in sub-agent is ungated. All the operator's configuration still constrained was whether delegation happened at all, since `task_tool` and the `subagent_spawn` family are themselves gateable tool calls. The linked issue carries that evidence in full — the spec census, the rule inventory, what a default deployment does, and a runnable reproduction.

**The change.** Forward `permissions` and `permission_host` from the parent's config into the `create_kwargs` that `create_subagent` builds. That is one choke point for every sub-agent: named specs and the `code` / `research` / `browser` / `mobile_gui` factories all pass through it, all four factories forward `**config_kwargs` into `create_deep_agent` (`mobile_gui` through a copy of the dict, the other three directly), and the two keys reach the sub-agent's config by the same route the parent's own did. Placing it there rather than at each call site also means a later consolidation of the sub-agent construction paths carries it along instead of needing it re-applied. It covers all three callers of `create_subagent` — the classic `task_tool` delegation, `SessionSpawnExecutor`, and the `subagent_spawn` / `wait` / `list` / `send_input` / `close` / `resume` runtime tools, which reach it through `SubagentControl` and `SubagentSessionManager`. A pre-built `DeepAgent` passed as a sub-agent short-circuits earlier in `create_subagent` and is unaffected; its own construction already configured it.

**Why the policy is inherited whole rather than narrowed.** `PermissionsSection` holds tool gates, path rules and approval overrides, and nothing keyed to an agent identity or a session — there is no sub-agent dimension in it to narrow along. Since a sub-agent's reach can extend to the parent's — the injected general-purpose spec is built from the parent's own tool list, workspace and `sys_operation` — any weaker policy would gate less than the reach it exists to bound, and any stronger one would have to be invented here rather than configured by the operator.

**Why the host travels with the policy.** `ToolPermissionHost` is where the product decides how a policy is enforced, not merely whether. `request_permission_confirmation` is the channel an ASK is put to a user over; without it the rail falls through to the built-in `ConfirmInterruptRail` interrupt, so a sub-agent holding the policy alone would raise its question over a protocol the host answering permission questions is not listening on. `tool_permission_checks_active` can turn checking off for an entry point entirely, and a sub-agent without it would keep checking where the product had decided not to. `persist_allow_rule` and `permission_yaml_path` are where an "always allow" is written, and `get_permissions_snapshot` is how a policy edited on disk reaches a live agent — a sub-agent without them would answer from a policy that has stopped tracking the product's.

The host holds callables and paths and no per-agent or per-session state, so one instance serves both agents. `build_permission_interrupt_rail` still fills in `resolve_workspace_dir` per rail when the host leaves it unset, so a sub-agent that inherits a bare host is bounded by its own workspace root rather than the parent's.

Both fields are passed by reference. The rail deep-copies the policy at construction, so neither agent can corrupt the other's through it, while a sub-agent created later still sees a policy the product has since updated in place.

**The collision with an operator's own `factory_kwargs`, and how it is resolved.** `create_subagent` splats `create_kwargs` and the spec's `factory_kwargs` into a single call, and `create_deep_agent` accepts these two keys through `**config_kwargs` rather than as named parameters. Both were therefore already legal in `factory_kwargs`, which was the only way to set a sub-agent's own `permissions` at all before this change — a spec carrying `factory_kwargs={"permissions": {...}}` reached `DeepAgentConfig.permissions` through the `setattr` loop in `create_deep_agent`, mounted a rail, and was gated by it. Adding the same keys to `create_kwargs` unconditionally would make every such configuration a duplicate keyword argument rather than an override:

```
TypeError: openjiuwen.harness.factory.create_deep_agent() got multiple values
for keyword argument 'permissions'
```

That would fire whether or not the parent holds a policy, because the key is in `create_kwargs` either way: a parent with no policy forwards `permissions=None`, which collides exactly as a real one does.

So the two keys are removed from `create_kwargs` by name when the spec sets them. The operator's entry stands, and inheritance fills in only the key they left unset. Four things make that the right resolution rather than the reverse:

- It is what the code already did. On the pre-change tree an explicit `factory_kwargs` policy was applied to the sub-agent, parent policy or not. Preserving that makes this a no-op for any deployment already using it, and inheritance is then strictly additional — it fills a key that was previously empty and gates a sub-agent that was previously ungated.
- Letting the inherited policy win would silently discard configuration an operator wrote deliberately, which is a hazard in its own direction: an operator who writes a *stricter* policy for a riskier sub-agent would get the parent's looser one instead, with nothing to say so. A sub-agent running under a policy nobody chose is the defect this PR closes; overriding a policy somebody did choose is the same fault pointed the other way.
- The two are not the same kind of thing. A sub-agent weaker than its parent because an operator configured it that way is auditable; a sub-agent weaker than its parent because a construction path omitted a key is not. Only the second is silent, and only the second is what this PR is for.
- There is no trust boundary between the two values. `SubAgentConfig.factory_kwargs` and the parent's own `permissions` are written by the same operator through the same configuration surface, and anyone who can set one can set the other. Letting the parent win would therefore buy no containment against an attacker — it would only override the operator against themselves.

The keys are dropped one by one rather than by merging the two dicts, which `create_deep_agent(**{**create_kwargs, **factory_kwargs})` would also have resolved. A merge would additionally turn every *other* collision — `model`, `card`, `tools`, `workspace`, `sys_operation`, `rails`, `restrict_to_work_dir` and the rest of `create_kwargs` — from the `TypeError` it has always raised into a silent override, quietly widening what `factory_kwargs` may do to a sub-agent across the twenty-two other keys of `create_kwargs` in order to fix two. A test pins that a collision on any other key stays loud.

**What is deliberately not changed.** Behaviour is unchanged wherever permissions are off. Both `build_permission_interrupt_rail` and its caller in `_queue_pending_rails` require `permissions.get("enabled")`, so a disabled policy propagates and mounts nothing, and an absent one sets the two config fields to the `None` they already defaulted to. No new rail appears on any agent that did not already have a policy, nothing about the parent's own gating changes, and a spec that set either key in `factory_kwargs` is constructed and configured exactly as before.

**What this does not yet do.** Mounting the rail is what makes a delegated tool call gateable. It is not yet what makes an ASK on that path visible to the user. Where the inherited host carries a `request_permission_confirmation` callback, an ASK is put to the user over it and resolved as it is for the parent. Where it does not — or where the host answers `"interrupt"` — the rail raises the built-in confirm interrupt, the sub-agent's `invoke` returns an interrupt envelope, and `task_tool` reads `result.get("output", "")` off that envelope and returns `ToolOutput(success=True, data={"output": ""})`. On that path the approval request is currently swallowed rather than surfaced: the tool call does not run, and the user is not asked. That is still a strict improvement on running the call ungated, and it is what this PR ships alone, but it is new user-visible behaviour and belongs in the description rather than being left to be discovered. Carrying a delegated sub-agent's pause out to the user and its answer back in is a change to the interrupt path and to `task_tool`, and is not made here; `fix(hitl): carry a delegated sub-agent's pause out and its answer back`, filed alongside this one, makes it. Neither request depends on the other to be correct, but each is weaker alone: this one is what makes a delegated tool call stop and ask, and that one has nothing to carry on the permission path until a rail is mounted there to raise a pause. The two also both edit the `create_kwargs` dict `create_subagent` builds — that one the `card` entry on its third line, this one two new entries at its end, fifty-nine lines further down — and both orders apply cleanly on the `develop` tip this is based on.

Two further requests touch the same rail from other directions, and neither depends on this one. `fix(security): let the host supply the tool permission prompt wording` moves the rail's ASK body into host-suppliable templates; this change is what causes that body to be built for a delegated tool call at all — though, as above, on the built-in interrupt path it is not yet surfaced to the user. `fix(security): deny the tool call when the permission gate cannot decide` rejects a call the rail could not decide on, which applies to a sub-agent's rail once this change mounts one. Neither alters what this request claims: the gap closed here is that no rail was mounted, not what a mounted rail does.

**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

Twenty-two tests are added in `tests/unit_tests/harness/test_subagent_permission_propagation.py`.

**Propagation.** Six drive the defect. A parent with an enabled policy now produces a sub-agent that mounts a permission rail; that rail's policy is asserted equal to the parent's rather than merely present; the sub-agent's rail is asserted to reach the parent's `request_permission_confirmation` callback, by calling it and observing the call arrive; one host instance is asserted to serve both agents; a mutation made through the sub-agent's rail is asserted not to reach the parent's copy; and a parent with no policy is asserted to hand its factory `permissions=None` and `permission_host=None` rather than something invented. Callback identity is asserted on the callback rather than on the host object, because the factory legitimately rebuilds the host to fill in `resolve_workspace_dir`.

Four more are one parametrized test over the `code` / `research` / `browser` / `mobile_gui` factories, asserting each receives the parent's policy and host by identity. The browser branch takes a modified copy of the kwargs, so this is worth asserting rather than assuming.

**Permissions off.** Three cover the paths on which nothing should appear: a parent holding no policy at all produces a sub-agent with none and no rail; a policy present but `enabled: false` propagates and still mounts no rail on the sub-agent; and that same disabled policy leaves the sub-agent's other rails exactly as they were. All three pass before and after, which is what pins that no rail appears on an agent that did not already have a policy.

**The `factory_kwargs` collision.** Eight cover it, and all eight fail with `TypeError` if the two keys are added to `create_kwargs` without being reconciled against the spec's own. A spec setting `permissions` in `factory_kwargs` is asserted to construct and to keep the operator's policy, both when the parent holds a policy and when it holds none — the second because a parent with no policy still forwards the key and still collides. A spec setting `permission_host` is asserted the same way. A spec setting only `permissions` is asserted to keep the operator's policy *and* the parent's host, pinning that the two keys are reconciled independently. The last four are one parametrized test over the same four factories, since each splats the two dicts itself and the browser branch splats a copy.

**The guard.** One test asserts that a `factory_kwargs` collision on any *other* key — `system_prompt` — still raises `TypeError`. It passes both before and after, which is what makes it a guard: it pins that the narrow reconciliation was not widened into a blanket merge that would silently let `factory_kwargs` override `model`, `tools`, `workspace`, `sys_operation` or `rails`.

**Against the unmodified source.** Eleven of the twenty-two fail on the merge base `dce36fc8`, none of them at setup or on an import. Six fail on an assertion about the sub-agent itself: no permission rail exists on it to assert anything about, its config's `permissions` and `permission_host` are `None`, and a spec overriding only `permissions` has no inherited host to fall back on. Five fail on a `KeyError` reading `permissions` back out of the recorded factory call, because no such key is handed to the factory at all. The other eleven pass on both sides, and they split three ways. Seven of the eight `factory_kwargs` tests pin behaviour that must survive this change; they pass on the base because the collision does not exist there, and they are what proves the change does not break it. The eighth of those eight is the one asserting that a spec overriding only `permissions` still inherits the parent's host, and it is among the six assertion failures above, since on the base there is no inherited host to fall back on. The guard passes on both sides by construction, and the last three pin the permissions-off path unchanged.

**The reported reproduction.** The script in the linked issue was run against both trees. On `dce36fc8` it prints `sub permissions: None`, `sub permission_host: None` and an empty rail list, and fails its assertion. On this branch it prints the parent's policy on the sub-agent's config and one `PermissionInterruptRail` in its rail list, and exits 0.

**Full suite.** `tests/` was run in full on this branch and on `dce36fc8`, one run at a time, and the two failure lists compared name by name rather than by count. All 172 names — 165 failures and 7 collection errors — are identical on both sides, while the passing count rises from 16842 to 16864, by exactly the twenty-two tests added here. No passing test was lost and none was gained by accident. The residual failures are environmental rather than upstream's code: tests in this suite share fixed-name temporary and lock paths, and `prompt_toolkit` is absent from the environment, which accounts for all seven collection errors. Both are present unchanged on the base.

**Performance and reliability.** No measurable cost. The change adds two dictionary entries and one two-iteration loop per sub-agent construction, which happens once per delegation; nothing is added to any per-tool-call path. A sub-agent that now mounts a rail runs the same `before_tool_call` check the parent already ran, on the same deep-copied policy. Reliability moves in one direction only: no new rail appears on any agent that had no policy, and no previously working `factory_kwargs` configuration begins to raise.

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

Notes on the unticked boxes:

- **Design** — not yet reviewed by a Maintainer. The point that most wants review is the collision resolution above: when a spec sets `permissions` or `permission_host` in its own `factory_kwargs`, the spec wins and inheritance fills in only the key it left unset. The argument for that direction, and against the reverse, is set out in full so it can be disagreed with.
- **Interface** — no external interface changes. No signature, parameter or return type is altered. `permissions` and `permission_host` were already accepted by `create_deep_agent` through `**config_kwargs` and were already legal in `SubAgentConfig.factory_kwargs`; what changes is which of two existing sources fills them for a sub-agent. No API annotation needs refreshing.
- **Document** — no official-website material is submitted, because none becomes inaccurate. *Tool permissions and host integration* already states that `PermissionInterruptRail` runs on `before_tool_call` for **all tools** and says nothing that carves sub-agents out; this change makes the code match what that page already implies. If the Doc repository would rather state sub-agent inheritance explicitly, a sentence can be added on request.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #656
- Fixes #657
- Fixes #831
- Fixes #866
- Fixes #963
<!-- /bot1-related-issues -->
