### PR TITLE
fix(logging): stop labelling failed records as successful events

### DIFF
--- a/openjiuwen/core/common/logging/base_impl.py
+++ b/openjiuwen/core/common/logging/base_impl.py
@@ -20,10 +20,15 @@ from typing import (
 from openjiuwen.core.common.logging.events import (
     BaseLogEvent,
     create_log_event,
+    EventStatus,
     LogEventType,
     LogLevel,
 )
 from openjiuwen.core.common.logging.utils import get_session_id
+
+# Levels at which the record already reports a failure, so a ``success`` status
+# in the payload beside it contradicts the record it belongs to.
+_FAILURE_LOG_LEVELS = frozenset({LogLevel.ERROR, LogLevel.CRITICAL})
 
 
 def resolve_log_type_label(log_type: str) -> str:
@@ -133,10 +138,19 @@ class StructuredLoggerMixin:
         event: Optional[BaseLogEvent] = None,
         **kwargs: Any,
     ) -> Optional[Dict[str, Any]]:
-        """Build a structured event payload for backends that support it."""
+        """Build a structured event payload for backends that support it.
+
+        ``BaseLogEvent.status`` defaults to ``SUCCESS`` and callers rarely
+        override it, so reconcile the status with the emitting level the same
+        way the level itself is reconciled: log analysis reads the payload, and
+        ``status: success`` beside an ``ERROR`` record contradicts it.
+        """
         if event is not None:
             if event.log_level != log_level:
                 event.log_level = log_level
+
+            if event.status is EventStatus.SUCCESS and log_level in _FAILURE_LOG_LEVELS:
+                event.status = EventStatus.FAILURE
 
             if msg and msg.strip():
                 event.message = self._sanitize_message(msg)
@@ -147,6 +161,9 @@ class StructuredLoggerMixin:
 
         if event_type is None:
             return None
+
+        if "status" not in kwargs and log_level in _FAILURE_LOG_LEVELS:
+            kwargs["status"] = EventStatus.FAILURE
 
         if "trace_id" not in kwargs:
             trace_id = get_session_id()

--- a/tests/unit_tests/core/common/log/test_loguru_backend.py
+++ b/tests/unit_tests/core/common/log/test_loguru_backend.py
@@ -338,6 +338,29 @@ def test_event_object_event_first_json_preserves_metadata_and_context(tmp_path):
     assert "stale" not in payload["metadata"]["_log_context"]
 
 
+def test_event_object_logged_as_error_reports_a_failure_status(tmp_path):
+    """A structured event logged at ERROR must not report ``status: success``.
+
+    Observed in production: an operation that failed emitted an ERROR record
+    whose payload still carried the ``BaseLogEvent.status`` default, so log
+    analysis counted the failure as a success.
+    """
+    config_file_path = os.path.join(tmp_path, "loguru_event_first_error_status.yaml")
+    write_yaml_config(config_file_path, _make_event_first_loguru_config(tmp_path))
+
+    event = create_log_event(LogEventType.AGENT_ERROR, module_id="agent_123")
+
+    with patched_logging_config(config_file_path):
+        logger = LogManager.get_logger("common")
+        set_session_id("TRACE-EVENT-ERROR")
+        logger.error("Failed to run the agent", event=event)
+
+    payload = _read_last_json_record(os.path.join(tmp_path, "common.jsonl"))
+
+    assert payload["log_level"] == "ERROR"
+    assert payload["status"] == "failure"
+
+
 def test_plain_log_can_emit_event_first_json_payload(tmp_path, capsys):
     config_file_path = os.path.join(tmp_path, "loguru_event_first_plain.yaml")
     write_yaml_config(config_file_path, _make_event_first_loguru_config(tmp_path))

--- a/tests/unit_tests/core/common/log/test_structured_log.py
+++ b/tests/unit_tests/core/common/log/test_structured_log.py
@@ -21,6 +21,7 @@ from openjiuwen.core.common.logging.events import (
     AgentEvent,
     BaseLogEvent,
     create_log_event,
+    EventStatus,
     get_event_class,
     LLMEvent,
     LogEventType,
@@ -930,3 +931,108 @@ def test_custom_event_validation():
 
     # Cleanup
     unregister_event_class(custom_type)
+
+
+def _read_single_json_record(log_file: str) -> dict:  # type: ignore
+    """Read the only JSON record written to *log_file*."""
+    with open(log_file, "r", encoding="utf-8") as f:
+        return json.loads(f.read().strip())
+
+
+def _json_logger(name: str, log_file: str) -> DefaultLogger:  # type: ignore
+    """Build a file-only JSON logger for status assertions."""
+    return DefaultLogger(
+        name,
+        {
+            "log_file": log_file,
+            "output": ["file"],
+            "structured_output_format": "json",
+            "level": logging.DEBUG,
+            "backup_count": 5,
+            "max_bytes": 10 * 1024 * 1024,
+            "format": "%(message)s",
+        },
+    )
+
+
+def test_error_record_with_event_object_is_not_labelled_success(temp_log_dir):  # type: ignore
+    """An event object logged at ERROR must not report ``status: success``.
+
+    ``BaseLogEvent.status`` defaults to ``SUCCESS`` and callers building an
+    event for a failure rarely override it, so the payload used to contradict
+    the very record it belongs to.
+    """
+    log_file = os.path.join(temp_log_dir, "event_error.log")  # type: ignore
+    logger = _json_logger("test_event_error_status", log_file)
+
+    event = create_log_event(LogEventType.AGENT_ERROR, module_id="agent_123")
+    logger.error("Operation failed", event=event)
+
+    for handler in logger.logger().handlers:
+        handler.flush()
+
+    parsed = _read_single_json_record(log_file)
+
+    assert parsed["log_level"] == "ERROR"
+    assert parsed["status"] == "failure"
+
+    safe_close_logger_handlers(logger)
+
+
+def test_error_record_from_event_type_is_not_labelled_success(temp_log_dir):  # type: ignore
+    """The keyword-built path carries the same default and needs the same fix."""
+    log_file = os.path.join(temp_log_dir, "kwargs_error.log")  # type: ignore
+    logger = _json_logger("test_kwargs_error_status", log_file)
+
+    logger.error("Operation failed", event_type=LogEventType.AGENT_ERROR, module_id="agent_123")
+
+    for handler in logger.logger().handlers:
+        handler.flush()
+
+    parsed = _read_single_json_record(log_file)
+
+    assert parsed["log_level"] == "ERROR"
+    assert parsed["status"] == "failure"
+
+    safe_close_logger_handlers(logger)
+
+
+def test_explicit_non_success_status_survives_an_error_record(temp_log_dir):  # type: ignore
+    """A status the caller chose is kept; only the ``SUCCESS`` default is replaced."""
+    log_file = os.path.join(temp_log_dir, "explicit_status.log")  # type: ignore
+    logger = _json_logger("test_explicit_status", log_file)
+
+    event = create_log_event(
+        LogEventType.AGENT_ERROR,
+        module_id="agent_123",
+        status=EventStatus.TIMEOUT,
+    )
+    logger.error("Operation timed out", event=event)
+
+    for handler in logger.logger().handlers:
+        handler.flush()
+
+    parsed = _read_single_json_record(log_file)
+
+    assert parsed["status"] == "timeout"
+
+    safe_close_logger_handlers(logger)
+
+
+def test_info_record_keeps_the_success_status(temp_log_dir):  # type: ignore
+    """Records below ERROR are untouched, so ordinary events keep reporting success."""
+    log_file = os.path.join(temp_log_dir, "info_status.log")  # type: ignore
+    logger = _json_logger("test_info_status", log_file)
+
+    event = create_log_event(LogEventType.AGENT_END, module_id="agent_123")
+    logger.info("Operation finished", event=event)
+
+    for handler in logger.logger().handlers:
+        handler.flush()
+
+    parsed = _read_single_json_record(log_file)
+
+    assert parsed["log_level"] == "INFO"
+    assert parsed["status"] == "success"
+
+    safe_close_logger_handlers(logger)


### PR DESCRIPTION
Paired: [GitHub #966](https://github.com/openJiuwen-ai/agent-core/pull/966) ↔ [GitCode !2533](https://gitcode.com/openJiuwen/agent-core/merge_requests/2533)

**What type of PR is this?**

/kind bug

**Which issue(s) this PR fixes**:

Fixes #965

Not #967. That report shares this one's root cause — the `BaseLogEvent.status` default — and nothing else: it is about `SYS_OP_START` records emitted at `INFO` before the work runs, which no rule keyed on the emitting level can reach. This request does not correct those records and should not close that issue. See *Adjacent, not overlapping* below.

**What does this PR do / why do we need it**:

`BaseLogEvent.status` defaults to `EventStatus.SUCCESS`, so a caller building an event to describe a failure has to override it by hand. Almost no caller does: of the 188 call sites under `openjiuwen/` that log a structured event at `ERROR` or `CRITICAL`, exactly one passes a status. The other 187 emit a record whose level says `ERROR`, whose message names what went wrong, and whose structured payload reads `"status": "success"` right beside it.

`status` is in the machine-readable half of the record, which is the half a log pipeline filters, counts and alerts on. A record whose level says `ERROR` and whose payload says `success` is read one way by a human and the opposite way by anything querying the field. #965 has the full case: the call-site census by area, the reproduction, the measured scale, and the archaeology of how the two halves came to disagree.

One point from that case bears directly on where the fix belongs. The loguru backend already decides this exact question — `_record_is_failure` returns true at `ERROR` or above, and `_enrich_exception_payload` stamps `"status": "failure"` when it does — but its guard is `if not had_status and ...`, and a structured event always carries a status because the dataclass default guarantees it. The rule this PR applies is the rule that backend already states; it is applied where structured events can actually reach it.

### The change

`StructuredLoggerMixin._build_structured_event_dict` already reconciles one field of the event against reality: if `event.log_level` disagrees with the level the record is being emitted at, the emitting level wins. The status is now reconciled the same way, in the same place:

- a `SUCCESS` status on an `ERROR` or `CRITICAL` record becomes `FAILURE`;
- `TIMEOUT`, `CANCELLED` and `PENDING` are left alone — a caller who names one of those has decided something the level does not contradict;
- the keyword-built path (`event_type=` with no event object) takes `FAILURE` as its default at those levels, for the same reason;
- records below `ERROR` are untouched, so ordinary events keep reporting success.

The fix sits on the shared mixin rather than in either backend, so the default and loguru implementations and every logger built on them are covered by one rule, and the two cannot drift apart.

The event object is mutated in place. That is the existing convention in this method — the `log_level` reconciliation immediately above does the same thing to the same object — so no new aliasing behaviour is introduced.

### What this does not do

- **It does not distinguish an explicit `SUCCESS` from the default on the event path.** An event object arrives with its `status` already set, and a dataclass default is not distinguishable from an explicit value assigned to the same field, so a caller passing `status=EventStatus.SUCCESS` on an `ERROR` record is overridden along with the 187 that passed nothing. That combination contradicts itself in any case, and between the two signals the emitting level is the more reliable. The keyword-built path is different, and deliberately so: there `status` is an ordinary keyword, an explicit one is visible as a choice, and `FAILURE` is supplied only when none was given. Measured on an `ERROR` record carrying `status=EventStatus.SUCCESS`: the event path emits `"status": "failure"`, the keyword path emits `"status": "success"`.
- **It does not touch the loguru `had_status` path.** That path still handles records built without a structured event, including the exception-without-error-level case, which the level check alone would miss.
- **It does not change `BaseLogEvent`.** Making `status` optional so that an unset status stayed out of the payload was considered and rejected: it changes a public dataclass, removes the field from every successful record as well, and would still leave the default backend with no status at all rather than a correct one.
- **It does not touch the 188 call sites.** Setting the status by hand at each one fixes today's callers and none of tomorrow's; the defect is in the default, so the correction belongs where the default is consumed.
- **It does not reach failure records emitted below `ERROR`.** A rule keyed on the level can only act where the level already says something is wrong. `sys_operation` alone emits 12 of its 23 `SYS_OP_ERROR` records at `WARNING` or `DEBUG`; those keep reporting `success` after this change. Correcting them means deciding per call site what level a failure deserves, which is a change to the call sites rather than to the logger. #965 records that residue explicitly so it is not mistaken for closed.

### Compatibility

No public signature changes and no schema change: `status` was already present on every structured record and its type is unchanged. What changes is the value on records emitted at `ERROR` or `CRITICAL`. A downstream consumer that counts `status == "success"` will see its counts drop by the number of structured error records — which is the point of the change, and is the direction of correction rather than a regression. A consumer keyed on `log_level` is unaffected.

### Adjacent, not overlapping

`fix(sys_operation): stop start events from claiming success`, filed alongside this one, is the producer-side sibling of this change, and the two are separate on purpose. This change reconciles a status against the level a record is emitted at. That is a rule for every logger and every event family, but it can only act where the level already says something is wrong: of the 23 `SYS_OP_ERROR` call sites, 11 emit at `ERROR` and are corrected here. A start event is emitted at `INFO`, with nothing in the record to say the work has not been attempted yet, so no rule keyed on the level can reach it — only the producer knows. Neither request can do the other's job and neither depends on the other; they can land in either order. Concretely: a `sys_operation_error` record emitted at `ERROR` is one this change corrects, and the `sys_operation_start` record beside it in the same stream is one that request corrects.

`43e77754`, `fix(logging): dedupe loguru sinks by target to cap file descriptors`, reworks sink lifecycle in the loguru backend and touches nothing this PR touches. `base_impl.py`, the only source file changed here, has been modified exactly once in its history. The open browser change (`#92`, GitCode !2040) adds `logging/browser_context.py` and gates a browser-context branch in `logging/default/default_impl.py`; it shares no file with this PR and neither depends on the other. No other open pull request touches `base_impl.py`, `events.py` or `loguru/loguru_impl.py`.

**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

Five tests were added, four against the default backend and one against loguru, so the fix is pinned on both implementations rather than on the mixin in isolation:

- an event object logged at `ERROR` reports `"status": "failure"`, on the default backend and on loguru's event-first JSON output;
- the keyword-built path (`logger.error(..., event_type=...)`) reports the same;
- an explicit `EventStatus.TIMEOUT` survives an `ERROR` record unchanged;
- an `INFO` record still reports `"status": "success"`.

Each test reads back the JSON record actually written to a file rather than inspecting the intermediate dictionary, so what is asserted is the emitted payload.

Three of the five discriminate — run against the base commit with only the test files applied, they fail on their `status` assertions (not at import or setup, which would prove much less); on this branch they pass. That is the claim that carries weight, since it describes a behaviour change rather than new coverage. The base record they fail on shows the defect directly, abridged to the fields that matter:

```json
{"event_type": "agent_error", "log_level": "ERROR", "status": "success", "message": "Operation failed", ...}
```

The remaining two — `TIMEOUT` survives, `INFO` keeps `success` — pass on both sides by design. They are regression guards for the two things the fix must not do.

`pytest tests/unit_tests/core/common/log/test_structured_log.py tests/unit_tests/core/common/log/test_loguru_backend.py` — 65 tests, the 60 already in those two files plus the 5 added, all passing.

`pytest tests/unit_tests/core/common/log/` — 116 tests, the whole logging test package, all passing. None of them appears in the full-suite failure list below, on this branch or on the base.

Full `tests/`, run on this branch and on a clean checkout of the base commit, compared test-by-test rather than by count: **the two failure sets are identical, with no line differing** — the same 165 tests fail and the same 7 modules fail to collect on both sides, 172 entries in all. Passes go from 16842 to 16847, which is the five added tests and nothing else. The collection errors are CLI test modules needing `prompt_toolkit`, absent from the environment used; `--continue-on-collection-errors` was passed on both sides so the rest of the suite still ran.

The suite run is also the widest behavioural check available, because the code under test logs while it runs. Across the full run at `dce36fc8` the suite's own product code emits 1958 structured records at `ERROR`, counted from the same two runs as the parity figures above:

| | base | this PR |
| --- | --- | --- |
| records at `"log_level": "ERROR"` | 1958 | 1958 |
| of those, `"status": "success"` | 1958 | 0 |
| of those, `"status": "failure"` | 0 | 1958 |

Same count of records on both sides, so none is gained or lost — only the field that was wrong is now right, on records produced by ordinary product code rather than by a fixture. No record ends up with any status other than `failure`, so the reconciliation is not partial.

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

On the three unticked items: **Design** — not yet reviewed by a Maintainer; this PR is the first submission and the reasoning behind the approach, and the alternatives rejected, are set out above for that review. **Interface** — no external interface changes: no public signature, dataclass field or configuration key is added, removed or retyped, so there is nothing for an interface review to approve and no API annotation to refresh. The emitted value of an existing field does change, which is described under *Compatibility* above. **Document** — no official website documentation change is needed: the corrected behaviour is what the existing documentation and the existing test suite already describe as intended, so there is nothing to amend in the Doc repository.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #965
- Fixes #967
<!-- /bot1-related-issues -->
