### PR TITLE
fix(sys_operation): stop start events from claiming success

### DIFF
--- a/openjiuwen/core/sys_operation/base.py
+++ b/openjiuwen/core/sys_operation/base.py
@@ -6,7 +6,7 @@ from typing import Union, List, Optional, Dict, Any
 from pydantic import BaseModel
 
 from openjiuwen.core.common.logging import LogEventType, create_log_event
-from openjiuwen.core.common.logging.events import SysOperationEvent
+from openjiuwen.core.common.logging.events import EventStatus, SysOperationEvent
 from openjiuwen.core.foundation.tool import ToolCard
 from openjiuwen.core.foundation.tool.utils.callable_schema_extractor import CallableSchemaExtractor
 from openjiuwen.core.sys_operation.config import LocalWorkConfig, SandboxGatewayConfig
@@ -134,6 +134,13 @@ class BaseOperation:
         an operation that moves a large file body does not pay to serialize it
         into every log sink.
 
+        A start event is emitted before the operation runs, so it has no outcome
+        to report and defaults to ``PENDING`` rather than to ``SUCCESS``. On an
+        end event ``status`` describes the operation, which completed, not the
+        work it wrapped: the command's exit code goes in ``method_result``, and
+        which non-zero codes count as failures is the caller's to decide --
+        ``grep`` finding nothing is not an error.
+
         Args:
             event_type: Type of the system operation event (enum or string)
             method_name: Name of the method/function being logged
@@ -149,6 +156,8 @@ class BaseOperation:
             kwargs["module_id"] = "sys_operation"
         if "module_name" not in kwargs:
             kwargs["module_name"] = "sys_operation"
+        if "status" not in kwargs and event_type == LogEventType.SYS_OP_START:
+            kwargs["status"] = EventStatus.PENDING
         event = create_log_event(
             event_type=event_type,
             operation_name=self.name,

--- a/tests/unit_tests/core/sys_operation/test_base.py
+++ b/tests/unit_tests/core/sys_operation/test_base.py
@@ -1,21 +1,28 @@
 # coding: utf-8
 # Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
-"""Log payload clipping for sys_operation events.
+"""What a sys_operation event records: clipped payloads, and its status.
 
 A sys_operation event records what an operation did, not the bytes it moved.
 Clipping runs on every logged operation, so it has to stay both cheap and
 total: anything it raises on would take the operation down with it.
+
+The status goes out with every event and is what a reader filters the stream on,
+so it has to say something true at the point the event is emitted.
 """
 from __future__ import annotations
 
 from collections import namedtuple
 
+from openjiuwen.core.common.logging.events import EventStatus, LogEventType
 from openjiuwen.core.sys_operation.base import (
+    BaseOperation,
     LOG_PAYLOAD_MAX_CHARS,
+    OperationMode,
     _LOG_PAYLOAD_MAX_DEPTH,
     _LOG_PAYLOAD_MAX_ITEMS,
     _clip_log_payload,
 )
+from openjiuwen.core.sys_operation.config import LocalWorkConfig
 
 
 def test_short_values_pass_through_untouched() -> None:
@@ -78,3 +85,51 @@ def test_pathological_nesting_is_summarized_instead_of_walked() -> None:
     rendered = repr(_clip_log_payload(payload))
 
     assert "omitted at depth" in rendered
+
+
+def _operation() -> BaseOperation:
+    """A bare operation, enough to build events from."""
+    return BaseOperation(
+        name="shell",
+        mode=OperationMode.LOCAL,
+        description="local shell operation",
+        run_config=LocalWorkConfig(),
+    )
+
+
+def test_start_events_report_pending_rather_than_success() -> None:
+    """A start event precedes the work, so it cannot report an outcome yet.
+
+    Observed in production: every start event carried the ``SUCCESS`` default,
+    which reads as a completed operation to anyone filtering the stream on status.
+    """
+    event = _operation()._create_sys_operation_event(
+        event_type=LogEventType.SYS_OP_START,
+        method_name="execute_cmd",
+    )
+
+    assert event.status is EventStatus.PENDING
+
+
+def test_end_events_keep_reporting_success() -> None:
+    """The operation completed; what the command exited with is a separate fact."""
+    event = _operation()._create_sys_operation_event(
+        event_type=LogEventType.SYS_OP_END,
+        method_name="execute_cmd",
+        method_result={"data": {"exit_code": 1}},
+    )
+
+    assert event.status is EventStatus.SUCCESS
+    assert event.method_result["data"]["exit_code"] == 1
+
+
+def test_an_explicit_status_is_kept_on_a_start_event() -> None:
+    """The default only applies where the caller expressed no status of its own."""
+    event = _operation()._create_sys_operation_event(
+        event_type=LogEventType.SYS_OP_START,
+        method_name="execute_cmd",
+        status=EventStatus.CANCELLED,
+    )
+
+    assert event.status is EventStatus.CANCELLED
+


### PR DESCRIPTION
Paired: [GitHub #968](https://github.com/openJiuwen-ai/agent-core/pull/968) ↔ [GitCode !2534](https://gitcode.com/openJiuwen/agent-core/merge_requests/2534)

**What type of PR is this?**

/kind bug

**Which issue(s) this PR fixes**:

Fixes #967

Not #965. That report shares this one's root cause — the `BaseLogEvent.status` default — and nothing else: it is about records emitted at `ERROR` or `CRITICAL`, corrected at the logging backend across every event family. This request does not correct those records and should not close that issue. See *Adjacent, not overlapping* below.

**What does this PR do / why do we need it**:

`BaseLogEvent.status` defaults to `EventStatus.SUCCESS` and nothing in `sys_operation` overrides it: `BaseOperation._create_sys_operation_event`, through which the fs, shell and code operations build their events, supplies no status of its own, and the keyword-built records in `local/utils.py` pass none either. Every `sys_operation` event inherits that default. A start event is built and emitted *before* the operation runs — all 15 `SYS_OP_START` emissions sit at the top of the method — so the record announcing `Start to execute cmd` goes out carrying `"status": "success"` for work that has not been attempted.

`status` is the field a reader of the stream filters and aggregates on, and it is present on every serialized event. So every operation contributes a success before doing anything, and filtering the stream down to `"status": "success"` does not narrow it to completed work — it keeps every start line as well, which is exactly the set an operator is trying to exclude when looking for what did not finish. #967 has the full case: the emission census, a self-contained reproduction that reports four successes for two operations of which one succeeded, and the observed payloads.

`EventStatus.PENDING` is the value the enum already carries for this case, and the event type carries the rest: `SYS_OP_END` means the operation completed, `SYS_OP_ERROR` that it did not.

This PR gives `SYS_OP_START` a `PENDING` default in `_create_sys_operation_event`. The change is one condition and it only supplies a default: a caller passing `status=` of its own still wins, and end, error and stream events are untouched. The reasoning is recorded in the method's docstring, because the next reader of that method will ask the same questions the section below answers.

### What this PR deliberately leaves alone

**End events still report success when the command exited non-zero.** `status` describes the operation, and the operation completed; the command's exit code is recorded in `method_result` beside it. Which non-zero exits count as failures is the caller's judgement — `grep` finding nothing and `diff` finding differences both exit non-zero and neither is an error — and a generic shell operation has no way to tell those apart from a real failure. Deciding it here would be guessing on the caller's behalf.

**Error events still carry the `SUCCESS` default, and that is a real defect** — one a companion request fixes rather than this one. Reconciling a status against the level a record is emitted at is a rule that holds for every logger and every event family, not for this one operation class, so it belongs at the logging backend. `fix(logging): stop labelling failed records as successful events`, filed alongside this one, is that change: it turns a `SUCCESS` on an `ERROR` or `CRITICAL` record into `FAILURE` on the shared logger mixin, which corrects the 11 of 23 `SYS_OP_ERROR` sites that emit at `ERROR`. The 12 at `WARNING` and `DEBUG` are out of its reach as well as this one's and stay wrong — a residue neither request claims to close, recorded in #965 so it is not mistaken for closed.

A start event needs the opposite treatment, and for a reason no backend rule can supply: it is emitted at `INFO`, nothing about the record tells a backend that anything is pending, and only the producer knows the work has not been attempted yet. That is why this case is fixed at the producer.

**Other event families still emit a successful start.** `RUNNER_START`, `GRAPH_START`, `LLM_CALL_START`, `AGENT_START`, `TOOL_CALL_START`, the workflow starts and the graph vertex and super-step starts all inherit the same default and have the same problem; #967 enumerates them. A blanket rule keyed on the `_START` suffix would be guessing at semantics none of those families state, each one needs its own tests, and the resulting change would touch a dozen unrelated modules at once. This PR fixes the family where the wrong status was observed and leaves the pattern visible for the others.

### Compatibility

No public signature changes and no schema change: `status` was already present on every `sys_operation` record and `PENDING` is an existing member of `EventStatus`, not a new one. What changes is the value on `SYS_OP_START` records. A downstream consumer that counts `status == "success"` will see its `sys_operation` counts drop by one per operation — which is the correction being made. A consumer that enumerates `EventStatus` exhaustively already had to handle `PENDING`; one that treats any non-`success` value as a failure will now read a start line as a failure rather than as a success, which is why the event type, not the status, remains the right discriminator for outcome.

### Adjacent, not overlapping

`fix(logging): stop labelling failed records as successful events`, filed alongside this one, is the backend-side sibling described above: it changes `core/common/logging/base_impl.py` only, shares no file with this request, and neither depends on the other — they can land in either order. `fix(sys_operation): scope the fs lock directory per user` (`#283`, GitCode !2164) is in the same package but in `local/_rw_lock_manager.py`; it shares no file either. `core/sys_operation/base.py`, the only source file changed here, was last touched on `develop` by `a6207c54`, which moved log-payload clipping off the hot path and left the event fields alone. No open pull request touches `core/sys_operation/base.py`; the open work in that package — `local/shell_operation.py`, `local/fs_operation.py`, `local/utils.py`, `cwd.py`, `config.py`, `local/_rw_lock_manager.py`, `sandbox/launchers/pre_deployment_launcher.py` — is all in other files.

**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

The change is directly observable in the serialized event. Building a start event and an end event through `_create_sys_operation_event` and rendering them with `to_dict()` — the same dict both logging backends write into the payload — gives:

| event | base | this PR |
| --- | --- | --- |
| `sys_operation_start` | `"status": "success"` | `"status": "pending"` |
| `sys_operation_end` | `"status": "success"` | `"status": "success"` |

The record that reads `Start to execute cmd` no longer claims an outcome, and nothing else in the stream moves. The `sys_operation_error` records in that same stream are unchanged by this PR on both sides, as intended; the companion logging change named above is what corrects those.

Unit tests are in `tests/unit_tests/core/sys_operation/test_base.py`, which goes from 7 tests to 10. One of the three new tests fails against the base, on its assertion rather than at setup:

```
assert <EventStatus.SUCCESS: 'success'> is <EventStatus.PENDING: 'pending'>
```

The other two are guards rather than regressions: an end event has to keep reporting success beside a non-zero exit code recorded in `method_result`, and a `status=` passed explicitly by a caller has to survive, since the change only supplies a default.

Full suite over `tests/`, run to completion on this branch and on its base at the same commit, one pytest process at a time:

| | base | this PR |
| --- | --- | --- |
| passed | 16842 | 16845 |
| failed | 165 | 165 |
| collection errors | 7 | 7 |

The three extra passes are the new tests. Failing test names and collection errors were compared name by name rather than by count, and both sets are identical between the two runs — 165 failing tests and 7 modules that fail to collect, 172 entries in all, on each side. Six of the failures are inside `core/sys_operation/`, the same six on both sides, and none of them fails on anything this change touches: two on `unable to open database file` out of the shared read-write lock directory, two on a `_configure_and_begin()` keyword mismatch in the lock manager, one on a closed sqlite handle, and one on `python` not being on `PATH`. All six reproduce on the base with the branch not applied. The collection errors are the seven CLI test modules that need `prompt_toolkit`, absent from the environment used here and equally absent on the base.

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

On the three unticked items: **Design** — not yet reviewed by a Maintainer; this PR is the first submission and the reasoning behind the approach, including what it deliberately leaves alone, is set out above for that review. **Interface** — no external interface changes: `_create_sys_operation_event` is a protected method, no public signature or configuration key is added, removed or retyped, and `PENDING` is an existing `EventStatus` member, so there is nothing for an interface review to approve and no API annotation to refresh. The emitted value of an existing field does change, which is described under *Compatibility* above. **Document** — no official website documentation change is needed: no documented behaviour, option or interface changes, so there is nothing to amend in the Doc repository.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #965
- Fixes #967
<!-- /bot1-related-issues -->
