### PR TITLE
fix(security): let the host supply the tool permission prompt wording

### DIFF
--- a/docs/en/2.Development Guide/Tool permissions and host integration.md
+++ b/docs/en/2.Development Guide/Tool permissions and host integration.md
@@ -66,6 +66,44 @@ See **`openjiuwen.harness.security.host.ToolPermissionHost`**.
 | **`permission_yaml_path`** | Agent **config YAML** path; **`persist_*`** writes the **`permissions:`** subtree. File may not exist yet if the **parent directory** exists; first write can bootstrap from the global engine config. |
 | **`tool_permission_checks_active`** | `Callable[[], bool]`. If it returns **False**, tool permission checks are **skipped** (allow). If **unset**, checks always run. The host decides what “active” means (e.g. product-specific entry routing). |
 | **`permission_scene_hook`** | Optional async hook before tiered evaluation; product-specific (e.g. digital-avatar flows in a host repo). |
+| **`prompt_texts`** | `PermissionPromptTexts`: wording for the built-in **ASK** confirmation. See section 3.1. |
+
+### 3.1 Confirmation wording (`prompt_texts`)
+
+When **ASK** reaches the built-in Confirm interrupt, the text a person reads comes from two places: `build_permission_ask_presentation` produces the category title and the summary, and `PermissionInterruptRail` appends the "remember" hint. Both take their wording from `ToolPermissionHost.prompt_texts` — a frozen `PermissionPromptTexts` of `str.format` templates in `openjiuwen.harness.security.permission_engine.prompt_texts`.
+
+The title does not appear in the interrupt body; it reaches the host as `ask_title` in the interrupt metadata, alongside `ask_category` and `ask_summary`. Overriding `prompt_texts` changes both.
+
+openjiuwen does **not** choose a language here. `AGENT_PROMPT_LANGUAGE` and `resolve_language()` govern the **system prompt sent to the model**, not text a person reads; the two need not agree, and only the host knows what language its users are served in. Every default but two reproduces the built-in Chinese wording, so a host that injects nothing keeps its current output unchanged; `remember_tool` and `path_scope` are corrected rather than reproduced (below).
+
+```python
+from openjiuwen.harness.security import (
+    ENGLISH_PERMISSION_PROMPT_TEXTS,
+    PermissionPromptTexts,
+    ToolPermissionHost,
+)
+
+# the bundled English wording
+host = ToolPermissionHost(prompt_texts=ENGLISH_PERMISSION_PROMPT_TEXTS)
+
+# or wording of the host's own, in any language, overriding only what it needs
+host = ToolPermissionHost(
+    prompt_texts=PermissionPromptTexts(
+        title_tool="This tool needs your approval",
+        summary_tool="{tool_name} (confirmation required)",
+    ),
+)
+```
+
+The "remember" hint describes a **whole-tool** allow, and `path_scope` says so rather than implying a path limit. Neither remember is keyed on the path: the session key comes from `PermissionInterruptRail._get_auto_confirm_key`, which appends a subcommand only for shell tools and returns the bare tool name for every other tool, so the session entry is the tool name and matches that tool's every later ASK; and the permanent rule goes through `merge_permission_allow_rule_into_permissions`, which drops `path` suggestions (paths are written to file_guard instead) and, with nothing else to write for a non-shell tool, sets `permissions.tools[<tool>] = "allow"`. The previous wording described the allow as limited to the path shown; a host overriding these two fields should not reintroduce that reading.
+
+Not every string in the ASK body is a template. The summary of a `path`, `network` or `shell` confirmation is a path, a URL or the command itself; only the `tool` summary and the risk name that prefixes a `finding` summary are prose, and those are the ones `prompt_texts` covers.
+
+Each field documents the placeholders it accepts, and constructing a `PermissionPromptTexts` renders every field once against **its own** set — not the union of all of them, which would let `title_tool="{tool_name}"` through even though a title is rendered with no placeholders at all. A misspelt placeholder, a placeholder belonging to another field, a malformed format string, or a non-string value raises `DEEPAGENT_CONFIG_PARAM_ERROR` naming the field and what was wrong with it. A literal brace must be doubled (`{{`, `}}`).
+
+Validating at construction rather than at render is what makes a typo safe to make. A rail's `before_tool_call` stops a tool call only by raising `AbortError` or by marking the call skipped; any other exception is caught per callback by the callback framework, logged, and the chain continues. An error raised while rendering an ASK body would therefore leave the rail with no decision and let that one call through unconfirmed. Raising where the host builds its texts turns the same typo into a startup failure at the integration point.
+
+A host whose `request_permission_confirmation` returns anything other than `"interrupt"` renders its own confirmation UI and never reaches these templates.
 
 ---
 
@@ -98,6 +136,8 @@ For the built-in YAML writer, **`_resolve_agent_config_yaml_path`** uses **only*
 | `openjiuwen/harness/security/host.py` | `ToolPermissionHost` |
 | `openjiuwen/harness/security/factory.py` | `build_permission_interrupt_rail` |
 | `openjiuwen/harness/rails/security/tool_security_rail.py` | `PermissionInterruptRail` |
+| `openjiuwen/harness/security/permission_engine/prompt_texts.py` | `PermissionPromptTexts`, `ENGLISH_PERMISSION_PROMPT_TEXTS` |
+| `openjiuwen/harness/security/permission_engine/approve/ask_presentation.py` | ASK category, title and summary |
 | `openjiuwen/harness/security/patterns.py` | Matching + YAML **`persist_*`** |
 | `openjiuwen/harness/deep_agent.py` | Queues permission rail when enabled |
 | `examples/permissions/permission_demo.py` | Demo script |

--- a/docs/zh/2.开发指南/工具权限防护.md
+++ b/docs/zh/2.开发指南/工具权限防护.md
@@ -68,6 +68,44 @@ permissions = {
 | **`permission_yaml_path`** | **Agent 配置文件**路径；`persist_*` 写入该 YAML 根下的 **`permissions:`** 小节。文件可尚不存在，**父目录须存在**；首次写入时可用当前全局引擎配置引导航。 |
 | **`tool_permission_checks_active`** | `Callable[[], bool]`：若返回 **False**，则跳过工具权限校验（等价放行）。**未设置**时始终执行校验；由宿主决定「当前上下文是否要做校验」（如按入口类型路由，实现可放在产品包）。 |
 | **`permission_scene_hook`** | 在通用 tiered 判定前异步介入；返回 `None` 则继续走引擎。用于数字分身、owner_scopes 等产品逻辑（实现通常在宿主仓库）。 |
+| **`prompt_texts`** | `PermissionPromptTexts`：内置 **ASK** 确认界面的文案模板。见 3.1。 |
+
+### 3.1 确认界面文案（`prompt_texts`）
+
+**ASK** 走内置 Confirm 中断时，用户看到的文字来自两处：`build_permission_ask_presentation` 给出分类标题与摘要，`PermissionInterruptRail` 再拼上「记住」提示。两处的措辞都取自 `ToolPermissionHost.prompt_texts` —— 定义在 `openjiuwen.harness.security.permission_engine.prompt_texts` 的冻结数据类 `PermissionPromptTexts`，每个字段是一条 `str.format` 模板。
+
+标题不进中断正文，而是随中断元数据的 `ask_title` 交给宿主（同行的还有 `ask_category` / `ask_summary`）。覆盖 `prompt_texts` 两处一起改。
+
+本层**不**替宿主挑选语言。`AGENT_PROMPT_LANGUAGE` 与 `resolve_language()` 管的是**发给模型的系统提示词**，不是给人读的文字；两者本就不必一致，而终端用户使用哪种语言只有宿主知道。除 `remember_tool` 与 `path_scope` 外，各字段默认值与内置中文措辞逐字一致，未注入的宿主输出不变；这两个字段是照代码改正的措辞，而非照搬（见下）。
+
+```python
+from openjiuwen.harness.security import (
+    ENGLISH_PERMISSION_PROMPT_TEXTS,
+    PermissionPromptTexts,
+    ToolPermissionHost,
+)
+
+# 随附的英文文案
+host = ToolPermissionHost(prompt_texts=ENGLISH_PERMISSION_PROMPT_TEXTS)
+
+# 或宿主自备任意语言的文案，只覆盖需要改的字段
+host = ToolPermissionHost(
+    prompt_texts=PermissionPromptTexts(
+        title_tool="This tool needs your approval",
+        summary_tool="{tool_name} (confirmation required)",
+    ),
+)
+```
+
+「记住」提示描述的是**整个工具**的放行，`path_scope` 也照此写，不再暗示限于某个路径。两种「记住」都不按路径生效：会话内放行的键取自 `PermissionInterruptRail._get_auto_confirm_key`，它只为 shell 类工具拼上子命令，其余工具直接返回工具名，写进会话的就是工具名本身，此后该工具的每一次 ASK 都命中它；永久放行经 `merge_permission_allow_rule_into_permissions` 落盘，它先滤掉 `path` 类建议（路径只写 file_guard），非 shell 工具再无其它建议时写的是 `permissions.tools[<工具名>] = "allow"`。历来的措辞把放行说成限于提示里那个路径；宿主覆盖这两个字段时同样不应写回那种读法。
+
+并非 ASK 正文里的每一段文字都是模板：`path` / `network` / `shell` 三类的摘要分别是路径、URL 与命令原文；只有 `tool` 类摘要与 `finding` 类摘要前缀的风险名称属于成句的措辞，`prompt_texts` 覆盖的正是这两处。
+
+每个字段各自说明可用的占位符；构造 `PermissionPromptTexts` 时按**该字段自己**那一份占位符逐字段试渲染一次，而不是取全部字段的并集——取并集会放过 `title_tool="{tool_name}"` 这类真错误，而渲染标题时一个占位符都不传。拼错占位符、用了别的字段才有的占位符、写错格式串、字段不是 `str`，都抛 `DEEPAGENT_CONFIG_PARAM_ERROR`，并指出是哪个字段、错在哪里。模板内的字面花括号需写成 `{{` / `}}`。
+
+校验放在构造时而非渲染时，是因为渲染时抛错并不安全：护栏的 `before_tool_call` 只有抛 `AbortError` 或标记跳过才能拦下工具调用，其余异常被回调框架逐个吞掉、链继续；渲染 ASK 正文时抛错，等于这次调用没有任何权限判定就直接放行。把同一个笔误挪到宿主构造文案处，它就成了集成期的启动失败。
+
+`request_permission_confirmation` 返回值不是 `"interrupt"` 的宿主自行渲染确认界面，不经过这些模板。
 
 ---
 
@@ -124,6 +162,8 @@ permissions = {
 | `openjiuwen/harness/security/host.py` | `ToolPermissionHost` |
 | `openjiuwen/harness/security/factory.py` | `build_permission_interrupt_rail` |
 | `openjiuwen/harness/rails/security/tool_security_rail.py` | `PermissionInterruptRail` |
+| `openjiuwen/harness/security/permission_engine/prompt_texts.py` | `PermissionPromptTexts`、`ENGLISH_PERMISSION_PROMPT_TEXTS` |
+| `openjiuwen/harness/security/permission_engine/approve/ask_presentation.py` | ASK 分类、标题与摘要 |
 | `openjiuwen/harness/security/patterns.py` | 模式匹配与 YAML `persist_*` |
 | `openjiuwen/harness/deep_agent.py` | `_queue_pending_rails` 挂载权限 Rail |
 | `examples/permissions/permission_demo.py` | 可运行示例 |

--- a/openjiuwen/harness/docs/specs/S_08_security-engine.md
+++ b/openjiuwen/harness/docs/specs/S_08_security-engine.md
@@ -27,6 +27,8 @@
 - `security/checker.py`：`ExternalDirectoryChecker`（外部路径校验）。
 - `security/host.py`：`ToolPermissionHost` / `PermissionConfirmationRequest` / `PermissionSceneHookInput`
   / `RequestPermissionConfirmationHook`。
+- `security/permission_engine/prompt_texts.py`：`PermissionPromptTexts`（内置 ASK 确认界面的
+  文案模板）/ `ENGLISH_PERMISSION_PROMPT_TEXTS`。
 - `security/factory.py`：`build_permission_interrupt_rail` 等装配。
 - `rails/security/`：`BaseSecurityRail` / `PermissionInterruptRail` / `SafetyPromptRail` /
   `SecurityRail`（决策类型见 `S_04`）。
@@ -62,6 +64,12 @@
 7. **宿主接口**：`ToolPermissionHost` 是工具的权限宿主协议；`RequestPermissionConfirmationHook`
    （`PermissionSceneHookInput` → `PermissionConfirmationResult`）是确认回调契约；
    `PermissionConfirmationRequest` 携带确认请求。
+   内置 ASK 确认界面的文案（分类标题、摘要、「记住」提示）同样经宿主注入
+   （`ToolPermissionHost.prompt_texts`）：本层不挑选语言，默认值与历来输出逐字一致，走
+   `request_permission_confirmation` 自行渲染确认界面的宿主不经过这些模板。模板的合法性在
+   `PermissionPromptTexts` 构造时按字段各自的占位符校验（见
+   `security/permission_engine/prompt_texts.py`），不在渲染时校验：`before_tool_call` 抛出的
+   非 `AbortError` 异常被回调框架吞掉、链继续，渲染期抛错等于该次调用不经权限判定即放行。
 8. **到 rail 的桥唯一**：`security/factory.py:build_permission_interrupt_rail(...)` 构造
    `PermissionInterruptRail`；`deep_agent.py` 的 `build_permission_interrupt_rail` 导入路径
    一致。安全 rail 特性（`supported_events` / 静默降级）见 `S_04` 不变量 8。

--- a/openjiuwen/harness/rails/security/tool_security_rail.py
+++ b/openjiuwen/harness/rails/security/tool_security_rail.py
@@ -804,7 +804,9 @@ class PermissionInterruptRail(ConfirmInterruptRail):
 
         tool_name = tool_call.name if tool_call else ""
         tool_args = self.parse_tool_args(tool_call)
-        presentation = build_permission_ask_presentation(tool_name, tool_args, result)
+        presentation = build_permission_ask_presentation(
+            tool_name, tool_args, result, texts=self._host.prompt_texts,
+        )
         hint = self._build_always_allow_hint(tool_call)
         return render_ask_presentation_message(presentation, always_allow_hint=hint)
 
@@ -819,7 +821,9 @@ class PermissionInterruptRail(ConfirmInterruptRail):
 
         tool_name = tool_call.name if tool_call else ""
         tool_args = self.parse_tool_args(tool_call)
-        presentation = build_permission_ask_presentation(tool_name, tool_args, result)
+        presentation = build_permission_ask_presentation(
+            tool_name, tool_args, result, texts=self._host.prompt_texts,
+        )
         return {
             "ask_category": presentation.category,
             "ask_title": presentation.title,
@@ -834,6 +838,7 @@ class PermissionInterruptRail(ConfirmInterruptRail):
         tool_name = tool_call.name or ""
         tool_args = self.parse_tool_args(tool_call)
         auto_confirm_key = self._get_auto_confirm_key(tool_call)
+        texts = self._host.prompt_texts
 
         path_hint = ""
         for key in ("path", "file_path", "target_file", "file", "old_path", "new_path"):
@@ -854,22 +859,14 @@ class PermissionInterruptRail(ConfirmInterruptRail):
             cmd = tool_args.get("command", tool_args.get("cmd", ""))
             shell_key = self._build_shell_auto_confirm_key(tool_name, str(cmd or ""))
             if shell_key:
-                return (
-                    f'\n\n> 选择「会话内记住」可在本会话内自动放行 ``{shell_key}`` 类调用；'
-                    f'选择「永久记住」可将此规则写回磁盘，所有会话均自动放行。'
-                )
+                return texts.remember_command.format(command_key=shell_key)
             if auto_confirm_key:
-                return (
-                    f'\n\n> 选择「会话内记住」可在本会话内自动放行 ``{auto_confirm_key}`` 类调用。'
-                )
+                return texts.remember_command_session_only.format(command_key=auto_confirm_key)
             return ""
 
         if auto_confirm_key:
-            path_desc = f"在 ``{path_hint}`` 下" if path_hint else ""
-            return (
-                f'\n\n> 选择「会话内记住」可在本会话内自动放行 ``{tool_name}`` 类工具{path_desc}的调用；'
-                f'选择「永久记住」可将此规则写回磁盘，所有会话均自动放行。'
-            )
+            path_scope = texts.path_scope.format(path_hint=path_hint) if path_hint else ""
+            return texts.remember_tool.format(tool_name=tool_name, path_scope=path_scope)
         return ""
 
 

--- a/openjiuwen/harness/security/__init__.py
+++ b/openjiuwen/harness/security/__init__.py
@@ -28,6 +28,10 @@ from openjiuwen.harness.security.permission_engine.host import (
     RequestPermissionConfirmationHook,
     ToolPermissionHost,
 )
+from openjiuwen.harness.security.permission_engine.prompt_texts import (
+    ENGLISH_PERMISSION_PROMPT_TEXTS,
+    PermissionPromptTexts,
+)
 from openjiuwen.harness.security.permission_engine.models import (
     ApprovalOverrideEntry,
     PermissionConfirmResponse,
@@ -49,6 +53,7 @@ from openjiuwen.harness.security.permission_engine.toolguard.pattern_matchers im
 )
 
 __all__ = [
+    "ENGLISH_PERMISSION_PROMPT_TEXTS",
     "get_package_builtin_rules_path",
     "inline_package_command_rules",
     "load_package_command_rules",
@@ -63,6 +68,7 @@ __all__ = [
     "PermissionEngine",
     "ApprovalOverrideEntry",
     "PermissionLevel",
+    "PermissionPromptTexts",
     "PermissionResult",
     "PermissionsSection",
     "ToolPermissionHost",

--- a/openjiuwen/harness/security/permission_engine/__init__.py
+++ b/openjiuwen/harness/security/permission_engine/__init__.py
@@ -5,7 +5,7 @@
 Layout::
 
     permission_engine/
-      models.py / host.py / core.py
+      models.py / host.py / core.py / prompt_texts.py
       toolguard/     command rules, tool_policy, shell AST, matching
       fileguard/     path policy, path_extract, file_tool_specs, sensitive paths
       netguard/      fetch URL policy
@@ -22,10 +22,16 @@ from openjiuwen.harness.security.permission_engine.models import (
     PermissionResult,
     PermissionsSection,
 )
+from openjiuwen.harness.security.permission_engine.prompt_texts import (
+    ENGLISH_PERMISSION_PROMPT_TEXTS,
+    PermissionPromptTexts,
+)
 
 __all__ = [
+    "ENGLISH_PERMISSION_PROMPT_TEXTS",
     "PermissionEngine",
     "PermissionLevel",
+    "PermissionPromptTexts",
     "PermissionResult",
     "PermissionsSection",
     "ToolPermissionHost",

--- a/openjiuwen/harness/security/permission_engine/approve/ask_presentation.py
+++ b/openjiuwen/harness/security/permission_engine/approve/ask_presentation.py
@@ -4,6 +4,11 @@
 
 User-visible text is title + summary (+ remember hint). Internal rule ids stay
 out of the message body.
+
+The wording itself comes from a :class:`PermissionPromptTexts`, which the host
+supplies through ``ToolPermissionHost.prompt_texts``; the defaults reproduce the
+wording this module used to inline. Only the categorization and the composition
+live here.
 """
 
 from __future__ import annotations
@@ -12,6 +17,10 @@ from dataclasses import dataclass
 from typing import Any
 
 from openjiuwen.harness.security.permission_engine.models import PermissionResult
+from openjiuwen.harness.security.permission_engine.prompt_texts import (
+    DEFAULT_PERMISSION_PROMPT_TEXTS,
+    PermissionPromptTexts,
+)
 
 _SHELL_TOOLS = frozenset({"bash", "mcp_exec_command", "create_terminal", "powershell"})
 _FETCH_TOOLS = frozenset({"mcp_fetch_webpage", "fetch_webpage", "web_fetch_webpage"})
@@ -44,13 +53,6 @@ _PATH_ARG_KEYS = (
     "dir",
 )
 
-_FINDING_LABELS = {
-    "download_and_execute": "下载并执行",
-    "dynamic_or_encoded_execution": "动态或编码执行",
-    "shell_risky_structure": "含重定向或命令替换等结构",
-    "shell_too_complex": "命令结构过复杂",
-}
-
 _ESCALATING = frozenset({"MEDIUM", "HIGH", "CRITICAL"})
 
 
@@ -66,28 +68,31 @@ def build_permission_ask_presentation(
     tool_name: str,
     tool_args: dict[str, Any] | None,
     result: PermissionResult,
+    *,
+    texts: PermissionPromptTexts | None = None,
 ) -> PermissionAskPresentation:
+    copy = texts or DEFAULT_PERMISSION_PROMPT_TEXTS
     args = tool_args if isinstance(tool_args, dict) else {}
     name = (tool_name or "").strip() or "tool"
     category = _resolve_category(name, args, result)
 
     if category == "path":
-        title = "检测到受保护的文件路径访问"
+        title = copy.title_path
         summary = _path_summary(name, args, result)
     elif category == "network":
-        title = "检测到需确认的网络访问"
+        title = copy.title_network
         summary = _network_summary(args) or name
     elif category == "finding":
-        title = "检测到风险命令结构"
-        summary = _finding_summary(name, args, result)
+        title = copy.title_finding
+        summary = _finding_summary(name, args, result, copy)
     elif category == "shell":
-        title = "检测到需确认的命令执行"
+        title = copy.title_shell
         summary = _shell_summary(name, args)
     elif category == "tool":
-        title = "工具需要授权后才能使用"
-        summary = f"{name}（当前模式默认需确认）"
+        title = copy.title_tool
+        summary = copy.summary_tool.format(tool_name=name)
     else:
-        title = "操作需要授权"
+        title = copy.title_generic
         summary = name
 
     return PermissionAskPresentation(
@@ -209,14 +214,28 @@ def _shell_summary(tool_name: str, tool_args: dict[str, Any]) -> str:
     return tool_name
 
 
-def _finding_summary(tool_name: str, tool_args: dict[str, Any], result: PermissionResult) -> str:
-    label = "风险命令行为"
+def _finding_label(texts: PermissionPromptTexts, reason: str) -> str:
+    return {
+        "download_and_execute": texts.finding_download_and_execute,
+        "dynamic_or_encoded_execution": texts.finding_dynamic_or_encoded_execution,
+        "shell_risky_structure": texts.finding_shell_risky_structure,
+        "shell_too_complex": texts.finding_shell_too_complex,
+    }.get(reason, texts.finding_other)
+
+
+def _finding_summary(
+    tool_name: str,
+    tool_args: dict[str, Any],
+    result: PermissionResult,
+    texts: PermissionPromptTexts,
+) -> str:
+    label = texts.finding_other
     for item in getattr(result, "findings", None) or []:
         sev = str(getattr(item, "severity", "") or "").strip().upper()
         if sev not in _ESCALATING:
             continue
         reason = str(getattr(item, "reason", "") or "").strip()
-        label = _FINDING_LABELS.get(reason, label)
+        label = _finding_label(texts, reason)
         break
     cmd = _command_text(tool_args)
     if cmd:

--- a/openjiuwen/harness/security/permission_engine/host.py
+++ b/openjiuwen/harness/security/permission_engine/host.py
@@ -4,11 +4,12 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Literal
 
 from openjiuwen.harness.security.permission_engine.models import PermissionConfirmResponse, PermissionResult
+from openjiuwen.harness.security.permission_engine.prompt_texts import PermissionPromptTexts
 
 
 @dataclass(frozen=True)
@@ -108,6 +109,13 @@ class ToolPermissionHost:
 
     permission_scene_hook: PermissionSceneHook | None = None
     """宿主场景钩子（如数字分身）；见 :data:`PermissionSceneHook`。"""
+
+    prompt_texts: PermissionPromptTexts = field(default_factory=PermissionPromptTexts)
+    """内置 ASK 确认界面的文案模板；见 :class:`PermissionPromptTexts`。
+
+    默认值与该确认界面历来的输出逐字一致；面向其它语言用户的宿主传入自己的实例。
+    走 ``request_permission_confirmation`` 自行渲染确认界面的宿主用不到本字段。
+    """
 
 
 __all__ = [

--- a/openjiuwen/harness/security/permission_engine/prompt_texts.py
+++ b/openjiuwen/harness/security/permission_engine/prompt_texts.py
@@ -1,0 +1,223 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""内置工具权限确认提示的文案模板。
+
+``PermissionLevel.ASK`` 走内置确认时，用户看到的文字来自两处：
+:func:`~openjiuwen.harness.security.permission_engine.approve.ask_presentation.build_permission_ask_presentation`
+给出的分类标题与摘要，以及
+:class:`~openjiuwen.harness.rails.security.tool_security_rail.PermissionInterruptRail`
+拼出的「记住」提示。两处都从本模块的模板取词，模板由宿主经
+:attr:`~openjiuwen.harness.security.permission_engine.host.ToolPermissionHost.prompt_texts`
+注入：openjiuwen 是被嵌入的库，无从得知终端用户使用哪种语言，因此不替宿主挑选语言。
+
+除 :attr:`PermissionPromptTexts.remember_tool` 与 :attr:`PermissionPromptTexts.path_scope`
+外，各字段默认值与这两处历来输出逐字一致，未注入 ``prompt_texts`` 的宿主行为不变。那两个
+字段的措辞是照代码改正过的：历来的写法称放行限于本次的路径，而放行实际以工具为单位，
+详见这两个字段的说明。
+
+每个字段都是 :meth:`str.format` 模板，占位符见各字段说明；模板内的字面花括号需写成
+``{{`` / ``}}``。构造时按 :data:`_FIELD_PLACEHOLDERS` 逐字段试渲染一次：拼错占位符、
+用了别的字段才有的占位符、写错格式串、字段不是 ``str``，都在这里抛
+``DEEPAGENT_CONFIG_PARAM_ERROR``，并指出是哪个字段、错在哪里。抛错点在宿主构造文案的
+地方，即集成阶段，而不是某次 ASK 渲染时——护栏的 ``before_tool_call`` 只有抛
+``AbortError`` 或标记跳过才能拦下工具调用，其余异常被回调框架逐个吞掉并继续，渲染期
+抛错等于这次调用没有任何权限判定就直接放行。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+
+from openjiuwen.core.common.exception.codes import StatusCode
+from openjiuwen.core.common.exception.errors import build_error
+
+_FIELD_PLACEHOLDERS: dict[str, tuple[str, ...]] = {
+    "title_path": (),
+    "title_network": (),
+    "title_finding": (),
+    "title_shell": (),
+    "title_tool": (),
+    "title_generic": (),
+    "summary_tool": ("tool_name",),
+    "finding_download_and_execute": (),
+    "finding_dynamic_or_encoded_execution": (),
+    "finding_shell_risky_structure": (),
+    "finding_shell_too_complex": (),
+    "finding_other": (),
+    "remember_command": ("command_key",),
+    "remember_command_session_only": ("command_key",),
+    "remember_tool": ("tool_name", "path_scope"),
+    "path_scope": ("path_hint",),
+}
+"""每个字段各自允许的占位符——各不相同，故逐字段校验，不取并集。
+
+取并集会让 ``title_path="...{tool_name}..."`` 这类真错误蒙混过关：渲染标题时调用方
+一个占位符都不传。键集与 :class:`PermissionPromptTexts` 的字段一一对应，缺项会在本模块
+导入时构造默认实例就抛 :exc:`KeyError`。
+"""
+
+
+def _allowed_text(placeholders: tuple[str, ...]) -> str:
+    if not placeholders:
+        return "this field takes no placeholders"
+    return "allowed placeholders: " + ", ".join(f"{{{name}}}" for name in placeholders)
+
+
+@dataclass(frozen=True)
+class PermissionPromptTexts:
+    """内置 ASK 确认界面的文案模板集合。"""
+
+    title_path: str = "检测到受保护的文件路径访问"
+    """``path`` 类确认的标题；无占位符。工具访问了受 file_guard 保护的路径时使用。"""
+
+    title_network: str = "检测到需确认的网络访问"
+    """``network`` 类确认的标题；无占位符。"""
+
+    title_finding: str = "检测到风险命令结构"
+    """``finding`` 类确认的标题；无占位符。命中 MEDIUM 及以上的命令结构风险时使用。"""
+
+    title_shell: str = "检测到需确认的命令执行"
+    """``shell`` 类确认的标题；无占位符。"""
+
+    title_tool: str = "工具需要授权后才能使用"
+    """``tool`` 类确认的标题；无占位符。命中权限规则、但不属于以上各类时使用。"""
+
+    title_generic: str = "操作需要授权"
+    """``generic`` 类确认的标题；无占位符。未命中任何规则时的兜底。"""
+
+    summary_tool: str = "{tool_name}（当前模式默认需确认）"
+    """``tool`` 类确认的摘要；占位符 ``{tool_name}``。其余各类的摘要是路径、URL 或命令
+    原文，不经模板。"""
+
+    finding_download_and_execute: str = "下载并执行"
+    """``download_and_execute`` 风险的名称；无占位符。作为 ``finding`` 类摘要的前缀。"""
+
+    finding_dynamic_or_encoded_execution: str = "动态或编码执行"
+    """``dynamic_or_encoded_execution`` 风险的名称；无占位符。"""
+
+    finding_shell_risky_structure: str = "含重定向或命令替换等结构"
+    """``shell_risky_structure`` 风险的名称；无占位符。"""
+
+    finding_shell_too_complex: str = "命令结构过复杂"
+    """``shell_too_complex`` 风险的名称；无占位符。"""
+
+    finding_other: str = "风险命令行为"
+    """其余风险的名称；无占位符。风险原因不在以上四项时使用。"""
+
+    remember_command: str = (
+        "\n\n> 选择「会话内记住」可在本会话内自动放行 ``{command_key}`` 类调用；"
+        "选择「永久记住」可将此规则写回磁盘，所有会话均自动放行。"
+    )
+    """shell 类工具的「记住」提示；占位符 ``{command_key}``。子命令可作为持久化规则时使用。"""
+
+    remember_command_session_only: str = (
+        "\n\n> 选择「会话内记住」可在本会话内自动放行 ``{command_key}`` 类调用。"
+    )
+    """shell 类工具的「记住」提示；占位符 ``{command_key}``。命令结构过于复杂、无法写成持久化规则时使用。"""
+
+    remember_tool: str = (
+        "\n\n> 选择「会话内记住」可在本会话内自动放行 ``{tool_name}`` 的所有调用{path_scope}；"
+        "选择「永久记住」可将此规则写回磁盘，所有会话均自动放行。"
+    )
+    """其余工具的「记住」提示；占位符 ``{tool_name}``、``{path_scope}``。
+
+    措辞是「``{tool_name}`` 的所有调用」而不是某个路径下的调用：放行以工具为单位，
+    与本次调用的路径无关，理由见 :attr:`path_scope`。
+    """
+
+    path_scope: str = "，而不只是本次针对 ``{path_hint}`` 的调用"
+    """``remember_tool`` 末尾附加的片段；占位符 ``{path_hint}``。工具入参无路径时该片段为空串。
+
+    该片段点出本次请求涉及的路径，并说明放行**不**以它为界；覆盖本字段的宿主同样不应
+    写成限定路径的措辞，因为两种「记住」都不按路径生效：
+
+    - 会话内记住的键来自 ``PermissionInterruptRail._get_auto_confirm_key``，它只为
+      shell 类工具拼上子命令，其余工具直接返回工具名，写进会话的因此就是工具名本身，
+      此后该工具的每一次 ASK 都命中它；
+    - 永久记住经 ``merge_permission_allow_rule_into_permissions`` 落盘，它先滤掉
+      ``match_type`` 为 ``path`` 的建议（路径只写 file_guard），非 shell 工具再无其它
+      建议时写的是 ``permissions.tools[<工具名>] = "allow"``，同样是整个工具。
+    """
+
+    def __post_init__(self) -> None:
+        """逐字段试渲染一次，把宿主的模板错误挡在构造处。"""
+        for spec in fields(self):
+            placeholders = _FIELD_PLACEHOLDERS[spec.name]
+            template = getattr(self, spec.name)
+            if not isinstance(template, str):
+                raise build_error(
+                    StatusCode.DEEPAGENT_CONFIG_PARAM_ERROR,
+                    error_msg=(
+                        f"PermissionPromptTexts.{spec.name} must be a str.format template, "
+                        f"got {type(template).__name__}"
+                    ),
+                )
+            try:
+                template.format(**{name: "" for name in placeholders})
+            except KeyError as exc:
+                raise build_error(
+                    StatusCode.DEEPAGENT_CONFIG_PARAM_ERROR,
+                    error_msg=(
+                        f"PermissionPromptTexts.{spec.name} uses unknown placeholder "
+                        f"{{{exc.args[0]}}}; {_allowed_text(placeholders)}"
+                    ),
+                    cause=exc,
+                ) from exc
+            except (IndexError, ValueError) as exc:
+                raise build_error(
+                    StatusCode.DEEPAGENT_CONFIG_PARAM_ERROR,
+                    error_msg=(
+                        f"PermissionPromptTexts.{spec.name} is not a valid str.format "
+                        f"template ({type(exc).__name__}: {exc}); "
+                        f"{_allowed_text(placeholders)}. A literal brace must be doubled "
+                        f"as {{{{ or }}}}"
+                    ),
+                    cause=exc,
+                ) from exc
+
+
+DEFAULT_PERMISSION_PROMPT_TEXTS = PermissionPromptTexts()
+"""内置默认文案；``ToolPermissionHost`` 未注入时以及调用方不传 ``texts`` 时使用。"""
+
+
+ENGLISH_PERMISSION_PROMPT_TEXTS = PermissionPromptTexts(
+    title_path="Protected file path access detected",
+    title_network="Network access needing confirmation detected",
+    title_finding="Risky command structure detected",
+    title_shell="Command execution needing confirmation detected",
+    title_tool="This tool needs approval before it can be used",
+    title_generic="This operation needs approval",
+    summary_tool="{tool_name} (needs confirmation by default in the current mode)",
+    finding_download_and_execute="downloads and executes",
+    finding_dynamic_or_encoded_execution="dynamic or encoded execution",
+    finding_shell_risky_structure="contains redirection, command substitution or similar",
+    finding_shell_too_complex="command structure is too complex",
+    finding_other="risky command behaviour",
+    remember_command=(
+        "\n\n> Remembering this for the session allows ``{command_key}`` calls "
+        "automatically until the session ends; remembering it permanently writes "
+        "the rule to disk, so every session allows them automatically."
+    ),
+    remember_command_session_only=(
+        "\n\n> Remembering this for the session allows ``{command_key}`` calls "
+        "automatically until the session ends."
+    ),
+    remember_tool=(
+        "\n\n> Remembering this for the session allows every ``{tool_name}`` call "
+        "automatically until the session ends{path_scope}; remembering it permanently "
+        "writes the rule to disk, so every session allows them automatically."
+    ),
+    path_scope=", not only this one on ``{path_hint}``",
+)
+"""与默认中文文案对应的英文文案，供英文部署直接传给 ``ToolPermissionHost``。
+
+仅是一份现成的数据，不引入语言选择：仍由宿主决定用哪一份。「记住」提示的措辞刻意描述
+**选项的效果**而不引用选项名，因为按钮文案由宿主自己渲染，护栏无从得知它们叫什么。
+"""
+
+
+__all__ = [
+    "DEFAULT_PERMISSION_PROMPT_TEXTS",
+    "ENGLISH_PERMISSION_PROMPT_TEXTS",
+    "PermissionPromptTexts",
+]

--- a/tests/unit_tests/harness/security/test_permission_prompt_texts.py
+++ b/tests/unit_tests/harness/security/test_permission_prompt_texts.py
@@ -1,0 +1,440 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""``PermissionInterruptRail`` ASK 确认界面的文案来源。
+
+三组断言：默认文案与该确认界面历来的输出逐字一致（升级不改变既有部署所见），
+``remember_tool`` / ``path_scope`` 除外——那两段措辞照代码改正，另有一条断言给出改正的
+依据；宿主经 ``ToolPermissionHost.prompt_texts`` 注入后，标题、摘要与「记住」提示都改用
+宿主文案，不残留内置措辞；以及模板校验发生在构造时——宿主写错的模板到不了任何一次工具
+调用。
+
+用户可见的文字分处两地：分类标题与摘要来自
+``permission_engine.approve.ask_presentation``，「记住」提示由护栏拼出。标题不进正文，
+只经 ``_build_interrupt_metadata`` 的 ``ask_title`` 交给宿主，故标题断言走元数据。
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import fields, replace
+from types import SimpleNamespace
+
+import pytest
+
+from openjiuwen.core.common.exception.codes import StatusCode
+from openjiuwen.core.common.exception.errors import BaseError
+from openjiuwen.core.foundation.llm.schema.tool_call import ToolCall
+from openjiuwen.harness.rails.security.tool_security_rail import PermissionInterruptRail
+from openjiuwen.harness.security.permission_engine.core import build_permission_interrupt_rail
+from openjiuwen.harness.security.permission_engine.host import ToolPermissionHost
+from openjiuwen.harness.security.permission_engine.models import PermissionLevel, PermissionResult
+from openjiuwen.harness.security.permission_engine.prompt_texts import (
+    _FIELD_PLACEHOLDERS,
+    DEFAULT_PERMISSION_PROMPT_TEXTS,
+    ENGLISH_PERMISSION_PROMPT_TEXTS,
+    PermissionPromptTexts,
+)
+
+CJK_RANGE = range(0x4E00, 0xA000)
+
+
+def _tool_call(name: str, arguments: dict) -> ToolCall:
+    return ToolCall(id="call-1", type="function", name=name, arguments=json.dumps(arguments))
+
+
+def _ask(**kwargs) -> PermissionResult:
+    findings = kwargs.pop("findings", None)
+    result = PermissionResult(permission=PermissionLevel.ASK, **kwargs)
+    if findings is not None:
+        # ``PermissionResult`` declares no ``findings`` field; the ``finding`` category is
+        # driven by an attribute a producer sets from outside, as it is in
+        # ``test_ask_presentation.py``.
+        result.findings = findings  # type: ignore[attr-defined]
+    return result
+
+
+def _rail(texts: PermissionPromptTexts | None = None) -> PermissionInterruptRail:
+    host = ToolPermissionHost() if texts is None else ToolPermissionHost(prompt_texts=texts)
+    return PermissionInterruptRail(config={"enabled": True}, host=host)
+
+
+def _finding(reason: str, severity: str = "MEDIUM") -> list:
+    return [SimpleNamespace(severity=severity, reason=reason)]
+
+
+# --- one case per ASK category, plus the hint branches ------------------------
+
+_PATH_CALL = ("write_file", {"file_path": "/data/x.txt"})
+_PATH_RESULT = {"matched_rule": "file_guard:defaults", "external_paths": ["/data/x.txt"]}
+_NETWORK_CALL = ("mcp_fetch_webpage", {"url": "https://evil.test/a"})
+_NETWORK_RESULT = {"matched_rule": "tools.mcp_fetch_webpage"}
+_FINDING_CALL = ("bash", {"command": "echo hi > out.txt"})
+_FINDING_RESULT = {
+    "matched_rule": "tiered_policy:defaults.*",
+    "findings": _finding("shell_risky_structure"),
+}
+_SHELL_CALL = ("bash", {"command": "ls -la"})
+_SHELL_RESULT = {"matched_rule": "tiered_policy:defaults.*"}
+_TOOL_CALL = ("todo_list", {})
+_TOOL_RESULT = {"matched_rule": "tiered_policy:defaults.*"}
+_GENERIC_CALL = ("noop", {})
+_GENERIC_RESULT: dict = {"matched_rule": None}
+
+_CATEGORIES = [
+    pytest.param(_PATH_CALL, _PATH_RESULT, "path", id="path"),
+    pytest.param(_NETWORK_CALL, _NETWORK_RESULT, "network", id="network"),
+    pytest.param(_FINDING_CALL, _FINDING_RESULT, "finding", id="finding"),
+    pytest.param(_SHELL_CALL, _SHELL_RESULT, "shell", id="shell"),
+    pytest.param(_TOOL_CALL, _TOOL_RESULT, "tool", id="tool"),
+    pytest.param(_GENERIC_CALL, _GENERIC_RESULT, "generic", id="generic"),
+]
+
+
+# =============================================================================
+# 1. 默认文案与历来输出逐字一致（「记住」提示的措辞除外）
+# =============================================================================
+
+def test_default_path_body_scopes_the_remember_hint_to_the_tool() -> None:
+    """默认文案下 path 类的完整正文（摘要 + 「记住」提示）。
+
+    摘要逐字不变；「记住」提示的措辞则与历来输出不同：历来写作「``write_file`` 类工具在
+    ``/data/x.txt`` 下的调用」，把放行说成限于提示里那个路径。放行并不按路径生效，依据见
+    ``test_the_session_remember_is_keyed_on_the_bare_tool_name``，故改写为「所有调用」，
+    并让 ``path_scope`` 明说本次的路径不是界限。
+    """
+    message = _rail()._build_message(_tool_call(*_PATH_CALL), _ask(**_PATH_RESULT))
+
+    assert message == (
+        "write /data/x.txt\n\n\n"
+        "> 选择「会话内记住」可在本会话内自动放行 ``write_file`` 的所有调用，"
+        "而不只是本次针对 ``/data/x.txt`` 的调用；"
+        "选择「永久记住」可将此规则写回磁盘，所有会话均自动放行。\n"
+    )
+
+
+def test_the_session_remember_is_keyed_on_the_bare_tool_name() -> None:
+    """「会话内记住」按工具名生效，与提示里的路径无关——上一条措辞改正的依据。
+
+    ``_get_auto_confirm_key`` 只为 shell 类工具拼上子命令，其余工具直接返回工具名，
+    而会话放行的写入与命中都用这个键。于是在某个路径上按下「会话内记住」，此后同一
+    工具在任何路径上的 ASK 都被自动放行。
+    """
+    rail = _rail()
+    asked = rail._get_auto_confirm_key(_tool_call("write_file", {"file_path": "/data/x.txt"}))
+    later = rail._get_auto_confirm_key(_tool_call("write_file", {"file_path": "/etc/hosts"}))
+
+    assert asked == "write_file"
+    assert later == asked
+    # 在 /data/x.txt 上记住，随后 /etc/hosts 的调用命中同一条会话放行。
+    assert rail._is_auto_confirmed({asked: True}, later) is True
+
+
+def test_default_shell_hint_names_the_subcommand() -> None:
+    """可归纳为持久化规则的简单命令，提示里给出 ``<工具>:<子命令>`` 形式的键。"""
+    message = _rail()._build_message(_tool_call(*_SHELL_CALL), _ask(**_SHELL_RESULT))
+
+    assert message == (
+        "bash: ls -la\n\n\n"
+        "> 选择「会话内记住」可在本会话内自动放行 ``bash:ls -la`` 类调用；"
+        "选择「永久记住」可将此规则写回磁盘，所有会话均自动放行。\n"
+    )
+
+
+def test_default_body_has_no_hint_for_a_compound_command() -> None:
+    """结构复杂、无法归纳为规则的命令没有可记住的键，正文止于摘要。"""
+    message = _rail()._build_message(
+        _tool_call("bash", {"command": "ls -la && rm -rf /tmp/x"}), _ask(**_SHELL_RESULT)
+    )
+
+    assert message == "bash: ls -la && rm -rf /tmp/x\n"
+
+
+def test_default_tool_summary_keeps_the_historical_parenthetical() -> None:
+    """``tool`` 类摘要是唯一带模板的摘要，其默认值应逐字不变。"""
+    message = _rail()._build_message(_tool_call(*_TOOL_CALL), _ask(**_TOOL_RESULT))
+
+    assert message.startswith("todo_list（当前模式默认需确认）\n")
+
+
+@pytest.mark.parametrize(
+    ("reason", "expected_label"),
+    [
+        pytest.param("download_and_execute", "下载并执行", id="download_and_execute"),
+        pytest.param("dynamic_or_encoded_execution", "动态或编码执行", id="dynamic_or_encoded"),
+        pytest.param("shell_risky_structure", "含重定向或命令替换等结构", id="risky_structure"),
+        pytest.param("shell_too_complex", "命令结构过复杂", id="too_complex"),
+        pytest.param("brand_new_reason", "风险命令行为", id="unmapped_reason_falls_back"),
+    ],
+)
+def test_default_finding_labels_are_unchanged(reason: str, expected_label: str) -> None:
+    """五个风险名称（四个已知 + 兜底）的默认值应逐字不变。"""
+    message = _rail()._build_message(
+        _tool_call("bash", {"command": "echo hi > out.txt"}),
+        _ask(matched_rule="tiered_policy:defaults.*", findings=_finding(reason, "HIGH")),
+    )
+
+    assert message.startswith(f"{expected_label}: echo hi > out.txt")
+
+
+@pytest.mark.parametrize(
+    ("call", "result_kwargs", "category", "expected_title"),
+    [
+        pytest.param(_PATH_CALL, _PATH_RESULT, "path", "检测到受保护的文件路径访问", id="path"),
+        pytest.param(_NETWORK_CALL, _NETWORK_RESULT, "network", "检测到需确认的网络访问", id="network"),
+        pytest.param(_FINDING_CALL, _FINDING_RESULT, "finding", "检测到风险命令结构", id="finding"),
+        pytest.param(_SHELL_CALL, _SHELL_RESULT, "shell", "检测到需确认的命令执行", id="shell"),
+        pytest.param(_TOOL_CALL, _TOOL_RESULT, "tool", "工具需要授权后才能使用", id="tool"),
+        pytest.param(_GENERIC_CALL, _GENERIC_RESULT, "generic", "操作需要授权", id="generic"),
+    ],
+)
+def test_default_titles_are_unchanged(
+    call: tuple, result_kwargs: dict, category: str, expected_title: str
+) -> None:
+    """六个分类标题的默认值应逐字不变；标题只经中断元数据交给宿主。"""
+    metadata = _rail()._build_interrupt_metadata(_tool_call(*call), _ask(**result_kwargs))
+
+    assert metadata["ask_category"] == category
+    assert metadata["ask_title"] == expected_title
+
+
+# =============================================================================
+# 2. 宿主注入后每一段都改用宿主文案
+# =============================================================================
+
+def _sentinel_texts() -> PermissionPromptTexts:
+    return PermissionPromptTexts(
+        title_path="TITLE-PATH",
+        title_network="TITLE-NETWORK",
+        title_finding="TITLE-FINDING",
+        title_shell="TITLE-SHELL",
+        title_tool="TITLE-TOOL",
+        title_generic="TITLE-GENERIC",
+        summary_tool="SUMMARY-TOOL {tool_name}",
+        finding_download_and_execute="FINDING-DOWNLOAD",
+        finding_dynamic_or_encoded_execution="FINDING-DYNAMIC",
+        finding_shell_risky_structure="FINDING-RISKY",
+        finding_shell_too_complex="FINDING-COMPLEX",
+        finding_other="FINDING-OTHER",
+        remember_command="\n\nREMEMBER-COMMAND {command_key}",
+        remember_command_session_only="\n\nREMEMBER-COMMAND-SESSION {command_key}",
+        remember_tool="\n\nREMEMBER-TOOL {tool_name}{path_scope}",
+        path_scope=" SCOPE {path_hint}",
+    )
+
+
+@pytest.mark.parametrize(("call", "result_kwargs", "category"), _CATEGORIES)
+def test_host_titles_replace_the_builtin_titles(
+    call: tuple, result_kwargs: dict, category: str
+) -> None:
+    """六个分类的标题都取自宿主，元数据里不残留内置措辞。"""
+    metadata = _rail(_sentinel_texts())._build_interrupt_metadata(
+        _tool_call(*call), _ask(**result_kwargs)
+    )
+
+    assert metadata["ask_title"] == f"TITLE-{category.upper()}"
+    assert not any(ord(ch) in CJK_RANGE for ch in metadata["ask_title"])
+
+
+@pytest.mark.parametrize(
+    ("reason", "expected_label"),
+    [
+        pytest.param("download_and_execute", "FINDING-DOWNLOAD", id="download_and_execute"),
+        pytest.param("dynamic_or_encoded_execution", "FINDING-DYNAMIC", id="dynamic_or_encoded"),
+        pytest.param("shell_risky_structure", "FINDING-RISKY", id="risky_structure"),
+        pytest.param("shell_too_complex", "FINDING-COMPLEX", id="too_complex"),
+        pytest.param("brand_new_reason", "FINDING-OTHER", id="unmapped_reason_falls_back"),
+    ],
+)
+def test_host_finding_labels_replace_the_builtin_labels(
+    reason: str, expected_label: str
+) -> None:
+    """五个风险名称都取自宿主，含未登记原因的兜底。"""
+    message = _rail(_sentinel_texts())._build_message(
+        _tool_call("bash", {"command": "echo hi > out.txt"}),
+        _ask(matched_rule="tiered_policy:defaults.*", findings=_finding(reason, "HIGH")),
+    )
+
+    assert message.startswith(f"{expected_label}: echo hi > out.txt")
+    assert not any(ord(ch) in CJK_RANGE for ch in message)
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "tool_args", "expected_tail"),
+    [
+        pytest.param("write_file", {"file_path": "/data/x.txt"},
+                     "REMEMBER-TOOL write_file SCOPE /data/x.txt", id="path_tool"),
+        pytest.param("web_search", {"query": "openjiuwen"},
+                     "REMEMBER-TOOL web_search", id="tool_without_path"),
+        pytest.param("bash", {"command": "ls -la"},
+                     "REMEMBER-COMMAND bash:ls -la", id="simple_command"),
+    ],
+)
+def test_host_texts_replace_the_remember_hint(
+    tool_name: str, tool_args: dict, expected_tail: str
+) -> None:
+    """三条可达的「记住」提示都取自宿主，正文不残留中文内置措辞。"""
+    message = _rail(_sentinel_texts())._build_message(
+        _tool_call(tool_name, tool_args), _ask(matched_rule="tools.any"),
+    )
+
+    assert message.rstrip("\n").endswith(expected_tail)
+    assert not any(ord(ch) in CJK_RANGE for ch in message)
+
+
+def test_host_summary_replaces_the_builtin_parenthetical() -> None:
+    """``tool`` 类摘要取自宿主模板。"""
+    message = _rail(_sentinel_texts())._build_message(
+        _tool_call(*_TOOL_CALL), _ask(**_TOOL_RESULT)
+    )
+
+    assert message.startswith("SUMMARY-TOOL todo_list\n")
+    assert not any(ord(ch) in CJK_RANGE for ch in message)
+
+
+def test_factory_carries_host_texts_into_the_rail() -> None:
+    """``build_permission_interrupt_rail`` 应把宿主文案透传给护栏。"""
+    rail = build_permission_interrupt_rail(
+        permissions={"enabled": True},
+        host=ToolPermissionHost(prompt_texts=_sentinel_texts()),
+    )
+
+    assert rail is not None
+    metadata = rail._build_interrupt_metadata(_tool_call(*_TOOL_CALL), _ask(**_TOOL_RESULT))
+    assert metadata["ask_title"] == "TITLE-TOOL"
+
+
+def test_default_host_texts_are_the_builtin_defaults() -> None:
+    """未注入时 ``ToolPermissionHost`` 携带内置默认文案。"""
+    assert ToolPermissionHost().prompt_texts == PermissionPromptTexts()
+    assert DEFAULT_PERMISSION_PROMPT_TEXTS == PermissionPromptTexts()
+
+
+@pytest.mark.parametrize(("call", "result_kwargs", "category"), _CATEGORIES)
+def test_english_texts_render_without_any_chinese(
+    call: tuple, result_kwargs: dict, category: str
+) -> None:
+    """传入随附的英文文案后，任一分类的正文与元数据都不含中文。"""
+    rail = _rail(ENGLISH_PERMISSION_PROMPT_TEXTS)
+    tool_call = _tool_call(*call)
+    result = _ask(**result_kwargs)
+
+    message = rail._build_message(tool_call, result)
+    metadata = rail._build_interrupt_metadata(tool_call, result)
+
+    assert not any(ord(ch) in CJK_RANGE for ch in message)
+    assert not any(ord(ch) in CJK_RANGE for ch in metadata["ask_title"])
+    assert not any(ord(ch) in CJK_RANGE for ch in metadata["ask_summary"])
+
+
+def test_english_texts_are_not_the_default() -> None:
+    """英文文案只是随附数据；不注入时不会自动生效。"""
+    assert ToolPermissionHost().prompt_texts != ENGLISH_PERMISSION_PROMPT_TEXTS
+
+
+def test_a_valid_partial_override_still_renders() -> None:
+    """合法的部分覆盖照旧渲染，未覆盖的字段仍取内置默认值。"""
+    rail = _rail(PermissionPromptTexts(title_tool="Tool needs your approval"))
+    tool_call = _tool_call(*_TOOL_CALL)
+    result = _ask(**_TOOL_RESULT)
+
+    assert rail._build_interrupt_metadata(tool_call, result)["ask_title"] == (
+        "Tool needs your approval"
+    )
+    assert rail._build_message(tool_call, result).startswith("todo_list（当前模式默认需确认）")
+
+
+# =============================================================================
+# 3. 模板校验发生在构造时
+# =============================================================================
+
+def test_every_field_declares_its_own_placeholders() -> None:
+    """占位符表与字段一一对应：新增字段若漏登记，构造默认实例即报错，不会漏过校验。"""
+    assert set(_FIELD_PLACEHOLDERS) == {spec.name for spec in fields(PermissionPromptTexts)}
+
+
+@pytest.mark.parametrize(
+    ("field_name", "template", "bad_placeholder"),
+    [
+        pytest.param("summary_tool", "{tool} needs approval", "tool", id="misspelt"),
+        pytest.param("title_tool", "{tool_name} needs approval", "tool_name",
+                     id="placeholder_in_a_field_that_takes_none"),
+        pytest.param("remember_tool", "> {tool_name} under {path_hint}", "path_hint",
+                     id="borrowed_from_path_scope"),
+        pytest.param("path_scope", " under {tool_name}", "tool_name",
+                     id="borrowed_from_remember_tool"),
+    ],
+)
+def test_an_unknown_placeholder_raises_at_construction(
+    field_name: str, template: str, bad_placeholder: str
+) -> None:
+    """宿主写错占位符在构造处就报错，且报错点名字段与那个占位符。
+
+    每个字段只用自己那一份占位符校验，所以「别的字段有、本字段没有」同样算写错——
+    取并集会放过 ``title_tool`` 里的 ``{tool_name}``，而渲染标题时调用方一个占位符
+    都不传。
+    """
+    with pytest.raises(BaseError) as excinfo:
+        PermissionPromptTexts(**{field_name: template})
+
+    assert excinfo.value.status is StatusCode.DEEPAGENT_CONFIG_PARAM_ERROR
+    assert f"PermissionPromptTexts.{field_name}" in str(excinfo.value)
+    assert f"{{{bad_placeholder}}}" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    ("field_name", "template"),
+    [
+        pytest.param("summary_tool", "{tool_name", id="unclosed_brace"),
+        pytest.param("path_scope", " under {}", id="positional_placeholder"),
+        pytest.param("title_path", "50{}% risk", id="positional_in_a_field_that_takes_none"),
+        pytest.param("remember_command", "key {command_key:d}", id="bad_format_spec"),
+    ],
+)
+def test_a_template_that_cannot_render_raises_at_construction(
+    field_name: str, template: str
+) -> None:
+    """占位符拼写之外，格式串本身不合法也在构造处拦下，报错点名字段。"""
+    with pytest.raises(BaseError) as excinfo:
+        PermissionPromptTexts(**{field_name: template})
+
+    assert excinfo.value.status is StatusCode.DEEPAGENT_CONFIG_PARAM_ERROR
+    assert f"PermissionPromptTexts.{field_name}" in str(excinfo.value)
+
+
+def test_a_non_string_template_raises_at_construction() -> None:
+    """字段不是 ``str`` 时同样在构造处报错，而不是渲染时抛 ``AttributeError``。"""
+    with pytest.raises(BaseError) as excinfo:
+        PermissionPromptTexts(title_tool=None)  # type: ignore[arg-type]
+
+    assert excinfo.value.status is StatusCode.DEEPAGENT_CONFIG_PARAM_ERROR
+    assert "PermissionPromptTexts.title_tool" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "texts",
+    [
+        pytest.param(PermissionPromptTexts(), id="builtin_defaults"),
+        pytest.param(ENGLISH_PERMISSION_PROMPT_TEXTS, id="bundled_english"),
+    ],
+)
+def test_shipped_texts_pass_their_own_validation(texts: PermissionPromptTexts) -> None:
+    """随本仓库发布的两份文案自身通过校验——逐字段再各渲染一次，与构造时同一条路径。"""
+    for spec in fields(texts):
+        placeholders = _FIELD_PLACEHOLDERS[spec.name]
+        getattr(texts, spec.name).format(**{name: "" for name in placeholders})
+
+
+def test_a_broken_override_never_reaches_a_rail() -> None:
+    """错模板到不了工具调用：文案对象都构造不出来，护栏无从携带它。
+
+    这条是本文件里唯一有安全含义的断言。护栏的 ``before_tool_call`` 只有抛
+    ``AbortError`` 或标记跳过才拦得住工具调用；渲染时抛出的其它异常被回调框架逐个
+    吞掉、链继续，那一次调用于是没有任何权限判定就执行。把校验放到构造处，宿主的
+    模板错误便成了集成期的启动失败。
+    """
+    with pytest.raises(BaseError):
+        ToolPermissionHost(prompt_texts=PermissionPromptTexts(summary_tool="{tool}"))
+
+    # ``dataclasses.replace`` 也走 ``__init__``，改坏既有实例同样在这里挡下。
+    with pytest.raises(BaseError):
+        replace(PermissionPromptTexts(), summary_tool="{tool}")


### PR DESCRIPTION
Paired: [GitHub #970](https://github.com/openJiuwen-ai/agent-core/pull/970) ↔ [GitCode !2540](https://gitcode.com/openJiuwen/agent-core/merge_requests/2540)

**What type of PR is this?**

/kind bug

**Which issue(s) this PR fixes**:

Fixes #969

That report also records two further findings which this PR deliberately does **not**
fix, so neither is closed by this merge:

- an unreachable branch in `_build_always_allow_hint` — repairing it changes behaviour and
  belongs in its own request (see *One template still cannot render today* below);
- a security fail-open in the same code path, where any exception out of the rail's
  `before_tool_call` lets the guarded tool run unconfirmed. It is not caused by the
  hardcoded wording and warranted its own report rather than being folded into either this
  request or the wording issue; it is recorded there only because it constrains where a
  wording seam may validate its input. It now has that report — #971, fixed by
  `fix(security): deny the tool call when the permission gate cannot decide`, filed
  alongside this one — and the two are reconciled under *Checking at construction* below.
  This change does not repair it — it only makes sure the new seam cannot become another
  way into it.

Related but not fixed here:

- #831 reports four other defects in the permission ASK path. None concerns the wording.
- #963 reports that a sub-agent's tool calls run ungated because `create_subagent`
  forwards neither `permissions` nor `permission_host`; it is fixed by
  `fix(harness): gate sub-agent tool calls with the parent's permissions`, filed
  alongside this one. That change edits `deep_agent.py` and one test file, and no
  render site, so it shares no file with this one.

**Rebased onto the merged permission-engine restructure.** This request was first written
against `dce36fc8`, before #866 / PR #792 merged as `20e35736`. That restructure moved and
rewrote every render site this touches, so the change has been re-expressed against the
new layout rather than replayed onto it. What survived, what did not, and what the
restructure added to the problem are set out under *What #792 changed* below.

**What does this PR do / why do we need it**:

The text a person reads before deciding whether a tool may run is assembled from Chinese
string literals compiled into the library. openjiuwen is embedded as a library, so that
wording is what reaches the end user, on whatever channel the host serves them, in
Chinese, whatever language the deployment is otherwise configured for. Nothing in
`openjiuwen.harness` lets a host prevent that: there is no message catalogue,
`AGENT_PROMPT_LANGUAGE` selects the system prompt sent to the model rather than text a
person reads, and `agent_teams.i18n` sits on the wrong side of the dependency. The issue
above has the reproduction, the rendered output and the full account of why each apparent
workaround is not one.

Those literals are also the whole of the permission rail's user-facing text — the issue
has the census — so closing this seam closes the language gap for the rail rather than
part of it.

### What #792 changed, and what it did not

The restructure did not close the gap. On `20e35736`:

- `permission_engine/approve/ask_presentation.py` holds twelve lines containing CJK, and
  **every one of them is a user-visible literal**: six category titles, the parenthetical
  in the `tool` category's summary, four risk names in `_FINDING_LABELS`, and the
  fallback risk name in `_finding_summary`.
- `rails/security/tool_security_rail.py` still holds the four hint literals in
  `_build_always_allow_hint`, untouched.
- A repository search of `openjiuwen/harness/security` for `prompt_texts`, `PromptTexts`,
  `i18n`, `locale` or `language_pack` returns no file.

It also made the problem slightly larger in two ways. It introduced six category titles
where there was one header, so there is more hardcoded prose than before; and it added
`_build_interrupt_metadata`, which hands `ask_title` and `ask_summary` to the host as
structured fields. A host that renders the interrupt itself now receives the Chinese
title as a field of its own, not only as part of a body.

The restructure is not released. No tag contains `20e35736`, and no released tag contains
`ask_presentation.py`; every release from `v0.1.11.post1` to `v0.1.17.post1` still carries
the pre-restructure `_build_message`. The set of affected releases is therefore exactly
what it was — the restructure changed what a fix must be written against, not who is
affected.

### The change

The wording comes from `PermissionPromptTexts`, a frozen dataclass of `str.format`
templates carried on `ToolPermissionHost` — which is already how this module receives
everything else it cannot decide for itself (permission snapshots, persistence, workspace
resolution, host-side confirmation, scene hooks).

```python
from openjiuwen.harness.security import (
    ENGLISH_PERMISSION_PROMPT_TEXTS,
    PermissionPromptTexts,
    ToolPermissionHost,
)

host = ToolPermissionHost(prompt_texts=ENGLISH_PERMISSION_PROMPT_TEXTS)

host = ToolPermissionHost(
    prompt_texts=PermissionPromptTexts(
        title_tool="This tool needs your approval",
        summary_tool="{tool_name} (confirmation required)",
    ),
)
```

openjiuwen picks **no** language on the host's behalf. That is deliberate: only the host
knows what language its users are served in, and deciding here would also lock out hosts
whose users fall outside the project's `cn`/`en` pair. Each field is independently
overridable, so a host that only wants a different title supplies only a title.

### One seam, two render sites — and one file deliberately left alone

After the restructure the user-visible text is produced in two places, and both had to be
reached from the same host field or the two halves of one prompt could disagree:

- `permission_engine/approve/ask_presentation.py` produces the category, title and
  summary. `build_permission_ask_presentation` takes an optional keyword-only
  `texts=`, defaulting to the built-in set, so its existing callers keep working with the
  three positional arguments they pass today — the rail itself, and upstream's
  `test_ask_presentation.py` and `test_command_canonicalize.py`, all of which pass
  unmodified.
- `PermissionInterruptRail._build_always_allow_hint` produces the remember hint, and reads
  `self._host.prompt_texts` directly.

The rail threads the host's texts into `build_permission_ask_presentation` from **both**
its call sites — `_build_message` and `_build_interrupt_metadata`. Passing them from only
the first would give a host an English body under a Chinese `ask_title`, which is a worse
failure than the one being fixed because it looks deliberate.

`permission_engine/approve/persist_rule_merge.py` is **not** touched, although it holds
thirteen lines containing CJK — more than `ask_presentation.py` does. Every one of them is
a module, function or field docstring, or an inline comment: `"""解析落盘用的 agent 配置
文件路径。"""`, `"""写入 command 类 approval_overrides；path 类忽略..."""`, and so on. None
of that text is ever rendered to a user; it is developer documentation, and it is in the
same language as the docstrings in `host.py` and `models.py` beside it. Translating the
repository's internal documentation is a different project from giving a host a seam for
what its users read, and folding it in would put that translation inside a change whose
subject is what users see. The same reasoning leaves the nine CJK docstrings and comments
in `tool_security_rail.py` alone: only the four literals that render are touched.

### The template set, and why it is shaped this way

The set has been re-derived twice as the render sites moved. `header`, `confirm_instruction`, `arguments` and `external_paths` no longer have a render site. `matched_rule` was deliberately removed from the body, and `test_ask_presentation.py` asserts its absence. The four hint templates survive, two of them reworded, as described below. They are joined by the `tool` and `generic` titles, the `tool` category's summary, and five finding risk names.

`1c22b9f2`, `fix(guardrail): permission engine 统一收编命令行安全检查`, and `13d226d9` then rewrote the title path, which is why the remaining fields are shaped as they are. A title no longer names its category. It names the risk that triggered the confirmation, inside one frame, `title_risk_detected`. The name is the first of these that applies: the matched built-in rule's entry in `rule_risk_labels`, `risk_interpreter_sink`, `finding_shell_too_complex`, a finding name, and last the confirmation's own category (`risk_path`, `risk_network`, `risk_finding`, `risk_shell`). Where nothing names a risk the whole title is `title_tool` or `title_generic`, as before.

`rule_risk_labels` is the one field that is a table rather than a template, and deliberately so. The seventeen built-in rule ids it names are a set that grows between releases. A field per rule would make every added rule a change to this class's field set, and would make a host's catalogue incomplete the moment it did not track one. A host's table replaces the default one whole, and a rule id it does not list falls back to the next name in the order above rather than raising, so a table that has gone out of date costs one named risk and nothing else. Its entries are names used whole rather than templates, so they are checked for type at construction and not rendered.

The finding risk names stay flat fields keyed by reason, and the argument runs the other way: their four reasons are produced by this repository's own command analysis rather than by a rule catalogue, an unknown one already falls back to `finding_other`, and each is one validated template like every other field.

Only prose is templated. A `path` summary is a path. A `network` summary is a URL. A `shell` summary is the tool name and the command. A `finding` summary over a command that reads or writes files is the file access. The verb in front of a path comes from a map whose fallback is the tool name.

### What is deliberately not covered

Not every string in an ASK body is prose. The summary of a `path` confirmation is
`"{action} {path}"`, of a `network` confirmation a URL, of a `shell` confirmation
`"{tool}: {command}"` — data lines, not sentences. The `action` in the first of those
comes from `_PATH_ACTION`, a map from tool name to a canonical verb whose fallback is the
tool name itself; it is in the register of identifiers, not of prose. Only two summary
fragments are sentences a translator would touch — the `tool` category's parenthetical and
the risk name prefixing a `finding` summary — and both are templated. Templating the
composition itself would mean handing the host the summary layout as well as its words,
which is a larger interface than the problem needs.

### Checking at construction

A mistyped override cannot reach a tool call: `PermissionPromptTexts.__post_init__`
renders every field once, and a host's typo fails there. Each field is checked against the
placeholders its own docstring documents rather than against the union of all sixteen — a
union would accept `title_tool="{tool_name}"`, even though a title is rendered with no
placeholders at all. `_FIELD_PLACEHOLDERS` holds that per-field set; a field added without
an entry raises on the first construction, which this module itself performs at import.
Both routes to an instance go through `__init__`, so `dataclasses.replace` on a valid set
re-checks the field it replaces. A misspelt placeholder, a placeholder borrowed from
another field, a malformed format string and a non-string value all raise
`DEEPAGENT_CONFIG_PARAM_ERROR`, naming the field and what was wrong with it — the status
code `Workspace.__post_init__` in `openjiuwen/harness/workspace/workspace.py` already uses
for a host's bad config value, chosen over a bare `KeyError` or a new exception type so
hosts that already map framework status codes need nothing new.

Checking at **construction** rather than at render is load-bearing, not a matter of taste,
and the restructure did not disturb the reason. On `20e35736` a rail's `before_tool_call`
can still stop a call only by raising `AbortError` or by marking the call skipped; any
other exception is swallowed by the callback framework and the tool then runs
unconfirmed. `openjiuwen/core/runner/callback/framework.py` is not among the 52 files
#792 changed, and `PermissionInterruptRail.before_tool_call` still awaits
`resolve_interrupt` with no guard around it. `_build_message` and
`_build_interrupt_metadata` are both reached inside `before_tool_call`, so an exception
raised while rendering an ASK body would not fail the round — it would skip the gate.
Validating at construction turns the same typo into a failure where the host builds its
texts, before any agent exists, so the seam adds no new route into that fail-open.

That premise is the subject of #971, filed alongside this request, and its fix changes it:
with that merged, a raise inside `before_tool_call` is caught at the callback boundary and
the tool call is rejected rather than run, so a render-time raise would fail the round
loudly instead of skipping the gate. The seam is designed the same way either way, for
three reasons that do not depend on it. Every release this request is written against —
`v0.1.11.post1` through `v0.1.17.post1` — carries the fail-open and none of them will
carry that fix, so a host validating at render time is unsafe on all of them. A malformed
template is a startup fault rather than a runtime one: it is wrong for every call the host
will ever make, and reporting it once where the host builds its texts is better than
reporting it as a denied tool call in the middle of a run, however loudly. And a template
that raises only on the branch that happens to be taken — an override of `remember_command`
that a path-only tool never reaches — would otherwise sit undetected until the first call
that renders it. Construction-time validation is therefore the right shape on its own
merits; the fail-open is what makes it not merely better but necessary on every version
currently released.

The check costs one pass over sixteen short templates, and runs once per
`PermissionPromptTexts` — hence once per `ToolPermissionHost`, once per rail.
`dataclasses.replace` on the host, which `build_permission_interrupt_rail` performs when
it supplies `resolve_workspace_dir`, passes the existing instance through and re-validates
nothing; nothing on the per-tool-call path constructs either dataclass.

These templates are reached when `request_permission_confirmation` is unset, which is the
default, or when it is set and returns the literal `"interrupt"`. Every other outcome
short-circuits before them: a `PermissionConfirmResponse`, where the host rendered its own
UI and decided; `None`, where the hosted request failed; a return of any other type; or an
exception out of the hook. Hosts on those paths are unaffected either way.

### Where the module lives, and what it exports

`prompt_texts.py` sits at `openjiuwen/harness/security/permission_engine/`, beside
`models.py` and `host.py`, rather than inside `approve/` next to its main consumer. Two
modules in different packages read it — `permission_engine/approve/ask_presentation.py`
and `rails/security/tool_security_rail.py` — and `host.py` carries it; putting it at the
engine's top level is what keeps `host.py` from importing the `approve` package at module
import time merely to name a type.

The module also names the built-in set, `DEFAULT_PERMISSION_PROMPT_TEXTS`, which exists so
that `build_permission_ask_presentation` has something to fall back on when no `texts=` is
passed without constructing — and so revalidating — a set on every render.
`ToolPermissionHost.prompt_texts` still uses `default_factory=PermissionPromptTexts`
rather than that singleton: it is the idiomatic dataclass default, it keeps `host.py` from
depending on another module's object identity, and it costs one validated construction per
host, which is once per rail.

`PermissionPromptTexts` and `ENGLISH_PERMISSION_PROMPT_TEXTS` are exported from
`permission_engine/__init__.py` and from `openjiuwen/harness/security/__init__.py`, which
is the surface the guide documents — those two names and no others; `host.py`'s own
`__all__` is left as it was, so nothing new leaks through the `import *` in the
compatibility shim. `openjiuwen/harness/security/host.py` is **not** changed at all: it is
a shim for names that used to live at that path, and a name that has never had an old path
does not belong in it.

### What changes for a user

The same ASK on `write_file` with the default `ToolPermissionHost()` emits, byte for byte,
what the unmodified code emits everywhere except inside the "remember" hint, whose wording
is corrected — the reason is two sections below:

````text
write /srv/app/notes.md

> 选择「会话内记住」可在本会话内自动放行 ``write_file`` 的所有调用，而不只是本次针对 ``/srv/app/notes.md`` 的调用；选择「永久记住」可将此规则写回磁盘，所有会话均自动放行。
````

Passing `ToolPermissionHost(prompt_texts=ENGLISH_PERMISSION_PROMPT_TEXTS)` instead, a
difference of one constructor argument at the integration point, renders this body:

````text
write /srv/app/notes.md

> Remembering this for the session allows every ``write_file`` call automatically until the session ends, not only this one on ``/srv/app/notes.md``; remembering it permanently writes the rule to disk, so every session allows them automatically.
````

with this interrupt metadata alongside it:

````json
{
  "ask_category": "path",
  "ask_title": "Protected file path access detected",
  "ask_summary": "write /srv/app/notes.md",
  "matched_rule": "file_guard:defaults"
}
````

### Compatibility

Every default but the tool "remember" hint reproduces the literal it replaces, so a host that injects nothing sees no other change. Sixteen confirmations render byte for byte identically before and after, in the interrupt metadata and in the body alike, except for that one hint. They span every category, the built-in and operator rule-id forms, the interpreter-sink and too-complex titles, all five finding names and every hint outcome the code can reach.

No public name is removed or repurposed. `prompt_texts` is a new field with a default,
`build_permission_ask_presentation` gains a keyword-only parameter with a default, and
`PermissionPromptTexts` / `ENGLISH_PERMISSION_PROMPT_TEXTS` are new exports.

### The two defaults that are corrected rather than reproduced

For a non-shell tool the hint has read this way since `785a0fcf`,
"bugfix(toolrail): remember option optimize", which added the `path_desc` local it
interpolates:

````text
> 选择「会话内记住」可在本会话内自动放行 ``write_file`` 类工具在 ``/srv/app/notes.md`` 下的调用；选择「永久记住」可将此规则写回磁盘，所有会话均自动放行。
````

— the allow bounded by the path in front of the person deciding. It is not bounded by it.

`_get_auto_confirm_key` appends a subcommand only for `bash`, `mcp_exec_command` and
`create_terminal`. For every other tool it returns the bare tool name:

````python
        if tool_name in {"bash", "mcp_exec_command", "create_terminal"}:
            cmd = tool_args.get("command", tool_args.get("cmd", ""))
            return self._build_shell_auto_confirm_key(tool_name, str(cmd or ""))

        return tool_name
````

That same string is what `_store_auto_confirm` writes into the session
(`config[auto_confirm_key] = True`) and what `_is_auto_confirmed` reads back, so an entry
stored from a prompt about one path matches that tool's every later ASK whatever the path.
The permanent half of the sentence is tool-wide too:
`merge_permission_allow_rule_into_permissions` drops the suggestions whose `match_type` is
`path` — paths are written to file_guard instead — and, with nothing else to write for a
non-shell tool, calls `_persist_tiered_tool_allow`, which sets
`permissions.tools[<tool>] = "allow"`.

The value the hint interpolates need not even be a path. `_build_always_allow_hint` falls
back to the first argument value containing a slash, so an ASK on a fetch of
`https://evil.test/a` described the allow as calls "under" that URL.

Both defaults are therefore reworded: the tool is named as the scope, and the path is
presented as the case in hand rather than as the limit.

````text
zh  remember_tool  before  ...自动放行 ``{tool_name}`` 类工具{path_scope}的调用；...
                   after   ...自动放行 ``{tool_name}`` 的所有调用{path_scope}；...
zh  path_scope     before  在 ``{path_hint}`` 下
                   after   ，而不只是本次针对 ``{path_hint}`` 的调用

en  remember_tool  before  ...allows ``{tool_name}`` calls{path_scope} automatically until the session ends;...
                   after   ...allows every ``{tool_name}`` call automatically until the session ends{path_scope};...
en  path_scope     before   under ``{path_hint}``
                   after   , not only this one on ``{path_hint}``
````

Both language sets change together. This request is the reason an English rendering of
that sentence exists at all, and shipping the two saying opposite things would be worse
than either alone. `path_scope` stays a field and stays overridable — the path is real
context for the decision, and only the claim made about it was wrong — and its docstring
now names what the key is, so a host writing its own wording does not restore the reading.
No behaviour changes; the hint is a string, and widening what it says brings it into line
with the allow the code already performs.

Correcting it here rather than beside it: this request is about where the ASK wording
comes from, it is the request that decides the English rendering of this sentence, and it
is the request that promotes `path_scope` from an inline `path_desc` local to a
documented, host-overridable field. Leaving it would publish the wrong claim as API.

### One template still cannot render today

The session-only shell hint in `_build_always_allow_hint` is unreachable, on `20e35736`
exactly as before: `shell_key` and `auto_confirm_key` are computed from the same call on
the same arguments, so `if shell_key:` returns first whenever either is truthy and the
`if auto_confirm_key:` guard beneath that return never runs. The sweep above
confirms it — that hint appears in none of them. The issue has the detail.

That is a defect in the rail as it stands, not one this change introduces or repairs. The
control flow is preserved line for line here; only the literals move.
`remember_command_session_only` is kept as a field, and translated in the bundled English
set, so that the seam covers the code exactly as written and the wording is already in
place when the branch is repaired. Repairing it changes behaviour and belongs in its own
request rather than inside one whose subject is where the wording comes from.

### Why an English wording set ships alongside the mechanism

The seam alone would leave every English-serving embedder translating the same sixteen
templates from the Chinese originals, independently and slightly differently — and one
group of them has a constraint that is invisible to a translator working from the Chinese
text alone. The "remember" hints must describe what each choice *does* rather than naming
the choices, because the buttons are rendered by the host and the rail cannot know what
they are called there. The Chinese originals name them (「会话内记住」, 「永久记住」); a
faithful translation would name them too, and would be wrong on every host that labels
them anything else. Getting that right once, in the tree, is worth more than the strings.

`ENGLISH_PERMISSION_PROMPT_TEXTS` is that translation, and it is data and nothing more —
no language detection, no selection logic, no change of default. A host passes it exactly
as it would pass an instance of its own; a host that passes nothing still gets the Chinese
defaults. So it commits the project neither to shipping a wording set per language nor to
a mechanism that depends on one: if the preference is for openjiuwen to ship no wording
data at all, deleting the constant leaves a working seam behind and the tests that cover
the mechanism keep passing. Shipping it also makes the seam demonstrably sufficient for a
whole real language rather than only plausibly so — the rendered block above is what
proves that, and it cannot be written without the data. The wording otherwise tracks the
Chinese defaults closely, including where those are loose, rather than quietly improving
on them.

### Documentation

Both language editions of the tool permission guide gain a `prompt_texts` row and a
section covering the built-in defaults, the two render sites, the fact that the title
travels in the interrupt metadata rather than the body, the bundled English set, partial
overrides, which strings are deliberately not templated, the template rules and why they
are enforced at construction; the source index gains the new module and
`ask_presentation.py`. Both sections also record that a remember is keyed on the tool
rather than on the path, and why, since that is what a host overriding those two fields
has to know. The section states plainly that `AGENT_PROMPT_LANGUAGE` does not
reach this text, because that is the first place an embedder looks for it. `S_08
security-engine` gains the new module and the matching invariant — but not a bumped file
count: that spec's `（14 文件）` and its module list still describe the pre-`20e35736`
layout, and asserting a corrected number for one module while the rest of the list is
stale would be false precision. Bringing that spec up to date belongs with the
restructure, not here.

**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

54 test items are added, in
`tests/unit_tests/harness/security/test_permission_prompt_texts.py`.

Against the merge base the file cannot be collected at all, because the module it
exercises does not exist there:

```
collected 0 items / 1 error
E   ModuleNotFoundError: No module named 'openjiuwen.harness.security.permission_engine.prompt_texts'
```

so nothing in it passes on `20e35736`. That is a weak claim on its own — it proves the
module is new, not that the seam works — so the file was also run against a base worktree
carrying `prompt_texts.py` and the `ToolPermissionHost.prompt_texts` field but with **both
render sites unmodified**. That run is `24 failed, 30 passed`, and the split is the point:

- **23 of the 24 failures** are exactly the tests that require the seam to reach a render
  site: all six `test_host_titles_replace_the_builtin_titles`, all five
  `test_host_finding_labels_replace_the_builtin_labels`, all three
  `test_host_texts_replace_the_remember_hint`, `test_host_summary_replaces_the_builtin_parenthetical`,
  `test_factory_carries_host_texts_into_the_rail`, all six
  `test_english_texts_render_without_any_chinese`, and
  `test_a_valid_partial_override_still_renders`. Every one of them fails with the built-in
  Chinese wording still in the output, which is the defect itself.
- **The 24th**, `test_default_path_body_scopes_the_remember_hint_to_the_tool`, fails there
  for the other reason: that tree still renders the uncorrected hint. It is the guard on
  the reworded default.
- **13 of the 30 passes** exercise `PermissionPromptTexts` alone — the per-field
  placeholder table, four placeholder mistakes each asserted to name its own field and the
  offending placeholder (including `{tool_name}` in a title, which is only a mistake
  because validation is per-field rather than against the union), four unrenderable format
  strings, a non-string field, both shipped sets passing their own validation, and the
  host wiring refusing to be built from an unrenderable template. They need the new module
  but not the wiring, which is why they pass in that tree and not on the real base.
- **2 more** assert the host's default is the built-in set and that the English set is not
  the default. They need the new field, not the wiring.
- **1 is the evidence for the rewording** and passes on both sides, since it touches no
  render site: `test_the_session_remember_is_keyed_on_the_bare_tool_name` derives the key
  for `write_file` on two different paths, asserts both are `"write_file"`, and asserts
  that the session entry stored from one matches the other.
- The remaining **14 are guards**, and pass on both sides deliberately:
  `test_default_shell_hint_names_the_subcommand`,
  `test_default_body_has_no_hint_for_a_compound_command`,
  `test_default_tool_summary_keeps_the_historical_parenthetical`, five
  `test_default_finding_labels_are_unchanged` and six `test_default_titles_are_unchanged`.
  They quote the shipped wording verbatim. They earn their place because "a host that
  injects nothing sees no change outside the corrected hint" is the compatibility promise
  this change makes, and
  without them that promise is checkable only in the one-off render sweep below and never
  again. They are also what fails if someone later edits a default template without
  meaning to alter what shipped deployments see — which, given that every default is now
  one line in one dataclass rather than a literal buried in a branch, is easier to do than
  it was.

The six category titles are asserted through `_build_interrupt_metadata` rather than the
body, because after the restructure the title never appears in the body at all.

The full unit suite was run on this change and on the base it sits on, serially, in
separate clean worktrees, with `--continue-on-collection-errors` so that a collection
abort cannot masquerade as a matched pair, and `openjiuwen.__file__` was asserted to
resolve inside the worktree under test before either result was believed. Failing and
erroring test **names** were compared, not counts: 138 names on each side, and the two
sets are identical — the same 134 tests fail and the same 4 modules fail to collect.
Passing count 16458 on the base and 16512 on this change, a difference of exactly the 54
items added here. The residual failures are pre-existing and unrelated: a local database
file the environment cannot open, which accounts for the largest group by far; optional
dependencies that are not installed (`pulsar`, and `prompt_toolkit` for the four
`agent_teams/cli` modules that fail to collect); and twelve tests that assume an event
loop already running in the main thread. No CI result is claimed.

`test_ask_presentation.py`, the test file #792 added for the render site this change
touches, passes unmodified — it asserts the built-in Chinese titles and summaries, so it
is itself a check that the defaults are unchanged.

`ruff check` against the repository's own `pyproject.toml` configuration reports the same
finding set on the security tree before and after, and none at all on either file this
change adds.

On performance: instrumenting `PermissionPromptTexts.__post_init__` counts exactly one
call across a whole `build_permission_interrupt_rail` — one still when the factory
supplies `resolve_workspace_dir`, because the `dataclasses.replace` it performs there
rebuilds the host around the existing instance rather than constructing a new one — and
zero across fifty `_build_message` plus `_build_interrupt_metadata` renders. The
rendering path itself gains one attribute lookup and a `str.format` per templated
segment in place of an inline literal; no measurable difference is claimed or expected.

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [x] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

> Two boxes are left unticked rather than ticked untruthfully.
> **Design**: this has had no Maintainer design review yet — the shape is described above
> and is meant to be argued with, in particular the decision that openjiuwen picks no
> language on the host's behalf, the choice of sixteen flat fields over a mapping for the
> risk names, and the decision to leave `persist_rule_merge.py` alone.
> **Interface**: this *does* change the public interface (one new field on
> `ToolPermissionHost`, one new keyword-only parameter on
> `build_permission_ask_presentation`, two new exports from
> `openjiuwen.harness.security`); the docstrings and both editions of the guide are
> updated, but interface-review sign-off has not been sought. Both are requests, not
> oversights.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #831
- Fixes #866
- Fixes #963
- Fixes #969
- Fixes #971
<!-- /bot1-related-issues -->



