### PR TITLE
fix(security): deny the tool call when the permission gate cannot decide

### DIFF
--- a/openjiuwen/harness/rails/security/tool_security_rail.py
+++ b/openjiuwen/harness/rails/security/tool_security_rail.py
@@ -12,6 +12,7 @@ from copy import deepcopy
 
 from typing import Any, Iterable, Optional, cast
 from openjiuwen.core.foundation.llm.schema.tool_call import ToolCall
+from openjiuwen.core.runner.callback import AbortError
 from openjiuwen.core.single_agent.interrupt.response import InterruptRequest
 from openjiuwen.core.single_agent.interrupt.state import INTERRUPT_AUTO_CONFIRM_KEY
 from openjiuwen.core.single_agent.rail.base import AgentCallbackContext
@@ -172,6 +173,62 @@ class PermissionInterruptRail(ConfirmInterruptRail):
         return bool(approved and auto_confirm and session is not None and auto_confirm_key and not persisted)
 
     async def before_tool_call(self, ctx: AgentCallbackContext) -> None:
+        """Decide this tool call, rejecting it when no decision can be reached.
+
+        A rail stops a tool call only by raising ``AbortError`` or by setting
+        ``_skip_tool``; every other exception is logged and swallowed by
+        ``AsyncCallbackFramework.trigger``, which then runs the remaining
+        callbacks and lets the call proceed. An exception escaping this method
+        would therefore leave the gate with no decision at all and the call
+        would run as if it had been approved. A gate that cannot decide must
+        not be the reason a call runs, so an escape is turned into a rejection
+        here rather than being allowed to reach the framework.
+        """
+        try:
+            await self._decide_tool_call(ctx)
+        except AbortError:
+            # An ASK is delivered as AbortError carrying ToolInterruptException;
+            # that is a decision this rail made, not a fault, and the framework
+            # is what turns it into a pause. It must pass through untouched.
+            raise
+        except Exception as exc:
+            self._reject_undecided(ctx, exc)
+
+    def _reject_undecided(self, ctx: AgentCallbackContext, exc: Exception) -> None:
+        """Reject a tool call whose permission decision could not be reached.
+
+        The rejection carries only the exception type, since the tool result is
+        fed back to the model; the failure itself is logged in full for the
+        operator.
+        """
+        try:
+            inputs = getattr(ctx, "inputs", None)
+            tool_name = getattr(inputs, "tool_name", "") or ""
+            tool_call = getattr(inputs, "tool_call", None)
+            logger.error(
+                "[PermissionEngine] permission.rail.undecided tool=%s error=%s",
+                tool_name,
+                type(exc).__name__,
+                exc_info=True,
+            )
+            message = (
+                "[PERMISSION_DENIED] The permission check for this tool call could "
+                f"not be completed ({type(exc).__name__}), so the call was not "
+                "approved."
+            )
+            self._apply_decision(
+                ctx, tool_call, tool_name, self.reject(tool_result=message)
+            )
+        except Exception as reject_exc:
+            # Rejecting needs a readable ``ctx``, which is exactly what a
+            # failure this early may have taken away. Aborting the chain is then
+            # the only way left to keep the call from running, and ``AbortError``
+            # is the one exception the framework does not swallow.
+            raise AbortError(
+                reason="Permission decision could not be reached, nor the call rejected",
+            ) from reject_exc
+
+    async def _decide_tool_call(self, ctx: AgentCallbackContext) -> None:
         tool_name = ctx.inputs.tool_name
         tool_call = ctx.inputs.tool_call
         normalized_name = self._normalize_tool_name(tool_name)

--- a/tests/unit_tests/harness/security/test_permission_rail_undecided.py
+++ b/tests/unit_tests/harness/security/test_permission_rail_undecided.py
@@ -1,0 +1,409 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""``PermissionInterruptRail`` must reject a call it could not decide.
+
+A rail stops a tool call only by raising ``AbortError`` or by setting
+``ctx.extra["_skip_tool"]``. ``AsyncCallbackFramework.trigger`` logs and
+swallows every other exception and then lets the call proceed, so an exception
+escaping ``before_tool_call`` means the gate reached no decision and the call
+runs as if approved. These tests pin that every escape becomes a rejection
+instead, and that a genuine ASK interrupt still passes through untouched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from copy import deepcopy
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from openjiuwen.core.foundation.llm.schema.tool_call import ToolCall
+from openjiuwen.core.foundation.tool import Tool, ToolCard
+from openjiuwen.core.runner import Runner
+from openjiuwen.core.runner.callback import AbortError
+from openjiuwen.core.session.agent import create_agent_session
+from openjiuwen.core.single_agent.agents.react_agent import ReActAgent, ReActAgentConfig
+from openjiuwen.core.single_agent.interrupt.exception import ToolInterruptException
+from openjiuwen.core.single_agent.rail.base import (
+    AgentCallbackContext,
+    ToolCallInputs,
+)
+from openjiuwen.core.single_agent.schema.agent_card import AgentCard
+from openjiuwen.harness.rails.security.tool_security_rail import PermissionInterruptRail
+from openjiuwen.harness.security.factory import build_permission_interrupt_rail
+from openjiuwen.harness.security.host import ToolPermissionHost
+from tests.unit_tests.fixtures.mock_llm import (
+    MockLLMModel,
+    create_text_response,
+    create_tool_call_response,
+)
+
+
+ASK_POLICY = {"enabled": True, "tools": {"write_file": "ask"}}
+DENY_POLICY = {"enabled": True, "tools": {"write_file": "deny"}}
+ALLOW_POLICY = {"enabled": True, "tools": {"write_file": "allow"}}
+
+BOOM = "orbital mind control laser offline"
+
+
+def _tool_call() -> ToolCall:
+    return ToolCall(
+        id="call_zaphod_1",
+        type="function",
+        name="write_file",
+        arguments='{"file_path": "beeblebrox.md", "content": "mostly harmless"}',
+    )
+
+
+def _ctx(tool_call: ToolCall | None = None) -> AgentCallbackContext:
+    call = _tool_call() if tool_call is None else tool_call
+    return AgentCallbackContext(
+        agent=object(),
+        inputs=ToolCallInputs(
+            tool_call=call,
+            tool_name=call.name,
+            tool_args=call.arguments,
+        ),
+    )
+
+
+def _rail(
+    policy: dict[str, Any] = ASK_POLICY,
+    host: ToolPermissionHost | None = None,
+) -> PermissionInterruptRail:
+    # Copied, because the rail keeps the dict it is given and the engine may
+    # rewrite it; the module-level policies must not leak between tests.
+    return PermissionInterruptRail(
+        config=deepcopy(policy), host=host or ToolPermissionHost()
+    )
+
+
+def _rejected(ctx: AgentCallbackContext) -> bool:
+    """Whether the rail stopped the call by the reject mechanism."""
+    return ctx.extra.get("_skip_tool") is True
+
+
+# --------------------------------------------------------------------------
+# Every route by which an exception can escape the gate becomes a rejection.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_host_confirmation_raising_rejects_the_call() -> None:
+    """A host approval channel that raises must deny, as returning ``None`` does.
+
+    ``RequestPermissionConfirmationHook`` already documents ``None`` as "hosted
+    confirmation failed, the call will be rejected". An exception from the same
+    hook is the same failure and must reach the same outcome.
+    """
+
+    async def unavailable(_request: Any) -> Any:
+        raise RuntimeError(BOOM)
+
+    rail = _rail(host=ToolPermissionHost(request_permission_confirmation=unavailable))
+    ctx = _ctx()
+
+    await rail.before_tool_call(ctx)
+
+    assert _rejected(ctx)
+    assert "[PERMISSION_DENIED]" in str(ctx.inputs.tool_result)
+
+
+@pytest.mark.asyncio
+async def test_permission_check_raising_rejects_the_call() -> None:
+    """``check_permission`` logs and reraises, so its failure reaches the framework."""
+    rail = _rail()
+
+    async def unevaluable(**_kwargs: Any) -> Any:
+        raise ValueError(BOOM)
+
+    rail._engine.check_permission = unevaluable
+    ctx = _ctx()
+
+    await rail.before_tool_call(ctx)
+
+    assert _rejected(ctx)
+    assert "[PERMISSION_DENIED]" in str(ctx.inputs.tool_result)
+
+
+@pytest.mark.asyncio
+async def test_permission_check_raising_under_a_deny_rule_still_rejects() -> None:
+    """An unevaluated policy must not become weaker than the policy it failed to read.
+
+    The rule here is ``deny``. Because the evaluation failed, the rail cannot
+    know that, so the outcome must be the strictest one the policy could have
+    carried rather than a question the user can answer with "yes".
+    """
+    rail = _rail(policy=DENY_POLICY)
+
+    async def unevaluable(**_kwargs: Any) -> Any:
+        raise ValueError(BOOM)
+
+    rail._engine.check_permission = unevaluable
+    ctx = _ctx()
+
+    await rail.before_tool_call(ctx)
+
+    assert _rejected(ctx)
+    assert "_interrupt_decision" not in ctx.extra
+
+
+@pytest.mark.asyncio
+async def test_auto_confirm_key_raising_rejects_the_call() -> None:
+    """A failure above the first-check branch escapes on the resume pass too.
+
+    ``_get_auto_confirm_key`` runs before ``resolve_interrupt`` splits on
+    ``user_input``, so it is reached whether or not the user has already
+    answered. Turning this into an interrupt would ask a question whose answer
+    leads straight back to the same failure.
+    """
+    rail = _rail()
+
+    def unusable(_tool_call: Any) -> str:
+        raise ValueError(BOOM)
+
+    rail._get_auto_confirm_key = unusable
+    ctx = _ctx()
+
+    await rail.before_tool_call(ctx)
+
+    assert _rejected(ctx)
+
+
+@pytest.mark.asyncio
+async def test_permissions_snapshot_of_the_wrong_shape_rejects_the_call() -> None:
+    """The snapshot call is guarded; applying what it returns is not.
+
+    ``get_permissions_snapshot`` is wrapped in ``try/except``, but the
+    ``update_config`` that consumes its result is outside that guard, so a host
+    returning a dict the engine cannot load still escapes.
+    """
+    rail = _rail()
+
+    def hostile_snapshot() -> dict[str, Any]:
+        return {"enabled": True, "tools": {"write_file": "ask"}}
+
+    rail._host = ToolPermissionHost(get_permissions_snapshot=hostile_snapshot)
+
+    def unusable(*_args: Any, **_kwargs: Any) -> None:
+        raise TypeError(BOOM)
+
+    rail._engine.update_config = unusable
+    ctx = _ctx()
+
+    await rail.before_tool_call(ctx)
+
+    assert _rejected(ctx)
+
+
+@pytest.mark.asyncio
+async def test_a_context_too_broken_to_reject_aborts_instead() -> None:
+    """When even rejecting is impossible, the chain is aborted rather than continued.
+
+    A context whose ``inputs`` cannot be read fails before a tool call can be
+    identified, so there is nothing to attach a rejection to. Aborting is then
+    the only remaining way to keep the call from running, and ``AbortError`` is
+    the one exception the framework honours.
+    """
+
+    class Unreadable:
+        def __getattr__(self, name: str) -> Any:
+            raise RuntimeError(BOOM)
+
+    rail = _rail()
+    ctx = AgentCallbackContext(agent=object(), inputs=Unreadable())
+
+    with pytest.raises(AbortError):
+        await rail.before_tool_call(ctx)
+
+
+@pytest.mark.asyncio
+async def test_rejection_names_the_failure_type_but_not_its_message() -> None:
+    """The tool result is fed back to the model, so the detail stays in the log."""
+
+    async def unavailable(_request: Any) -> Any:
+        raise RuntimeError(BOOM)
+
+    rail = _rail(host=ToolPermissionHost(request_permission_confirmation=unavailable))
+    ctx = _ctx()
+
+    await rail.before_tool_call(ctx)
+
+    result = str(ctx.inputs.tool_result)
+    assert "RuntimeError" in result
+    assert BOOM not in result
+
+
+# --------------------------------------------------------------------------
+# Guards: what must not change.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_ask_still_raises_the_interrupt() -> None:
+    """Guard. ``AbortError`` is how an ASK becomes a pause and must pass through.
+
+    Catching it alongside every other exception would convert every question
+    the rail exists to raise into a silent rejection, which would break the
+    feature while closing the hole. Passes before and after the fix.
+    """
+    rail = _rail()
+    ctx = _ctx()
+
+    with pytest.raises(AbortError) as excinfo:
+        await rail.before_tool_call(ctx)
+
+    assert isinstance(excinfo.value.cause, ToolInterruptException)
+    assert not _rejected(ctx)
+
+
+@pytest.mark.asyncio
+async def test_a_deny_rule_still_rejects_normally() -> None:
+    """Guard. A decided DENY is unaffected. Passes before and after the fix."""
+    rail = _rail(policy=DENY_POLICY)
+    ctx = _ctx()
+
+    await rail.before_tool_call(ctx)
+
+    assert _rejected(ctx)
+    assert "[PERMISSION_DENIED]" in str(ctx.inputs.tool_result)
+    assert "could not be completed" not in str(ctx.inputs.tool_result)
+
+
+@pytest.mark.asyncio
+async def test_an_allow_rule_still_lets_the_call_through() -> None:
+    """Guard. A decided ALLOW is unaffected. Passes before and after the fix."""
+    rail = _rail(policy=ALLOW_POLICY)
+    ctx = _ctx()
+
+    await rail.before_tool_call(ctx)
+
+    assert not _rejected(ctx)
+    assert ctx.inputs.tool_result is None
+
+
+@pytest.mark.asyncio
+async def test_cancellation_is_not_turned_into_a_rejection() -> None:
+    """Guard. ``CancelledError`` is a ``BaseException`` and must keep propagating.
+
+    Swallowing it would leave a cancelled task looking like a denied tool call
+    and would break cancellation for everything above the rail.
+    """
+    rail = _rail()
+
+    async def cancelled(**_kwargs: Any) -> Any:
+        raise asyncio.CancelledError
+
+    rail._engine.check_permission = cancelled
+    ctx = _ctx()
+
+    with pytest.raises(asyncio.CancelledError):
+        await rail.before_tool_call(ctx)
+
+    assert not _rejected(ctx)
+
+
+# --------------------------------------------------------------------------
+# End to end: what the swallowed exception costs when a real agent runs.
+# --------------------------------------------------------------------------
+
+
+class _RecordingTool(Tool):
+    """A stand-in for any tool an operator would put behind an ASK rule."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            ToolCard(
+                name="write_file",
+                description="Write a file",
+                input_params={
+                    "type": "object",
+                    "properties": {
+                        "file_path": {"type": "string", "description": "Path"},
+                        "content": {"type": "string", "description": "Content"},
+                    },
+                    "required": ["file_path", "content"],
+                },
+            )
+        )
+        self.calls: list[Any] = []
+
+    async def invoke(self, inputs: Any, session: Any = None, **_kwargs: Any) -> Any:
+        self.calls.append(inputs)
+        return {"success": True}
+
+    async def stream(self, inputs: Any, **kwargs: Any) -> Any:
+        yield await self.invoke(inputs, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_a_broken_gate_does_not_let_the_tool_run_in_a_real_agent() -> None:
+    """The whole chain: a raising host must not end with the tool having run.
+
+    The unit tests above pin the rail's own behaviour. This one pins the
+    consequence, because the fail-open is a property of the rail *and* the
+    callback framework together: the framework logs the escaped exception and
+    carries on, so nothing between the rail and the tool notices that no
+    decision was ever made.
+    """
+    os.environ.setdefault("LLM_SSL_VERIFY", "false")
+
+    async def unavailable(_request: Any) -> Any:
+        raise RuntimeError(BOOM)
+
+    await Runner.start()
+    try:
+        tool = _RecordingTool()
+        agent = ReActAgent(card=AgentCard(id="undecided_gate_agent"))
+        config = ReActAgentConfig()
+        config.configure_model_client(
+            provider="OpenAI",
+            api_key="sk-not-a-real-key",
+            api_base="https://api.example.invalid/v1",
+            model_name="mock-model",
+            verify_ssl=False,
+        )
+        config.configure_prompt_template([{"role": "system", "content": ""}])
+        agent.configure(config)
+        Runner.resource_mgr.add_tool(tool)
+        agent.ability_manager.add(tool.card)
+
+        rail = build_permission_interrupt_rail(
+            permissions=ASK_POLICY,
+            host=ToolPermissionHost(request_permission_confirmation=unavailable),
+        )
+        await agent.register_rail(rail)
+
+        session = create_agent_session(
+            session_id="undecided_gate_session",
+            card=AgentCard(id="undecided_gate_agent"),
+        )
+        mock_llm = MockLLMModel()
+        mock_llm.set_responses([
+            create_tool_call_response(
+                "write_file",
+                '{"file_path": "beeblebrox.md", "content": "mostly harmless"}',
+            ),
+            create_text_response("Finished."),
+        ])
+
+        with patch(
+            "openjiuwen.core.foundation.llm.model.Model.stream",
+            side_effect=mock_llm.stream,
+        ), patch(
+            "openjiuwen.core.foundation.llm.model.Model.invoke",
+            side_effect=mock_llm.invoke,
+        ):
+            await Runner.run_agent(
+                agent=agent,
+                inputs={"query": "write beeblebrox.md"},
+                session=session,
+            )
+
+        assert tool.calls == []
+    finally:
+        await Runner.stop()


### PR DESCRIPTION
Paired: [GitHub #972](https://github.com/openJiuwen-ai/agent-core/pull/972) ↔ [GitCode !2535](https://gitcode.com/openJiuwen/agent-core/merge_requests/2535)

**What type of PR is this?**

/kind bug

**Which issue(s) this PR fixes**:

Fixes #971

Related but not fixed here. `fix(security): let the host supply the tool permission prompt wording`, filed alongside this one, is the other change of ours to this file: it moves the ASK body's sixteen Chinese literals behind templates a host supplies on `ToolPermissionHost`, and validates them at construction *because* of the defect fixed here — building the confirmation message is one of the seven routes below, and on the unfixed tree a raise there skips the gate rather than failing the round. That reasoning is why it validates early; it is not why early validation is right, and it stands on its own once this merges, since the releases it is written against will not carry this fix. That change is written against `20e35736`, where #792 merged; this one is based on `dce36fc8`, two commits before it. On `20e35736` the two touch different methods of `tool_security_rail.py` — `_build_message`, `_build_interrupt_metadata` and `_build_always_allow_hint` there, `before_tool_call` here — and cherry-picking both onto it in either order applies cleanly and gives the same tree. Neither should be closed on the other's merge.

#831 concerns `ask` decisions the rail did reach — whether the gate can be switched off, how the interrupt is accounted for, how the answer comes back, and whether the answer can be trusted when a host auto-approves it. This change concerns calls for which the rail reached no decision at all, so nothing was there to account for or to trust. #792 — tracked by #866 — restructures the permission engine and edits this same file: its imports, its alias table, the persistence helpers around `_persist_allow_always`, parts of `resolve_interrupt`, and `_build_message`, which it rewrites to delegate to a new `permission_engine/approve/ask_presentation.py`. None of those hunks reaches `before_tool_call`, so the two apply cleanly in either order and neither supersedes the other. Neither should be closed on this merge.

**What does this PR do / why do we need it**:

`AsyncCallbackFramework.trigger` logs every callback exception that is not an `AbortError` and continues the chain, and a rail can stop a tool call only by raising `AbortError` or by setting `_skip_tool` — both of which require its callback to run to completion. `PermissionInterruptRail.before_tool_call` had no `try`/`except`, so any exception on the way to a decision left the gate having decided nothing, and a tool call nobody approved ran as though somebody had. The linked issue carries the evidence: the mechanism, the seven unguarded routes that reach it, and a self-contained reproduction.

Neither half is wrong on its own. `cdd57db4` gave the framework a deliberate policy of logging a failing callback and continuing, which is right for the observability and telemetry callbacks it was written for. `7475e8ce` added the permission rail, released at `v0.1.11.post1`, and mounted a security gate on that chain without reconciling the two contracts. Every release from `v0.1.11.post1` to `v0.1.17.post1` carries the result.

**The change.** Wrap the whole of `before_tool_call` in a guard, re-raise `AbortError` untouched, and turn anything else into a rejection. The existing body moves unchanged into a private `_decide_tool_call`, which is why the diff is fifty-seven added lines and no deleted or re-indented ones: the logic being guarded is byte-for-byte what it was.

**Why the guard is on the callback boundary rather than on each raising site.** The boundary is where the fault becomes an approval. Every one of the seven routes — the host's approval channel, `check_permission`, applying a hot-reloaded snapshot, computing the auto-confirm key, building the confirmation message, persisting an "always allow", and reading `ctx` at all — ends at the same place: the callback returns without deciding and the framework moves on. Guarding them individually would mean seven guards that each have to invent the same outcome, would leave the eighth route unguarded the day it is added, and would still not cover the two lines of `before_tool_call` itself that sit outside `resolve_interrupt`. One guard at the boundary is exhaustive by construction, and it stays exhaustive as the body grows.

**Why an undecidable call is denied rather than put to the user.** This is the substantive choice in this PR and it is the one worth disagreeing with, so the alternative is set out with what it actually does on this tree rather than dismissed. Raising an interrupt instead is genuinely attractive: it preserves the ASK semantics, it puts a decision to the person the gate exists to consult rather than taking it for them, and it is what the rail already does for a real `ask`. It also recovers cleanly in the single most likely failure — a host whose approval channel is momentarily unavailable — because the resume pass does not call the host at all, so the user answers the built-in interrupt and the call proceeds. Four things decide against it anyway.

- **An interrupt can be weaker than the policy that failed to be read.** When `check_permission` raises, the rail does not know what the rule said. Under a `deny` rule, turning that into an interrupt asks the user a question whose "yes" runs a call the policy forbids outright — traced on this tree: with `tools: {write_file: deny}` and a failing `check_permission`, the interrupt variant reaches `result_type: interrupt`, and one approval later the tool has executed. A rejection is the only outcome that is no weaker than any decision the policy could have carried, which is the property a gate needs when it cannot read its own policy.
- **An interrupt can fail to terminate.** `_get_auto_confirm_key` runs at the top of `resolve_interrupt`, above the branch on `user_input`, so a deterministic failure there — a malformed argument reaching the shell parser, say — recurs on the resume pass. Traced on this tree: the first pass interrupts, the user approves, and the second pass interrupts again with the tool still not run. The user is asked repeatedly for permission to do something that will never happen. Rejecting fails once, tells the model why, and the run continues.
- **It is what the host contract already says.** `RequestPermissionConfirmationHook` documents its `None` return as hosted confirmation having failed, and the rail already answers that with `[PERMISSION_DENIED] ... (Hosted permission request failed)`. Before this change a host that *returned* failure had its call denied while a host that *raised* had its call allowed. Denying is not a new policy invented here; it is the policy the host contract already states, extended to the case where the host raises instead of returning.
- **An interrupt needs somewhere to go, and a rejection does not.** Surfacing a pause and carrying an answer back requires a caller that does both. That holds for a top-level run with an interactive host; it is exactly what is still being worked out on the delegated sub-agent path, in #831 and in the requests filed alongside it. Making the failure path depend on that machinery would make the guard weakest on the paths that are least settled. A rejection reaches the model as a tool result through the same `_skip_tool` mechanism a `deny` uses, on every path, with nothing else required.

The cost is real and worth naming: a transient host fault now blocks a call that a retry would have permitted, and an operator whose policy template has a typo gets denials rather than prompts. Both are recoverable — the model receives `[PERMISSION_DENIED] The permission check for this tool call could not be completed (<ExceptionType>)`, which it can report, work around, or retry — and both are loud in a way the previous behaviour was not, where the same faults produced one unlabelled `Callback execution failed` line and a tool call that had already happened.

**`AbortError` passes through untouched, and that is load-bearing.** It is the mechanism by which a genuine `ask` becomes a pause: `_apply_decision` raises it carrying a `ToolInterruptException`, and the framework's own `AbortError` handler re-raises the cause. Catching it alongside everything else would convert every question this rail exists to raise into a silent rejection — closing the hole by breaking the feature. The guard therefore re-raises `AbortError` before the general handler, and a test pins that an `ask` still interrupts. `asyncio.CancelledError` is a `BaseException` and is not caught either, which a second test pins; swallowing it would make a cancelled task look like a denied tool call.

**When rejecting is itself impossible.** Rejecting needs a readable `ctx`, which is what a failure in the first two lines of the method may have taken away. If `_apply_decision` cannot be reached, the handler raises `AbortError` with no cause — the one exception the framework does not swallow — so the chain stops and the call still does not run. This is the difference between a guard and a guarantee: without it, a broken `ctx` would fail open through the guard itself.

**What the rejection tells the model, and what it does not.** The tool result is fed back into the model's context, so it names the exception type and no more. The exception's message and traceback go to the log, as `[PERMISSION_DENIED]`-adjacent detail in a failed permission check may quote a path, a command or a host-side error string that has no business being placed in a prompt. The log line is `[PermissionEngine] permission.rail.undecided tool=<name> error=<ExceptionType>` at `ERROR` with `exc_info=True`, which unlike the framework's `Callback execution failed` line names the tool and is greppable as a security event.

**What is deliberately not changed.**

- **The framework's swallow.** `trigger` still logs and continues for every other callback, which is the right default for the observability, memory and telemetry callbacks that make up most of the chain and is relied on across the codebase. Changing it would alter behaviour for every rail at once.
- **The general fix, and why it is not attempted here.** The principled version of this is for the framework to let a callback declare itself safety-critical, so that its failure aborts the chain rather than being logged, and for the permission rail to register as one. That is the better long-term shape, and #853 — *ratchet down broad `except Exception`* — is where it belongs: that RFC would make the framework's swallow illegal where it stands, since `trigger` is not one of the boundaries it designates. It is not this PR, though: it changes a public framework contract, needs a decision about what "critical" means when several such callbacks are registered and one of them fails, and needs an audit of every existing callback to establish which ought to claim it. It would also still not remove the need for the rail to decide *what* a failure means, which is the substance of this change. Shipping the local guard first makes the deployed behaviour safe without waiting on that discussion, and leaves the rail's guard as a no-op if the framework later gains the mechanism.
- **`BaseSecurityRail`.** It has the same shape — `_run_and_apply` calls `run_security_check` and applies the decision with no guard — and would fail open the same way. Its only subclass in the package is `SafetyPromptRail`, which is a prompt-safety rail rather than the tool permission gate, so it is out of scope here and noted rather than touched. It is a documented extension point, though — `examples/security_rail_demo` carries five subclasses of it, one of them a tool-rejecting rail — so an operator's own security rail has the same exposure, and it is worth the same treatment on its own merits.
- **Everything else in this file.** No prompt wording, no localisation, no rule evaluation and no persistence behaviour is altered. Nothing about a decided `allow`, `deny` or `ask` changes.

**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

Twelve tests are added in `tests/unit_tests/harness/security/test_permission_rail_undecided.py`.

**The routes.** Four drive the defect directly, one per class of failure, so that a future refactor that re-guards one route does not quietly leave the others open: the host's `request_permission_confirmation` raising; `check_permission` raising; `_get_auto_confirm_key` raising, chosen because it sits above the branch on `user_input` and so is the route an interrupt could not have terminated; and a host returning a snapshot that `PermissionEngine.update_config` cannot load, which is the route the existing `try` around `get_permissions_snapshot` does *not* cover because the `update_config` that consumes its result is outside that guard. Each asserts `_skip_tool` is set and the result carries `[PERMISSION_DENIED]`.

**The policy floor.** One drives `check_permission` to raise under a `deny` rule and asserts the call is rejected with no decision recorded in `ctx.extra`. This is the test that pins the design choice rather than the mechanism: it is what an interrupt-based fix would fail.

**The last resort.** One passes a `ctx` whose attribute access raises, so the guard cannot reach `_apply_decision`, and asserts `AbortError`. Without the inner handler this test fails with the original exception escaping — the guard failing open through itself.

**The message.** One asserts the tool result names `RuntimeError` and does not contain the exception's message, pinning that a failed check does not become a channel for host-side strings into the model's context.

**End to end.** One runs a `ReActAgent` through `Runner.run_agent` with the `ask` policy, the failing host, a stub model emitting one tool call, and a recording tool, and asserts the tool was not invoked. It earns its place beside the unit tests because the fail-open is a property of the rail *and* the framework together: the unit tests pin the rail's decision, this one pins that the decision actually stops the call.

**The guards.** Four pass on both sides and are labelled as such, because each pins something this change could plausibly have broken and none of them can fail for the reason the others fail:

- an `ask` still raises `AbortError` carrying `ToolInterruptException` — the guard must not swallow the interrupt mechanism;
- a `deny` rule still rejects with its own message rather than the undecided one;
- an `allow` rule still leaves `_skip_tool` unset and `tool_result` untouched;
- `asyncio.CancelledError` still propagates and does not become a rejection.

**Against the unmodified source.** Eight of the twelve fail on the merge base `dce36fc8`, none of them at setup or on an import. Seven fail with the injected exception escaping `before_tool_call` — the defect itself, reaching the test instead of the framework. The end-to-end one fails on its assertion, with the tool having run:

```
>           assert tool.calls == []
E           AssertionError: assert [{'file_path'...ly harmless'}] == []
E             Left contains one more item: {'file_path': 'beeblebrox.md', 'content': 'mostly harmless'}
```

The other four are the guards above, which pass on both sides by construction.

**The reported reproduction.** The script in the linked issue was run against both trees. On `dce36fc8` it prints `permission gate stopped the call : False` under a `Callback execution failed: before_tool_call` line; on this branch it prints `rail reached a reject decision: True` and `permission gate stopped the call : True`.

**Full suite.** `tests/` was run in full on `dce36fc8` and on this branch, one run at a time on an otherwise idle machine, and the two failure lists compared name by name rather than by count. All 172 names — 165 failures and 7 collection errors — are identical on both sides. Passing rises from 16842 to 16854, by exactly the twelve tests added here; no passing test was lost and none gained by accident. The residual failures are environmental rather than upstream's code — this suite shares fixed-name temporary and lock paths, and `prompt_toolkit` is absent from the environment, which accounts for all seven collection errors — and both conditions are present unchanged on the base.

**Performance.** No measurable cost. The guarded path adds one `try` frame per tool call and nothing else; Python's zero-cost exception handling means the `try` itself does not execute an instruction when nothing raises. The handler runs only on the path that previously ran a tool without asking.

**Reliability.** Behaviour moves in one direction for calls the rail decides — none at all — and in one direction for calls it cannot decide: previously the tool ran, now it does not. No new exception type escapes `before_tool_call` that did not escape it before: `AbortError` and `BaseException` subclasses propagate exactly as they did, and the ordinary exceptions that used to propagate into the framework's swallow now do not propagate at all, except on the broken-`ctx` path where the escape becomes an `AbortError` the framework already handles.

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

Notes on the unticked boxes:

- **Design** — not yet reviewed by a Maintainer. The point that most wants review is the choice of deny over interrupt, argued in four points above with the traced behaviour of both. A maintainer who prefers interrupt would be choosing a fix that can run a `deny`-ruled call on one user approval and that does not terminate on a deterministic failure; if those are acceptable in exchange for keeping the user in the loop, the alternative is a small change to the same handler. The secondary point is the last-resort `AbortError`, which is the only path on which this change can end a run that would previously have completed.
- **Interface** — no external interface changes. No signature, parameter, return type or configuration key is altered, and `_decide_tool_call` and `_reject_undecided` are private. `before_tool_call` keeps its signature and its contract for every call it can decide. What changes is the observable outcome for calls it cannot decide, from "the tool runs" to "the tool is rejected", which is a behaviour change rather than an interface one and is described above. No API annotation needs refreshing.
- **Document** — no official-website material is submitted, because none becomes inaccurate. *Tool permissions and host integration* describes what the rail does with `allow`, `deny` and `ask` decisions, all of which are unchanged, and says nothing about what happens when the check itself fails. If the Doc repository would rather state the failure behaviour explicitly — that a permission check which cannot complete denies the call, and that `permission.rail.undecided` is the line to look for — a sentence can be added on request.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #831
- Fixes #853
- Fixes #866
- Fixes #971
<!-- /bot1-related-issues -->

