### PR TITLE
fix(multi-agent): forward callback_context through P2PAbilityManager

### DIFF
--- a/openjiuwen/core/multi_agent/teams/hierarchical_msgbus/p2p_ability_manager.py
+++ b/openjiuwen/core/multi_agent/teams/hierarchical_msgbus/p2p_ability_manager.py
@@ -165,12 +165,27 @@ class P2PAbilityManager(AbilityManager):
         tool_call: ToolCall,
         session: Session,
         tag=None,
+        callback_context: Optional[AgentCallbackContext] = None,
     ) -> Tuple[Any, ToolMessage]:
-        """Route AgentCard calls via P2P send; delegate all others to super()."""
+        """Route AgentCard calls via P2P send; delegate all others to super().
+
+        Args:
+            tool_call:        The tool call to execute.
+            session:          Current agent session.
+            tag:              Optional resource tag forwarded to the base class.
+            callback_context: Callback context for the tool call, forwarded to
+                              the base class so that tools opting into
+                              ``accepts_tool_callback_context`` still receive it.
+        """
         tool_name = tool_call.name
 
         if tool_name not in self._agents:
-            return await super()._execute_single_tool_call(tool_call, session, tag)
+            return await super()._execute_single_tool_call(
+                tool_call=tool_call,
+                session=session,
+                tag=tag,
+                callback_context=callback_context,
+            )
 
         import json as _json
 

--- a/tests/unit_tests/core/single_agent/test_ability_manager_subclass_signatures.py
+++ b/tests/unit_tests/core/single_agent/test_ability_manager_subclass_signatures.py
@@ -1,0 +1,131 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+"""Signature compatibility between AbilityManager and its subclasses.
+
+AbilityManager invokes its own methods on ``self``, so an override whose
+parameter list has drifted from the base turns every such call into a
+``TypeError`` at run time rather than at import time.  Nothing in the type
+system or the test suite catches that today, and it has now happened twice in
+the same subclass: once for ``execute`` and once for
+``_execute_single_tool_call``.
+
+These tests pin the invariant for every subclass and every overridden method,
+so the next override that drifts fails here instead of in production.
+"""
+from __future__ import annotations
+
+import importlib
+import inspect
+
+import pytest
+
+from openjiuwen.core.single_agent.ability_manager import AbilityManager
+
+# A subclass is only reachable through ``__subclasses__()`` once the module
+# defining it has been imported, so every module holding one is imported here
+# for that side effect. A subclass missing from this list is a subclass this
+# guard cannot see, which is what ``test_known_subclasses_are_discovered``
+# exists to catch.
+_SUBCLASS_MODULES = (
+    "openjiuwen.core.context_engine.processor.forked.compressor.session_memory_agent",
+    "openjiuwen.core.multi_agent.teams.hierarchical_msgbus.p2p_ability_manager",
+)
+for _module_name in _SUBCLASS_MODULES:
+    importlib.import_module(_module_name)
+
+
+def _all_subclasses(cls) -> list[type]:
+    """Every subclass of ``cls``, transitively."""
+    found: list[type] = []
+    for sub in cls.__subclasses__():
+        found.append(sub)
+        found.extend(_all_subclasses(sub))
+    return found
+
+
+def _overridden_methods(sub: type):
+    """Yield ``(name, base_function, override_function)`` for each override."""
+    # Dunder methods are excluded: __init__ in particular is not called
+    # polymorphically by the base class, and subclasses legitimately take
+    # different construction arguments (P2PAbilityManager requires a
+    # supervisor). Every other method may be reached through ``self`` from
+    # base-class code, so its signature has to stay call-compatible.
+    for name, member in vars(sub).items():
+        if name.startswith("__") or not inspect.isfunction(member):
+            continue
+        base_member = getattr(AbilityManager, name, None)
+        if inspect.isfunction(base_member):
+            yield name, base_member, member
+
+
+def _override_cases():
+    cases = []
+    for sub in _all_subclasses(AbilityManager):
+        for name, base_member, override in _overridden_methods(sub):
+            cases.append(
+                pytest.param(
+                    base_member, override, id=f"{sub.__name__}.{name}"
+                )
+            )
+    return cases
+
+
+class TestAbilityManagerSubclassSignatures:
+    """Every AbilityManager override stays callable the way the base calls it."""
+
+    @staticmethod
+    def test_known_subclasses_are_discovered():
+        """The guard is only meaningful if it actually sees the subclasses."""
+        names = {sub.__name__ for sub in _all_subclasses(AbilityManager)}
+        assert {"P2PAbilityManager", "SessionMemoryAbilityManager"} <= names
+
+    @staticmethod
+    @pytest.mark.parametrize("base_member,override", _override_cases())
+    def test_override_accepts_every_base_parameter(base_member, override):
+        """An override must accept every parameter name the base declares."""
+        over_sig = inspect.signature(override)
+        if any(
+            param.kind is inspect.Parameter.VAR_KEYWORD
+            for param in over_sig.parameters.values()
+        ):
+            pytest.skip("override accepts **kwargs, so every keyword binds")
+        base_sig = inspect.signature(base_member)
+        missing = [
+            name for name in base_sig.parameters if name not in over_sig.parameters
+        ]
+        assert not missing, (
+            f"{override.__qualname__} does not accept {missing}, "
+            f"which {base_member.__qualname__} declares. "
+            f"base={base_sig} override={over_sig}"
+        )
+
+    @staticmethod
+    @pytest.mark.parametrize("base_member,override", _override_cases())
+    def test_override_takes_no_positional_only_parameters(base_member, override):
+        """Base-class code calls these by keyword, so none may be positional-only."""
+        positional_only = [
+            name
+            for name, param in inspect.signature(override).parameters.items()
+            if param.kind is inspect.Parameter.POSITIONAL_ONLY
+        ]
+        assert not positional_only, (
+            f"{override.__qualname__} makes {positional_only} positional-only; "
+            f"{base_member.__qualname__} is called with keyword arguments"
+        )
+
+    @staticmethod
+    def test_railed_call_binds_on_every_single_tool_call_override():
+        """Pin the exact keyword set _railed_execute_single_tool_call passes."""
+        # This is the call that broke: the base passes ``callback_context=``
+        # and an override predating that parameter cannot bind it.
+        for sub in _all_subclasses(AbilityManager):
+            override = vars(sub).get("_execute_single_tool_call")
+            if override is None:
+                continue
+            inspect.signature(override).bind(
+                None,  # self
+                tool_call=None,
+                session=None,
+                tag=None,
+                callback_context=None,
+            )

--- a/tests/unit_tests/multi_agent/builtin_teams/hierarchical_msgbus/test_hierarchical_msgbus.py
+++ b/tests/unit_tests/multi_agent/builtin_teams/hierarchical_msgbus/test_hierarchical_msgbus.py
@@ -1023,3 +1023,105 @@ class TestSupervisorAgentCreate:
         instance = provider()
         assert _get_semaphore_value(_get_ability_manager(instance)) == 4
         
+
+# ---------------------------------------------------------------------------
+# SECTION 3f -- P2PAbilityManager: callback_context propagation
+# ---------------------------------------------------------------------------
+
+_P2P_SUPER_SINGLE_CALL = (
+    "openjiuwen.core.multi_agent.teams.hierarchical_msgbus"
+    ".p2p_ability_manager.AbilityManager._execute_single_tool_call"
+)
+
+
+def _rail_ctx() -> MagicMock:
+    """A context the base-class rail can fire lifecycle events on."""
+    # ``extra`` must be a real dict: _railed_execute_single_tool_call pops
+    # ``_skip_tool`` from it and treats any truthy value as "skip the call",
+    # so a bare MagicMock would short-circuit the code under test.
+    ctx = MagicMock()
+    ctx.agent.agent_callback_manager.execute = AsyncMock(return_value=None)
+    ctx.extra = {}
+    ctx.steering_queue = None
+    return ctx
+
+
+class TestP2PAbilityManagerCallbackContext:
+    """_execute_single_tool_call matches the base signature and forwards it."""
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_non_agent_call_accepts_callback_context_keyword():
+        """The keyword the base class passes must bind on the override."""
+        mgr = P2PAbilityManager(supervisor=MagicMock())
+        expected = ("res", ToolMessage(content="ok", tool_call_id="tc1"))
+        with patch(_P2P_SUPER_SINGLE_CALL, new=AsyncMock(return_value=expected)):
+            result = await mgr._execute_single_tool_call(
+                tool_call=_tc("plain_tool"),
+                session=MagicMock(),
+                tag=None,
+                callback_context=MagicMock(),
+            )
+        assert result == expected
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_non_agent_call_forwards_callback_context_to_super():
+        """The context reaches the base implementation instead of being dropped."""
+        # The base class uses it to decide whether a tool receives
+        # ``_tool_callback_context``, so dropping it here would silently
+        # disable deferred-tool execution rather than raise.
+        mgr = P2PAbilityManager(supervisor=MagicMock())
+        ctx = MagicMock()
+        expected = ("res", ToolMessage(content="ok", tool_call_id="tc1"))
+        with patch(
+            _P2P_SUPER_SINGLE_CALL, new=AsyncMock(return_value=expected)
+        ) as mock_super:
+            await mgr._execute_single_tool_call(
+                tool_call=_tc("plain_tool"),
+                session=MagicMock(),
+                tag=None,
+                callback_context=ctx,
+            )
+        assert mock_super.await_args.kwargs["callback_context"] is ctx
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_agent_call_still_dispatches_over_p2p_with_callback_context():
+        """The P2P branch is unaffected by the added parameter."""
+        sv = MagicMock()
+        sv.send = AsyncMock(return_value={"out": "ok"})
+        sv.runtime = MagicMock(p2p_timeout=1800.0)
+        mgr = P2PAbilityManager(supervisor=sv)
+        mgr.add(_sub_card("sub_a"))
+        session = MagicMock()
+        session.get_session_id = MagicMock(return_value="s1")
+        result, tool_message = await mgr._execute_single_tool_call(
+            tool_call=_tc("sub_a", {"x": 1}),
+            session=session,
+            tag=None,
+            callback_context=MagicMock(),
+        )
+        sv.send.assert_awaited_once()
+        assert result == {"out": "ok"}
+        assert tool_message.tool_call_id == "tc1"
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_non_agent_call_reaches_base_implementation_through_execute():
+        """A plain tool call routed by a supervisor reaches the base class."""
+        # Drives the real AbilityManager.execute rather than patching it, so the
+        # call travels the path that fails in production:
+        # execute -> _railed_execute_single_tool_call -> the override. With a
+        # mismatched override the base implementation is never reached and the
+        # caller receives an "Ability execution error" ToolMessage instead.
+        mgr = P2PAbilityManager(supervisor=MagicMock())
+        expected = ("RESULT", ToolMessage(content="tool ran", tool_call_id="tc1"))
+        with patch(
+            _P2P_SUPER_SINGLE_CALL, new=AsyncMock(return_value=expected)
+        ) as mock_super:
+            results = await mgr.execute(
+                _rail_ctx(), _tc("plain_tool"), MagicMock()
+            )
+        assert mock_super.await_count == 1
+        assert results == [expected]


### PR DESCRIPTION
Paired: [GitHub #977](https://github.com/openJiuwen-ai/agent-core/pull/977) ↔ [GitCode !2538](https://gitcode.com/openJiuwen/agent-core/merge_requests/2538)

**What type of PR is this?**

/kind bug

**Which issue(s) this PR fixes**:

Fixes #976

Adjacent work that a reviewer may mistake for overlap, and does not overlap. Seven open pull requests edit `openjiuwen/core/single_agent/ability_manager.py` — `#33`, `#192`, `#289`, `#442`, `#443`, `#962` and `#974`. Four of them (`#33`, `#442`, `#443`, `#962`) edit the body of `AbilityManager._execute_single_tool_call`, and `#974` edits `_railed_execute_single_tool_call`, the caller that passes the keyword. None of the seven adds, removes or reorders a parameter on `_execute_single_tool_call`: `#962` changes only its return annotation, and `#442` and `#443` carry a base predating `dce36fc8`, so their copy of the method still shows the signature ending at `tag=None`. None of the seven touches `p2p_ability_manager.py`, so none fixes this defect and none is disturbed by fixing it. No open pull request on either platform touches `p2p_ability_manager.py` at all, and this change edits no file any of the seven touches — the intersection of their changed-file lists with this one's is empty, so there is no textual conflict to resolve in either merge order, and none of them should be closed on this merging.

The earlier fix to this same class, `4bff33a1`, is already present on `develop` and is not superseded here: it corrected `execute`, this corrects the sibling method it delegates to.

**What does this PR do / why do we need it**:

`P2PAbilityManager._execute_single_tool_call` is given the `callback_context` parameter its base class already passes, and forwards it when it delegates. Without it, every ability a `HierarchicalTeam` supervisor holds other than a sub-agent card fails to run: `AbilityManager._railed_execute_single_tool_call` calls the method on `self`, the override cannot bind the keyword, and the resulting `TypeError` is collected by `execute` and handed back to the model as the tool's result. The linked issue carries the mechanism, the split between the branch that breaks and the branch that does not, and a self-contained reproduction.

This is a regression in `develop` rather than a long-standing defect. `dce36fc8`, *fix(tool_search): add tool_call for unified deferred-tool execution*, added the parameter to `AbilityManager._execute_single_tool_call` and the `callback_context=ctx` keyword to the call site in `_railed_execute_single_tool_call`, and did not update the single override in the tree; it touched `ability_manager.py` but not `p2p_ability_manager.py`. No tagged release carries it — `git tag --contains dce36fc8` is empty — so the affected range is `develop` from `dce36fc8` to the current tip.

**The change is one parameter and one call, and deliberately nothing else.** The override gains `callback_context: Optional[AgentCallbackContext] = None`, matching the base's name, type and default; `Optional` and `AgentCallbackContext` were already imported in the file. The `super()` delegation passes it on. The docstring gains an `Args:` block, since the method had only a one-line summary and the new parameter needs saying.

**Forwarding, not merely accepting.** Adding the parameter and dropping it would silence the `TypeError` and introduce a quieter fault in its place. The base class consumes `callback_context` — it is what decides whether a tool declaring `accepts_tool_callback_context` receives `_tool_callback_context` in its invoke kwargs, which is the mechanism `dce36fc8` added for unified deferred-tool execution. An override that accepted and discarded it would leave supervisors unable to use deferred tools: `ToolCallTool.invoke` would find no context, catch its own `RuntimeError` and return `ToolOutput(success=False, error="tool_call requires an active agent callback context")` under a warning log. That is a narrower failure than the present one and a harder one to attribute — a failed tool result that no longer names a signature mismatch. The parameter has to reach the base implementation, so the test suite asserts the forwarding by name and not just that the call binds.

**Why the delegation now passes keywords.** The previous call was `super()._execute_single_tool_call(tool_call, session, tag)` — positional. Positional forwarding is what made the earlier instance of this same drift worse: before `4bff33a1`, this class's `execute` forwarded `tag` positionally into the slot that `parallel_tool_calls` had taken, so the override kept binding while passing the wrong value to the wrong parameter. Keywords make the next parameter added to the base a loud failure instead of a silent misbinding.

**Why `_dispatch_one` is left alone.** The `execute` override also calls `self._execute_single_tool_call(tc, session, tag)` positionally, from `_dispatch_one`. That call is not changed. It runs only for names in `self._agents`, which take the P2P branch and never consult `callback_context`, so nothing is dropped. Forwarding something there would mean forwarding `execute`'s turn-level `ctx` — but `AbilityManager.execute` deliberately builds a fresh per-tool `AgentCallbackContext` for each call, precisely to keep concurrent `BEFORE`/`AFTER_TOOL_CALL` hooks from racing. Passing the shared context instead would be a behaviour change to the P2P dispatch path, unrelated to this defect and not obviously correct.

**Scope: every subclass was checked, and only one is affected.** `AbilityManager` has two subclasses in the tree. `P2PAbilityManager` is the one that overrides `_execute_single_tool_call`, and is fixed here. `SessionMemoryAbilityManager` (`openjiuwen/core/context_engine/processor/forked/compressor/session_memory_agent.py`) overrides only `execute` and `list_tool_info`, both signature-compatible with the base and both delegating by keyword; it does not override `_execute_single_tool_call` at all and needs no change. `dce36fc8` touches twenty-two files and changes other method signatures besides this one — `ProgressiveToolRail._build_progressive_tool_rules_section` among them — but `_execute_single_tool_call` is the only changed signature that any subclass in the tree overrides, so it is the only override the commit broke. Its edit to `react_agent.py`, the only other file it touches under `openjiuwen/core/`, rewrites a docstring and a method body and adds no parameter and no call-site keyword.

**Not changed, reported instead.** Two observations from the same audit are left alone because neither is this defect: `P2PAbilityManager.execute` declares `tag` and `parallel_tool_calls` in the opposite order to the base, which is harmless today only because every caller uses keywords; and `P2PAbilityManager.__init__` does not accept or forward the base's `owner_id`, so a supervisor's manager always has `owner_id=None`. Both are worth their own look and neither belongs in a regression fix.

**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

Fourteen tests are added, in two files, and they answer two different questions. Six fail on the unmodified tip.

**The targeted regression tests** (`tests/unit_tests/multi_agent/builtin_teams/hierarchical_msgbus/test_hierarchical_msgbus.py`, new `TestP2PAbilityManagerCallbackContext`, four tests) pin this defect and this class:

- the override binds the keyword the base passes;
- the context arrives at the base implementation, asserted by name on the delegated call, which is the half that a merely-accepting fix would fail;
- the P2P branch still dispatches over `supervisor.send` when a context is supplied, so the added parameter does not disturb sub-agent delegation;
- and one end-to-end test drives the real `AbilityManager.execute` — patching only the base leaf, not `execute` — so the call travels `execute` → `_railed_execute_single_tool_call` → the override, the path that actually fails in production, and asserts the base implementation is reached rather than an `Ability execution error` being returned.

That last one exists because of *why* the suite missed this. The non-agent branch was already covered, by `TestP2PAbilityManagerExecuteNonAgent` — but both of the tests there that reach the delegation patch `AbilityManager.execute` itself, which is the exact frame the defect lives in; the third returns on an empty tool-call list before the delegation runs. The branch was tested with the breaking call mocked away. A regression test that repeated that style would have passed on the broken tree.

**The signature-compatibility guard** (`tests/unit_tests/core/single_agent/test_ability_manager_subclass_signatures.py`, new file, ten tests) is the more durable half, and is included deliberately rather than as extra. `AbilityManager` calls its own methods on `self`, so any override whose parameter list drifts becomes a run-time `TypeError` that nothing catches earlier: not the type system, not import, not review. This has now happened twice in the same subclass — `execute` in GitCode issue `#1056`, fixed by `4bff33a1`, and `_execute_single_tool_call` here — which is the argument for guarding the invariant rather than the instance. The file walks `AbilityManager.__subclasses__()` transitively and, for every overridden method, asserts the override accepts every parameter name the base declares and makes none of them positional-only; a further test binds the exact four-keyword call `_railed_execute_single_tool_call` makes against every `_execute_single_tool_call` override. It parametrizes over what it discovers, so a third subclass is covered on the day it is written, and a first test asserts the two known subclasses are actually discovered — without which the guard could pass by finding nothing.

Dunder methods are excluded, with the reason in the file: `__init__` is not called polymorphically by the base, and `P2PAbilityManager` legitimately requires a supervisor argument the base knows nothing about. Overrides taking `**kwargs` are skipped rather than failed, since every keyword binds.

**Against the unmodified source.** Reverting only `p2p_ability_manager.py` and keeping both test files, six of the fourteen fail, none at setup and none on an import:

```
FAILED tests/unit_tests/core/single_agent/test_ability_manager_subclass_signatures.py::TestAbilityManagerSubclassSignatures::test_override_accepts_every_base_parameter[P2PAbilityManager._execute_single_tool_call]
FAILED tests/unit_tests/core/single_agent/test_ability_manager_subclass_signatures.py::TestAbilityManagerSubclassSignatures::test_railed_call_binds_on_every_single_tool_call_override
FAILED tests/unit_tests/multi_agent/builtin_teams/hierarchical_msgbus/test_hierarchical_msgbus.py::TestP2PAbilityManagerCallbackContext::test_non_agent_call_accepts_callback_context_keyword
FAILED tests/unit_tests/multi_agent/builtin_teams/hierarchical_msgbus/test_hierarchical_msgbus.py::TestP2PAbilityManagerCallbackContext::test_non_agent_call_forwards_callback_context_to_super
FAILED tests/unit_tests/multi_agent/builtin_teams/hierarchical_msgbus/test_hierarchical_msgbus.py::TestP2PAbilityManagerCallbackContext::test_agent_call_still_dispatches_over_p2p_with_callback_context
FAILED tests/unit_tests/multi_agent/builtin_teams/hierarchical_msgbus/test_hierarchical_msgbus.py::TestP2PAbilityManagerCallbackContext::test_non_agent_call_reaches_base_implementation_through_execute
=================== 6 failed, 8 passed, 2 warnings in 1.24s ====================
```

Four fail with the `TypeError` reaching the test directly — the defect itself, raised either at the call or by `Signature.bind`. The other two fail on their assertions, which is the stronger evidence: the guard's parametrized case reports the mismatch it was written to detect,

```
E       AssertionError: P2PAbilityManager._execute_single_tool_call does not accept ['callback_context'], which AbilityManager._execute_single_tool_call declares. base=(self, tool_call: 'ToolCall', session: 'Session', tag=None, callback_context: 'Optional[AgentCallbackContext]' = None) -> 'Tuple[Any, ToolMessage]' override=(self, tool_call: 'ToolCall', session: 'Session', tag=None) -> 'Tuple[Any, ToolMessage]'
```

and the end-to-end one fails with the base implementation never awaited, under the captured log line the deployment would show:

```
E       AssertionError: assert 0 == 1
E        +  where 0 = <AsyncMock id='...'>.await_count
------------------------------ Captured log call -------------------------------
ERROR    common:ability_manager.py:1062 Ability execution error: P2PAbilityManager._execute_single_tool_call() got an unexpected keyword argument 'callback_context'
```

The eight that pass on both sides are load-bearing rather than filler: they are the guard's other parametrizations and its discovery check, and they establish that the guard is not failing everything indiscriminately — it distinguishes the one drifted override from the compatible ones, including `SessionMemoryAbilityManager`'s.

With the fix restored, both files pass in full together with the pre-existing `hierarchical_msgbus` suite: `83 passed`.

**The reported reproduction.** The script in the linked issue was run against both trees from the checkout root. On the unmodified tip it prints `the base class can call the override: False` and returns `Ability execution error: ... unexpected keyword argument 'callback_context'` as the tool result. On this branch it prints `the base class can call the override: True` and the call reaches the base implementation, which returns `Ability not found in resource_mgr: some_plain_tool` — the deliberate outcome for a tool the reproduction never registers.

**Full suite.** `tests/` was run in full on the tip and on this branch, one run at a time on an otherwise idle machine, and the two failure lists were compared name by name rather than by count. All 172 names — 165 failures and 7 collection errors — are identical on both sides, compared as sorted sets with no differences. Passing rises from 16938 to 16952, by exactly the fourteen tests added here; no passing test was lost and none gained by accident. The residual failures are environmental rather than a property of the code under review: this suite shares fixed-name temporary and lock paths, and `prompt_toolkit` is absent from the environment, which accounts for all seven collection errors (the four `tests/unit_tests/agent_teams/cli/` modules and the three under `tests/cli/`). Both conditions are present unchanged on the base.

**Performance.** No measurable cost. One optional parameter is bound per delegated tool call and passed on by reference; nothing is copied, allocated or computed. The P2P dispatch path is untouched.

**Reliability.** Behaviour changes in one direction only: calls that previously returned a `TypeError` string without running now run. No call that previously succeeded takes a different path — sub-agent dispatch is byte-for-byte unchanged, and the delegated call reaches the same base implementation it was always meant to reach, now with the context the base expects. No public interface changes.

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

Notes on the unticked boxes:

- **Design** — not yet reviewed by a Maintainer. The fix itself is not the part worth arguing about; the question for a maintainer is whether the signature-compatibility guard belongs in this PR. It is broader than the defect, and a maintainer who wants the regression fix landed narrowly can drop that file and keep the four targeted tests. The case for keeping it is that this drift has now happened twice in the same class and nothing in the toolchain catches it, so the third occurrence will also reach a deployment before it reaches a test.
- **Interface** — no external interface changes. `_execute_single_tool_call` is private, and the added parameter is optional with the base's default, so every existing call site — including the positional three-argument call inside this class — continues to bind unchanged. No configuration key, return type or public signature is altered, and no API annotation needs refreshing.
- **Document** — no official-website material becomes inaccurate. The published documentation does not describe this method or the supervisor's ability-execution path, and the behaviour being restored is what the documentation already implies.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #976
<!-- /bot1-related-issues -->
