### PR TITLE
test(context_evolver): cover offline L2 pairwise reflection

### DIFF
--- a/tests/unit_tests/extensions/offline_memory/test_l2.py
+++ b/tests/unit_tests/extensions/offline_memory/test_l2.py
@@ -1,0 +1,88 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Unit tests for openjiuwen.extensions.context_evolver.offline_memory.l2.reflect_pair."""
+
+from __future__ import annotations
+
+import pytest
+
+from openjiuwen.core.common.exception.errors import BaseError
+from openjiuwen.core.foundation.llm import Model, ModelClientConfig, ModelRequestConfig
+from openjiuwen.extensions.context_evolver.offline_memory.l2 import reflect_pair
+
+from tests.unit_tests.fixtures.mock_llm import create_json_response, create_text_response, mock_llm_context
+
+
+def _model() -> Model:
+    return Model(
+        ModelClientConfig(client_provider="OpenAI", api_key="mock-api-key", api_base="http://mock", verify_ssl=False),
+        ModelRequestConfig(model_name="mock-model"),
+    )
+
+
+class TestReflectPair:
+    @pytest.mark.asyncio
+    async def test_parses_valid_response(self) -> None:
+        with mock_llm_context() as mock_llm:
+            mock_llm.set_responses([
+                create_json_response({
+                    "correlation_notes": "Communicates clearly and follows up promptly.",
+                    "profile": {"reliability": "high", "strengths": ["clear communicator"]},
+                })
+            ])
+            result = await reflect_pair(
+                _model(),
+                reflecting_role="researcher",
+                partner_role="writer",
+                evidence_block="[t1] researcher -> writer: here's the draft data",
+                existing_notes="",
+            )
+        assert result.correlation_notes == "Communicates clearly and follows up promptly."
+        assert result.profile == {"reliability": "high", "strengths": ["clear communicator"]}
+
+    @pytest.mark.asyncio
+    async def test_missing_fields_default_empty(self) -> None:
+        with mock_llm_context() as mock_llm:
+            mock_llm.set_responses([create_json_response({})])
+            result = await reflect_pair(
+                _model(),
+                reflecting_role="researcher",
+                partner_role="writer",
+                evidence_block="(no direct messages found)",
+                existing_notes="",
+            )
+        assert result.correlation_notes == ""
+        assert result.profile == {}
+
+    @pytest.mark.asyncio
+    async def test_retries_then_raises_on_persistent_malformed_json(self) -> None:
+        with mock_llm_context() as mock_llm:
+            mock_llm.set_responses([create_text_response("not json") for _ in range(3)])
+            with pytest.raises(BaseError):
+                await reflect_pair(
+                    _model(),
+                    reflecting_role="researcher",
+                    partner_role="writer",
+                    evidence_block="evidence",
+                    existing_notes="",
+                    retries=3,
+                )
+        assert mock_llm.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_recovers_after_one_bad_attempt(self) -> None:
+        with mock_llm_context() as mock_llm:
+            mock_llm.set_responses([
+                create_text_response("not json"),
+                create_json_response({"correlation_notes": "ok", "profile": {}}),
+            ])
+            result = await reflect_pair(
+                _model(),
+                reflecting_role="researcher",
+                partner_role="writer",
+                evidence_block="evidence",
+                existing_notes="",
+                retries=3,
+            )
+        assert result.correlation_notes == "ok"
+        assert mock_llm.call_count == 2


### PR DESCRIPTION
Paired: [GitHub #980](https://github.com/openJiuwen-ai/agent-core/pull/980) ↔ [GitCode !2541](https://gitcode.com/openJiuwen/agent-core/merge_requests/2541)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openJiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
Choose one label from `bug`, `task`, `feature` and `refactor`, and replace `<label>` below the comment block. 

If this pr is not only bugfix/task/feature and also a refactor, you can append `/kind refactor` label after `/kind bug`, `/kind task` and `/kind feature`.
-->
/kind test


**What does this PR do / why do we need it**:
Adds unit-test coverage for the offline memory Level 2 (pairwise collaboration)
reflection path — `openjiuwen.extensions.context_evolver.offline_memory.l2.reflect_pair`.

`reflect_pair` asks an LLM to summarize how one role collaborates with a partner
role (correlation notes + a structured profile) from an evidence block of their
direct messages. Its parsing, default-filling, and retry behavior were previously
untested. This PR pins that contract down with deterministic, mocked-LLM tests so
regressions in aught in CI.

Covered cases (`TestReflectPair`):
- `test_parses_valid_response` — a well-formed JSON response is parsed into
  `correlation_notes` and `profile`.
- `test_missing_fields_default_empty` — missing fields default to `""` / `{}`
  instead of raising.
- `test_retriesalformed_json` —persistently malformed                                       JSON exhaustsraises`BaseError` (asserts exactly                                 3 LLM calls).
- `test_recovers_after_one_bad_attempt` — a bad attempt    followed by val
  recovers successfully (asserts exactly 2 LLM calls).     
All tests use the shared `mock_llm_context` fixture, so no real credential
network access are required.


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #354


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

- Function / reliability: ran the new suite locally.
  `make test TESTFLAGS="tests/unit_tests/extensions/offline_memory/test_l2.py"`
  → **4 passed** (0 failed), ~1.3s. Covers happy path, default-filling, retry
  exhaustion, and mid-retry recovery for `reflect_pair`.
- Deterministic: LLM responses are mocked via`mock_llm_context`; no external
  services involved.


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #354
<!-- /bot1-related-issues -->
