### PR TITLE
Fix hung agent loop: no-progress stop, vision fallback, outer-round cap, and skill budget

### DIFF
--- a/openjiuwen/core/single_agent/agents/react_agent.py
+++ b/openjiuwen/core/single_agent/agents/react_agent.py
@@ -1609,6 +1609,7 @@ class ReActAgent(BaseAgent):
             except Exception as exc:
                 if image_input_present and self._is_image_input_unsupported_error(exc):
                     ai_message = self._build_image_input_unsupported_message()
+                    ctx.extra["_last_image_unsupported"] = True
                 else:
                     await self._emit_context_usage(
                         ctx,
@@ -1680,6 +1681,7 @@ class ReActAgent(BaseAgent):
             if image_input_present and self._is_image_input_unsupported_error(exc):
                 ai_message = self._build_image_input_unsupported_message()
                 ctx.inputs.response = ai_message
+                ctx.extra["_last_image_unsupported"] = True
                 await self._emit_context_usage(
                     ctx,
                     context_window,
@@ -1880,8 +1882,18 @@ class ReActAgent(BaseAgent):
     def _build_image_input_unsupported_message() -> AssistantMessage:
         return AssistantMessage(
             content=(
-                "当前主模型或模型服务端点不支持图片输入，因此无法直接读取这张图片的内容。"
-                "请切换到支持视觉输入的主模型，或配置专用视觉模型工具后再读取图片。"
+                "[Vision Input Unsupported] The current model or endpoint does not support image input.\n"
+                "当前主模型或模型服务端点不支持图片输入。\n\n"
+                "Suggested alternatives / 建议替代方案：\n"
+                "1. If reading a PDF, use `read_file` in text mode or use `pypdf`/`pdfplumber` "
+                "to extract text and form fields directly, without rendering pages to images.\n"
+                "   如果读取的是 PDF，请使用文本模式读取，或用 `pypdf` 提取文本和表单字段。\n"
+                "2. If reading an image (JPG/PNG), describe what information you need and ask the "
+                "user for a text transcription, or use an available OCR tool if one is configured.\n"
+                "   如果读取的是图片，请描述所需信息并请用户提供文字转录。\n"
+                "3. If the task absolutely requires vision, configure a `vision_model_config` "
+                "with a vision-capable endpoint.\n"
+                "   如果任务必须依赖视觉，请配置支持视觉输入的模型。"
             ),
             tool_calls=[],
         )
@@ -2752,6 +2764,13 @@ class ReActAgent(BaseAgent):
                             # the loop so the next iteration
                             # drains and injects it.
                             if ctx.has_pending_steering():
+                                continue
+                            # If the only failure was an unsupported image
+                            # input, continue the loop so the model sees the
+                            # error message in context and can try a fallback.
+                            if ctx.extra.get("_last_image_unsupported"):
+                                ctx.extra["_last_image_unsupported"] = False
+                                await self.context_engine.save_contexts(session)
                                 continue
                             await self.context_engine.save_contexts(session)
                             result = {"output": ai_message.content, "result_type": "answer"}

--- a/openjiuwen/harness/deep_agent.py
+++ b/openjiuwen/harness/deep_agent.py
@@ -2618,9 +2618,24 @@ class DeepAgent(BaseAgent):
         try:
             current_query = modified.query
             outer_round = 0
+            MAX_OUTER_ROUNDS = 50
 
             while coordinator.should_continue():
                 outer_round += 1
+                if outer_round > MAX_OUTER_ROUNDS:
+                    self._log_loop(
+                        f"round={outer_round} exceeded MAX_OUTER_ROUNDS={MAX_OUTER_ROUNDS}, forcing stop"
+                    )
+                    yield {
+                        "output": (
+                            "Task loop stopped after exceeding the maximum number of "
+                            f"outer rounds ({MAX_OUTER_ROUNDS}). This usually indicates "
+                            "the model is not making observable progress."
+                        ),
+                        "result_type": "error",
+                        "stop_reason": "MaxOuterRounds",
+                    }
+                    break
                 # Drain new follow-ups, merge into state buffer
                 new_follow_ups = controller.drain_follow_up()
                 _state = self.load_state(session)
@@ -2706,6 +2721,8 @@ class DeepAgent(BaseAgent):
                         "result_type": "error",
                         "stop_reason": stop_reason,
                     }
+                # Note: MaxOuterRounds yields its own error result inside the loop,
+                # so no additional yield is needed here.
         finally:
             # Clear stop_condition_state so the next invoke starts fresh.
             _state = self.load_state(session)

--- a/openjiuwen/harness/deep_agent.py
+++ b/openjiuwen/harness/deep_agent.py
@@ -69,6 +69,10 @@ from openjiuwen.harness.rails.task_completion_rail import (
     TaskCompletionRail,
 )
 from openjiuwen.harness.schema.config import DeepAgentConfig
+from openjiuwen.harness.schema.stop_condition import (
+    NoProgressAnswerEvaluator,
+    StopConditionEvaluator,
+)
 from openjiuwen.harness.schema.state import (
     _SESSION_RUNTIME_ATTR,
     _SESSION_STATE_KEY,
@@ -2229,6 +2233,46 @@ class DeepAgent(BaseAgent):
             session,
         )
 
+    def _build_task_loop_evaluators(self) -> List[StopConditionEvaluator]:
+        """Build stop evaluators for the outer task loop."""
+        evaluators = (
+            self._task_completion_rail.build_evaluators()
+            if self._task_completion_rail is not None
+            else []
+        )
+        guard_cfg = (
+            self._deep_config.task_loop_no_progress_guard
+            if self._deep_config is not None
+            else None
+        )
+        if isinstance(guard_cfg, dict):
+            guard_enabled = bool(guard_cfg.get("enabled", False))
+            max_consecutive_empty_answers = guard_cfg.get(
+                "max_consecutive_empty_answers",
+                3,
+            )
+            min_answer_chars = guard_cfg.get("min_answer_chars", 80)
+        else:
+            guard_enabled = bool(getattr(guard_cfg, "enabled", False))
+            max_consecutive_empty_answers = getattr(
+                guard_cfg,
+                "max_consecutive_empty_answers",
+                3,
+            )
+            min_answer_chars = getattr(
+                guard_cfg,
+                "min_answer_chars",
+                80,
+            )
+        if guard_enabled:
+            evaluators.append(
+                NoProgressAnswerEvaluator(
+                    max_consecutive_empty_answers=max_consecutive_empty_answers,
+                    min_answer_chars=min_answer_chars,
+                )
+            )
+        return evaluators
+
     async def _setup_task_loop(
         self,
         session: Session,
@@ -2253,11 +2297,7 @@ class DeepAgent(BaseAgent):
         ):
             coordinator = self._loop_coordinator
             if coordinator is None:
-                evaluators = (
-                    self._task_completion_rail.build_evaluators()
-                    if self._task_completion_rail is not None
-                    else []
-                )
+                evaluators = self._build_task_loop_evaluators()
                 coordinator = LoopCoordinator(evaluators=evaluators)
                 self._loop_coordinator = coordinator
             coordinator.reset()
@@ -2267,11 +2307,7 @@ class DeepAgent(BaseAgent):
         if self._loop_controller is not None:
             await self._force_cleanup_controller()
 
-        evaluators = (
-            self._task_completion_rail.build_evaluators()
-            if self._task_completion_rail is not None
-            else []
-        )
+        evaluators = self._build_task_loop_evaluators()
         coordinator = LoopCoordinator(evaluators=evaluators)
         coordinator.reset()
 
@@ -2660,6 +2696,16 @@ class DeepAgent(BaseAgent):
                 self._log_loop(
                     f"loop stopped by: {stop_reason}"
                 )
+                if stop_reason == "NoProgressAnswerEvaluator":
+                    yield {
+                        "output": (
+                            "Task loop stopped after repeated empty or "
+                            "near-empty no-tool answers. This indicates "
+                            "the model is not making observable progress."
+                        ),
+                        "result_type": "error",
+                        "stop_reason": stop_reason,
+                    }
         finally:
             # Clear stop_condition_state so the next invoke starts fresh.
             _state = self.load_state(session)

--- a/openjiuwen/harness/deep_agent.py
+++ b/openjiuwen/harness/deep_agent.py
@@ -2618,18 +2618,18 @@ class DeepAgent(BaseAgent):
         try:
             current_query = modified.query
             outer_round = 0
-            MAX_OUTER_ROUNDS = 50
+            max_outer_rounds = 50
 
             while coordinator.should_continue():
                 outer_round += 1
-                if outer_round > MAX_OUTER_ROUNDS:
+                if outer_round > max_outer_rounds:
                     self._log_loop(
-                        f"round={outer_round} exceeded MAX_OUTER_ROUNDS={MAX_OUTER_ROUNDS}, forcing stop"
+                        f"round={outer_round} exceeded max_outer_rounds={max_outer_rounds}, forcing stop"
                     )
                     yield {
                         "output": (
                             "Task loop stopped after exceeding the maximum number of "
-                            f"outer rounds ({MAX_OUTER_ROUNDS}). This usually indicates "
+                            f"outer rounds ({max_outer_rounds}). This usually indicates "
                             "the model is not making observable progress."
                         ),
                         "result_type": "error",

--- a/openjiuwen/harness/factory.py
+++ b/openjiuwen/harness/factory.py
@@ -385,6 +385,8 @@ def resolve_deep_agent_parts(
             skill_mode="all",
             disabled_skills=disabled_skills or None,
             include_tools=include_tools,
+            max_skills=config.skill_budget_max_skills,
+            max_total_chars=config.skill_budget_max_total_chars,
         )
 
     def _make_task_planning_rail() -> TaskPlanningRail:

--- a/openjiuwen/harness/rails/skills/skill_use_rail.py
+++ b/openjiuwen/harness/rails/skills/skill_use_rail.py
@@ -63,6 +63,8 @@ class SkillUseRail(DeepAgentRail):
         disabled_skills: Optional[Union[str, List[str]]] = None,
         evolution_store: Optional[EvolutionStore] = None,
         multimodal_skill_mode: str = "hint",
+        max_skills: Optional[int] = None,
+        max_total_chars: Optional[int] = None,
     ):
         """Initialize SkillUseRail.
 
@@ -78,6 +80,10 @@ class SkillUseRail(DeepAgentRail):
             disabled_skills: Optional deny-list of skill names. Supports str or List[str].
             evolution_store: Optional EvolutionStore for progressive disclosure experience text.
             multimodal_skill_mode: ``hint`` (default), ``attach``, or ``branch``.
+            max_skills: Optional hard cap on the number of skills injected in ``all`` mode.
+            max_total_chars: Optional soft cap on total skill description chars in ``all`` mode.
+                When exceeded, skills are ranked by keyword overlap with the query and low-ranked
+                whole skills are dropped (gentle truncation — never mid-text).
         """
         super().__init__()
 
@@ -96,6 +102,8 @@ class SkillUseRail(DeepAgentRail):
         self.disabled_skills = self._normalize_name_set(disabled_skills)
         self.evolution_store: Optional[EvolutionStore] = evolution_store
         self.multimodal_skill_mode = multimodal_skill_mode
+        self.max_skills = max_skills
+        self.max_total_chars = max_total_chars
 
         self.skills: List[Skill] = []
         self.system_prompt_builder = None
@@ -442,7 +450,8 @@ class SkillUseRail(DeepAgentRail):
             else list(self.skills)
         )
         await self._fetch_evolution_texts([*baseline_skills, *self.skills])
-        skills_section = self._build_skills_section(baseline_skills)
+        query = self._extract_query_from_messages(ctx)
+        skills_section = self._build_skills_section(baseline_skills, query=query)
         if skills_section is not None:
             self.system_prompt_builder.add_section(skills_section)
         else:
@@ -479,10 +488,16 @@ class SkillUseRail(DeepAgentRail):
 
         return tuple(entries)
 
-    def _build_skills_section(self, skills: Optional[List[Skill]] = None):
-        """Build the stable system prompt section from session baseline skills."""
+    def _build_skills_section(self, skills: Optional[List[Skill]] = None, query: Optional[str] = None):
+        """Build the stable system prompt section from session baseline skills.
+
+        Args:
+            skills: Optional skill list override. Defaults to self.skills.
+            query: Optional task query for budget-based ranking.
+        """
         skills = self.skills if skills is None else skills
         if self.skill_mode == self.SKILL_MODE_ALL:
+            skills = self._apply_skill_budget(skills, query)
             body_lines: List[str] = []
             for idx, skill in enumerate(skills):
                 body_lines.append(
@@ -505,6 +520,111 @@ class SkillUseRail(DeepAgentRail):
                 language=self.system_prompt_builder.language,
                 mode="auto_list",
             )
+
+    def _apply_skill_budget(
+        self,
+        skills: List[Skill],
+        query: Optional[str] = None,
+    ) -> List[Skill]:
+        """Rank skills by query relevance and drop low-ranked ones to stay under budget.
+
+        This implements *gentle truncation*: whole skills are dropped,
+        never mid-description.
+
+        Args:
+            skills: Full list of skills to consider.
+            query: Optional task query for relevance scoring.
+
+        Returns:
+            Filtered skill list within budget constraints.
+        """
+        if not skills:
+            return skills
+        if self.max_skills is None and self.max_total_chars is None:
+            return skills
+
+        # Score skills by keyword overlap with query (or description length as fallback)
+        if query:
+            keywords = self._extract_keywords(query)
+            scored = []
+            for skill in skills:
+                text = f"{skill.name} {skill.description}".lower()
+                score = sum(1 for kw in keywords if kw in text)
+                scored.append((score, skill))
+            scored.sort(key=lambda x: (-x[0], x[1].name))
+            ranked = [s for _, s in scored]
+        else:
+            # Without a query, preserve original order (assumed pre-sorted by importance)
+            ranked = list(skills)
+
+        # Apply hard skill count cap
+        if self.max_skills is not None and len(ranked) > self.max_skills:
+            dropped = ranked[self.max_skills:]
+            ranked = ranked[:self.max_skills]
+            logger.info(
+                "[SkillUseRail] Dropped %d skills due to max_skills=%d: %s",
+                len(dropped),
+                self.max_skills,
+                ", ".join(s.name for s in dropped),
+            )
+
+        # Apply soft char cap by dropping lowest-ranked whole skills
+        if self.max_total_chars is not None:
+            total_chars = sum(len(s.description or "") for s in ranked)
+            while ranked and total_chars > self.max_total_chars:
+                dropped_skill = ranked.pop()
+                total_chars -= len(dropped_skill.description or "")
+                logger.info(
+                    "[SkillUseRail] Dropped skill '%s' to stay under max_total_chars=%d "
+                    "(remaining chars=%d)",
+                    dropped_skill.name,
+                    self.max_total_chars,
+                    total_chars,
+                )
+
+        return ranked
+
+    _STOP_WORDS: Set[str] = frozenset({
+        "the", "a", "an", "is", "are", "was", "were", "be", "been", "being",
+        "to", "of", "and", "or", "in", "on", "at", "by", "for", "with", "as",
+        "this", "that", "these", "those", "it", "its", "from", "have", "has",
+        "had", "do", "does", "did", "will", "would", "could", "should", "may",
+        "might", "can", "shall", "you", "your", "we", "our", "i", "my", "he",
+        "she", "they", "them", "their", "what", "which", "who", "when", "where",
+        "why", "how", "all", "each", "every", "both", "few", "more", "most",
+        "other", "some", "such", "no", "nor", "not", "only", "own", "same", "so",
+    })
+
+    @classmethod
+    def _extract_keywords(cls, text: str) -> Set[str]:
+        """Extract lowercase alphanumeric keywords from text, removing stop words."""
+        words = set()
+        for token in text.lower().split():
+            token = "".join(c for c in token if c.isalnum())
+            if token and token not in cls._STOP_WORDS and len(token) > 2:
+                words.add(token)
+        return words
+
+    @staticmethod
+    def _extract_query_from_messages(ctx: AgentCallbackContext) -> Optional[str]:
+        """Extract the latest user query from context messages for skill ranking.
+
+        Looks at the last few messages and returns the content of the most
+        recent UserMessage, or None if no user messages are found.
+        """
+        messages = getattr(ctx.inputs, "messages", None)
+        if not messages:
+            return None
+        try:
+            from openjiuwen.core.foundation.llm.schema.message import UserMessage
+            for message in reversed(messages):
+                if isinstance(message, UserMessage):
+                    content = getattr(message, "content", None)
+                    if isinstance(content, str) and content.strip():
+                        return content.strip()
+        except Exception:
+            pass
+        return None
 
     def get_skills_for_session(self, session: Any = None) -> List[Skill]:
         """Return the current skill view for a tool invocation.

--- a/openjiuwen/harness/rails/skills/skill_use_rail.py
+++ b/openjiuwen/harness/rails/skills/skill_use_rail.py
@@ -11,6 +11,7 @@ import yaml
 
 from openjiuwen.core.common.logging import logger
 from openjiuwen.core.foundation.llm.model import Model
+from openjiuwen.core.foundation.llm.schema.message import UserMessage
 from openjiuwen.core.foundation.tool.base import ToolCard
 from openjiuwen.core.single_agent.rail.base import AgentCallbackContext
 from openjiuwen.core.single_agent.skills.skill_manager import Skill
@@ -615,15 +616,11 @@ class SkillUseRail(DeepAgentRail):
         messages = getattr(ctx.inputs, "messages", None)
         if not messages:
             return None
-        try:
-            from openjiuwen.core.foundation.llm.schema.message import UserMessage
-            for message in reversed(messages):
-                if isinstance(message, UserMessage):
-                    content = getattr(message, "content", None)
-                    if isinstance(content, str) and content.strip():
-                        return content.strip()
-        except Exception:
-            pass
+        for message in reversed(messages):
+            if isinstance(message, UserMessage):
+                content = getattr(message, "content", None)
+                if isinstance(content, str) and content.strip():
+                    return content.strip()
         return None
 
     def get_skills_for_session(self, session: Any = None) -> List[Skill]:

--- a/openjiuwen/harness/rails/skills/skill_use_rail.py
+++ b/openjiuwen/harness/rails/skills/skill_use_rail.py
@@ -84,7 +84,9 @@ class SkillUseRail(DeepAgentRail):
             max_skills: Optional hard cap on the number of skills injected in ``all`` mode.
             max_total_chars: Optional soft cap on total skill description chars in ``all`` mode.
                 When exceeded, skills are ranked by keyword overlap with the query and low-ranked
-                whole skills are dropped (gentle truncation — never mid-text).
+                whole skills are dropped (gentle truncation — never mid-text). The cap is soft:
+                the single highest-ranked skill is always retained, even when it alone exceeds
+                the limit.
         """
         super().__init__()
 
@@ -530,7 +532,10 @@ class SkillUseRail(DeepAgentRail):
         """Rank skills by query relevance and drop low-ranked ones to stay under budget.
 
         This implements *gentle truncation*: whole skills are dropped,
-        never mid-description.
+        never mid-description. ``max_total_chars`` is a soft cap — the
+        highest-ranked skill is always retained, even when it alone exceeds
+        the limit, so callers never get an empty list back from a non-empty
+        input.
 
         Args:
             skills: Full list of skills to consider.
@@ -569,16 +574,26 @@ class SkillUseRail(DeepAgentRail):
                 ", ".join(s.name for s in dropped),
             )
 
-        # Apply soft char cap by dropping lowest-ranked whole skills
+        # Apply soft char cap by dropping lowest-ranked whole skills.
+        # The cap is soft: the highest-ranked skill is always retained, even if it
+        # alone exceeds max_total_chars, so the model never sees an empty skill list.
         if self.max_total_chars is not None:
             total_chars = sum(len(s.description or "") for s in ranked)
-            while ranked and total_chars > self.max_total_chars:
+            while len(ranked) > 1 and total_chars > self.max_total_chars:
                 dropped_skill = ranked.pop()
                 total_chars -= len(dropped_skill.description or "")
                 logger.info(
                     "[SkillUseRail] Dropped skill '%s' to stay under max_total_chars=%d "
                     "(remaining chars=%d)",
                     dropped_skill.name,
+                    self.max_total_chars,
+                    total_chars,
+                )
+            if ranked and total_chars > self.max_total_chars:
+                logger.warning(
+                    "[SkillUseRail] Skill '%s' alone exceeds max_total_chars=%d "
+                    "(%d chars); keeping it so the skills section is never empty",
+                    ranked[0].name,
                     self.max_total_chars,
                     total_chars,
                 )

--- a/openjiuwen/harness/schema/__init__.py
+++ b/openjiuwen/harness/schema/__init__.py
@@ -7,6 +7,7 @@ from openjiuwen.harness.schema.config import (
     AudioModelConfig,
     DeepAgentConfig,
     SubAgentConfig,
+    TaskLoopNoProgressGuardConfig,
     VisionModelConfig,
     is_vision_model_config_complete,
 )
@@ -31,6 +32,7 @@ from openjiuwen.harness.schema.task import (
 __all__ = [
     "AgentMode",
     "DeepAgentConfig",
+    "TaskLoopNoProgressGuardConfig",
     "AudioModelConfig",
     "VisionModelConfig",
     "is_vision_model_config_complete",

--- a/openjiuwen/harness/schema/config.py
+++ b/openjiuwen/harness/schema/config.py
@@ -161,6 +161,15 @@ class AudioModelConfig:
 
 
 @dataclass
+class TaskLoopNoProgressGuardConfig:
+    """Guard repeated empty/near-empty no-tool answers in task-loop mode."""
+
+    enabled: bool = True
+    max_consecutive_empty_answers: int = 3
+    min_answer_chars: int = 80
+
+
+@dataclass
 class DeepAgentConfig:
     """Runtime configuration for DeepAgent.
 
@@ -285,6 +294,10 @@ class DeepAgentConfig:
     # Subagents inherit the stricter of their own spec and this value.
     restrict_to_work_dir: bool = True
 
+    # Task-loop no-progress guard: stop repeated short answer rounds.
+    task_loop_no_progress_guard: TaskLoopNoProgressGuardConfig = field(
+        default_factory=lambda: TaskLoopNoProgressGuardConfig()
+    )
 
 @dataclass
 class SubAgentConfig:

--- a/openjiuwen/harness/schema/config.py
+++ b/openjiuwen/harness/schema/config.py
@@ -302,6 +302,8 @@ class DeepAgentConfig:
     # Skill budget: gently truncate skill prompts by dropping whole low-ranked skills.
     skill_budget_max_skills: Optional[int] = None
     skill_budget_max_total_chars: Optional[int] = None
+
+
 @dataclass
 class SubAgentConfig:
     """Configuration for a DeepAgent sub-agent."""

--- a/openjiuwen/harness/schema/config.py
+++ b/openjiuwen/harness/schema/config.py
@@ -166,7 +166,7 @@ class TaskLoopNoProgressGuardConfig:
 
     enabled: bool = True
     max_consecutive_empty_answers: int = 3
-    min_answer_chars: int = 80
+    min_answer_chars: int = 20
 
 
 @dataclass
@@ -299,6 +299,9 @@ class DeepAgentConfig:
         default_factory=lambda: TaskLoopNoProgressGuardConfig()
     )
 
+    # Skill budget: gently truncate skill prompts by dropping whole low-ranked skills.
+    skill_budget_max_skills: Optional[int] = None
+    skill_budget_max_total_chars: Optional[int] = None
 @dataclass
 class SubAgentConfig:
     """Configuration for a DeepAgent sub-agent."""

--- a/openjiuwen/harness/schema/stop_condition.py
+++ b/openjiuwen/harness/schema/stop_condition.py
@@ -3,6 +3,7 @@
 """Stop condition definitions for DeepAgent task loop."""
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import (
@@ -11,6 +12,8 @@ from typing import (
     Dict,
     Optional,
 )
+
+logger = logging.getLogger(__name__)
 
 
 # ================================================================
@@ -136,6 +139,69 @@ class TimeoutEvaluator(StopConditionEvaluator):
         return ctx.elapsed_seconds >= self._timeout_seconds
 
 
+class NoProgressAnswerEvaluator(StopConditionEvaluator):
+    """Stop after repeated no-tool answers with little or no content."""
+
+    def __init__(
+        self,
+        *,
+        max_consecutive_empty_answers: int = 3,
+        min_answer_chars: int = 80,
+    ) -> None:
+        self._max_consecutive_empty_answers = max(
+            1,
+            int(max_consecutive_empty_answers),
+        )
+        self._min_answer_chars = max(0, int(min_answer_chars))
+        self._consecutive_empty_answers = 0
+
+    def should_stop(self, ctx: StopEvaluationContext) -> bool:
+        """Return True once repeated short answers indicate no progress."""
+        result = ctx.last_result or {}
+        result_type = str(result.get("result_type", "")).strip().lower()
+        output_len = len(str(result.get("output", "")).strip())
+
+        if result_type == "answer" and output_len < self._min_answer_chars:
+            self._consecutive_empty_answers += 1
+        else:
+            self._consecutive_empty_answers = 0
+
+        if (
+            self._consecutive_empty_answers
+            >= self._max_consecutive_empty_answers
+        ):
+            logger.info(
+                "No progress answer guard triggered: "
+                "round=%s, output_len=%s, "
+                "consecutive_empty_answers=%s, "
+                "max_consecutive_empty_answers=%s, "
+                "min_answer_chars=%s",
+                ctx.iteration,
+                output_len,
+                self._consecutive_empty_answers,
+                self._max_consecutive_empty_answers,
+                self._min_answer_chars,
+            )
+            return True
+        return False
+
+    def reset(self) -> None:
+        self._consecutive_empty_answers = 0
+
+    def get_state(self) -> Optional[Dict[str, Any]]:
+        return {
+            "consecutive_empty_answers": self._consecutive_empty_answers,
+            "max_consecutive_empty_answers": self._max_consecutive_empty_answers,
+            "min_answer_chars": self._min_answer_chars,
+        }
+
+    def load_state(self, data: Dict[str, Any]) -> None:
+        self._consecutive_empty_answers = max(
+            0,
+            int(data.get("consecutive_empty_answers", 0) or 0),
+        )
+
+
 class CompletionPromiseEvaluator(StopConditionEvaluator):
     """Stop when a completion promise has been fulfilled.
 
@@ -251,6 +317,7 @@ __all__ = [
     "MaxRoundsEvaluator",
     "TokenBudgetEvaluator",
     "TimeoutEvaluator",
+    "NoProgressAnswerEvaluator",
     "CompletionPromiseEvaluator",
     "CustomPredicateEvaluator",
 ]

--- a/tests/unit_tests/harness/test_loop_coordinator.py
+++ b/tests/unit_tests/harness/test_loop_coordinator.py
@@ -9,6 +9,7 @@ from openjiuwen.harness.task_loop.loop_coordinator import (
 from openjiuwen.harness.schema.stop_condition import (
     CustomPredicateEvaluator,
     MaxRoundsEvaluator,
+    NoProgressAnswerEvaluator,
     TimeoutEvaluator,
     TokenBudgetEvaluator,
 )
@@ -116,4 +117,56 @@ def test_negative_tokens_ignored() -> None:
     coord.reset()
     coord.add_token_usage(-50)
     coord.add_token_usage(0)
+    assert coord.should_continue() is True
+
+
+def test_no_progress_answer_evaluator_stops_after_short_answers() -> None:
+    """Repeated short answer results stop task-loop mode."""
+    coord = LoopCoordinator(
+        evaluators=[
+            NoProgressAnswerEvaluator(
+                max_consecutive_empty_answers=3,
+                min_answer_chars=80,
+            )
+        ]
+    )
+    coord.reset()
+
+    for _ in range(2):
+        coord.set_last_result({"output": "", "result_type": "answer"})
+        coord.increment_iteration()
+        assert coord.should_continue() is True
+
+    coord.set_last_result({"output": "still stuck", "result_type": "answer"})
+    coord.increment_iteration()
+
+    assert coord.should_continue() is False
+    assert coord.stop_reason == "NoProgressAnswerEvaluator"
+
+
+def test_no_progress_answer_evaluator_allows_meaningful_answer() -> None:
+    """Meaningful no-tool final answers are not treated as no-progress."""
+    coord = LoopCoordinator(
+        evaluators=[
+            NoProgressAnswerEvaluator(
+                max_consecutive_empty_answers=2,
+                min_answer_chars=20,
+            )
+        ]
+    )
+    coord.reset()
+
+    coord.set_last_result({"output": "", "result_type": "answer"})
+    coord.increment_iteration()
+    assert coord.should_continue() is True
+
+    coord.set_last_result({
+        "output": "This is enough content to count as progress.",
+        "result_type": "answer",
+    })
+    coord.increment_iteration()
+    assert coord.should_continue() is True
+
+    coord.set_last_result({"output": "", "result_type": "answer"})
+    coord.increment_iteration()
     assert coord.should_continue() is True

--- a/tests/unit_tests/harness/test_skill_rail.py
+++ b/tests/unit_tests/harness/test_skill_rail.py
@@ -1068,3 +1068,69 @@ async def test_skill_rail_multi_dir_with_missing_dirs(tmp_path: Path):
     await skill_rail.before_invoke(ctx)
 
     assert _sorted_skill_names(skill_rail.skills) == ["skill-a", "skill-c"]
+
+
+def test_skill_use_rail_apply_skill_budget_no_budget():
+    """When no budget is set, all skills are returned unchanged."""
+    rail = SkillUseRail(skills_dir="./", skill_mode="all", include_tools=False)
+    skills = [
+        _MockSkill(name="alpha", description="Alpha does alpha things."),
+        _MockSkill(name="beta", description="Beta handles beta tasks."),
+    ]
+    result = rail._apply_skill_budget(skills, query="do alpha")
+    assert [s.name for s in result] == ["alpha", "beta"]
+
+
+def test_skill_use_rail_apply_skill_budget_max_skills():
+    """max_skills drops lowest-ranked whole skills."""
+    rail = SkillUseRail(
+        skills_dir="./", skill_mode="all", include_tools=False, max_skills=2
+    )
+    skills = [
+        _MockSkill(name="alpha", description="Alpha does alpha things."),
+        _MockSkill(name="beta", description="Beta handles beta tasks."),
+        _MockSkill(name="gamma", description="Gamma is for gamma work."),
+    ]
+    result = rail._apply_skill_budget(skills, query="alpha tasks")
+    assert len(result) == 2
+    assert result[0].name == "alpha"  # highest keyword overlap
+
+
+def test_skill_use_rail_apply_skill_budget_max_total_chars():
+    """max_total_chars drops lowest-ranked whole skills until under budget."""
+    rail = SkillUseRail(
+        skills_dir="./",
+        skill_mode="all",
+        include_tools=False,
+        max_total_chars=50,
+    )
+    skills = [
+        _MockSkill(name="alpha", description="Short."),
+        _MockSkill(name="beta", description="This is a much longer description that exceeds budget."),
+    ]
+    result = rail._apply_skill_budget(skills, query="beta")
+    # beta ranks higher (query match), but total chars might still exceed 50
+    # if so, alpha gets dropped first (lower rank), then beta if still over
+    total = sum(len(s.description) for s in result)
+    assert total <= 50
+
+
+def test_skill_use_rail_extract_keywords():
+    """Keyword extraction removes stop words and short tokens."""
+    text = "The quick brown fox does something with Python code."
+    keywords = SkillUseRail._extract_keywords(text)
+    assert "quick" in keywords
+    assert "brown" in keywords
+    assert "fox" in keywords
+    assert "python" in keywords
+    assert "code" in keywords
+    assert "the" not in keywords  # stop word
+    assert "does" not in keywords  # stop word
+
+
+class _MockSkill:
+    """Minimal mock for Skill objects in budget tests."""
+
+    def __init__(self, name: str, description: str):
+        self.name = name
+        self.description = description

--- a/tests/unit_tests/harness/test_skill_rail.py
+++ b/tests/unit_tests/harness/test_skill_rail.py
@@ -1097,7 +1097,8 @@ def test_skill_use_rail_apply_skill_budget_max_skills():
 
 
 def test_skill_use_rail_apply_skill_budget_max_total_chars():
-    """max_total_chars drops lowest-ranked whole skills until under budget."""
+    """max_total_chars is a soft cap: when the single highest-ranked skill alone
+    exceeds the budget, it is still retained (never an empty skill list)."""
     rail = SkillUseRail(
         skills_dir="./",
         skill_mode="all",
@@ -1109,8 +1110,29 @@ def test_skill_use_rail_apply_skill_budget_max_total_chars():
         _MockSkill(name="beta", description="This is a much longer description that exceeds budget."),
     ]
     result = rail._apply_skill_budget(skills, query="beta")
-    # beta ranks higher (query match), but total chars might still exceed 50
-    # if so, alpha gets dropped first (lower rank), then beta if still over
+    # beta ranks highest (query match) and alone exceeds the 50-char budget;
+    # dropping it too would leave the model with no skills at all.
+    assert result, "highest-ranked skill must be retained even when over budget"
+    assert [s.name for s in result] == ["beta"]
+
+
+def test_skill_use_rail_apply_skill_budget_max_total_chars_drops_low_ranked():
+    """max_total_chars drops whole lowest-ranked skills until back under budget."""
+    rail = SkillUseRail(
+        skills_dir="./",
+        skill_mode="all",
+        include_tools=False,
+        max_total_chars=50,
+    )
+    skills = [
+        _MockSkill(name="alpha", description="Short."),
+        _MockSkill(name="beta", description="Beta handles beta tasks."),
+        _MockSkill(name="gamma", description="Gamma is for gamma work."),
+    ]
+    result = rail._apply_skill_budget(skills, query="beta")
+    # beta ranks highest; gamma ties with alpha at the bottom and is dropped
+    # first, leaving beta + alpha comfortably under budget.
+    assert [s.name for s in result] == ["beta", "alpha"]
     total = sum(len(s.description) for s in result)
     assert total <= 50
 


### PR DESCRIPTION
Paired: [GitHub #1027](https://github.com/openJiuwen-ai/agent-core/pull/1027) ↔ [GitCode !2571](https://gitcode.com/openJiuwen/agent-core/merge_requests/2571)

Closes #1026

## Summary

The agent task loop can hang in several scenarios: it keeps looping on empty/near-empty answers, breaks prematurely on unsupported image input, and has no hard cap on outer rounds. This change adds safeguards to prevent hung agent loops and makes skill prompt injection budget-aware.

## Changes

### 1. Stop task loop on repeated empty answers
- New `NoProgressAnswerEvaluator` stop condition in `openjiuwen/harness/schema/stop_condition.py`.
- New `TaskLoopNoProgressGuardConfig` (enabled by default; `max_consecutive_empty_answers=3`, `min_answer_chars=20`) wired through `DeepAgentConfig` and exported from `openjiuwen/harness/schema`.
- `DeepAgent` builds task-loop evaluators via `_build_task_loop_evaluators()` and yields an explicit error result when the guard triggers.

### 2. Vision fallback instead of hard break
- `ReActAgent` tracks `_last_image_unsupported` in `ctx.extra` and continues the loop when the only failure was an unsupported image input, so the model sees the error and can try a fallback.
- Replaced the single Chinese vision error with an actionable bilingual message suggesting text-mode PDF read (`pypdf`/`pdfplumber`), OCR, or `vision_model_config`.

### 3. Outer-round hard cap
- `DeepAgent._run_task_loop` enforces `MAX_OUTER_ROUNDS = 50`, yielding an error result when exceeded.

### 4. Gentle skill budget
- `SkillUseRail` accepts optional `max_skills` / `max_total_chars`; `_apply_skill_budget()` ranks skills by keyword overlap with the current query and drops whole low-ranked skills (never mid-text).
- New `skill_budget_max_skills` / `skill_budget_max_total_chars` config fields wired through `factory.py`.

## Tests
- `tests/unit_tests/harness/test_loop_coordinator.py`: loop coordinator no-progress cases.
- `tests/unit_tests/harness/test_skill_rail.py`: skill budget + keyword extraction.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #1026
<!-- /bot1-related-issues -->
