### PR TITLE
fix(mcp): correct typos in openapi_client log message and private parameter

### DIFF
--- a/openjiuwen/core/foundation/tool/mcp/client/openapi_client.py
+++ b/openjiuwen/core/foundation/tool/mcp/client/openapi_client.py
@@ -104,7 +104,7 @@ class OpenApiClient(McpClient):
         else:
             new_name = f"{name}_{self._used_names[name]}"
             logger.debug(
-                f"tool_ame collision: '{name}' already used,using '{new_name}' instead. "
+                f"tool_name collision: '{name}' already used, using '{new_name}' instead. "
             )
 
         return new_name
@@ -114,7 +114,7 @@ class OpenApiClient(McpClient):
             http_route: "HTTPRoute",
             original_name: str,
             http_tags: set[str],
-            timout: float,
+            timeout: float,
     ):
         from fastmcp.utilities.openapi import (
             extract_output_schema_from_responses,
@@ -148,7 +148,7 @@ class OpenApiClient(McpClient):
             parameters=http_route.flat_param_schema,
             output_schema=output_schema,
             tags=set(http_route.tags or []) | http_tags,
-            timeout=timout,
+            timeout=timeout,
         )
 
         # add tool to tool_manager


### PR DESCRIPTION
Paired: [GitHub #1040](https://github.com/openJiuwen-ai/agent-core/pull/1040) ↔ [GitCode !2583](https://gitcode.com/openJiuwen/agent-core/merge_requests/2583)

## 问题 / Problem

`openjiuwen/core/foundation/tool/mcp/client/openapi_client.py` 有两处拼写错误：

1. **私有方法参数名拼错**：`_create_openapi_tool(..., timout: float)` —— `timout` 应为 `timeout`，而它下一行就要赋值给 `OpenAPITool(timeout=...)`，读起来极易误认为是另一个不同含义的参数。
2. **日志文案拼写错误 + 缺空格**：`"tool_ame collision: ... already used,using ..."` —— `tool_ame` 应为 `tool_name`，`used,using` 逗号后缺空格。这条 debug 日志正是排查工具名冲突时会读的那一行。

## 为什么安全 / Why this is safe

`_create_openapi_tool` 是私有方法（下划线前缀），全仓库唯一调用点以**位置参数**传入：

```python
# openapi_client.py:183
self._create_openapi_tool(route, tool_name, tool_tags, timeout)
```

因此重命名参数不影响任何调用方，也不改变运行时行为：`OpenAPITool(timeout=...)` 这个关键字参数名本来就写对了，错的只是本地变量名。

The renamed parameter is on a private method whose only call site passes it positionally, so there is no API or behaviour impact.

## 验证 / Verification

```bash
python -m py_compile openjiuwen/core/foundation/tool/mcp/client/openapi_client.py   # OK
grep -rn 'timout\|tool_ame' .                                                       # 0 matches（修复后全仓库无残留）
```

改动 `+3 / -3`，仅涉及一处参数名与一条日志文案。Diff is `+3 / -3`: one parameter name and one log string.
