### PR TITLE
fix(symphony): keep beam states that leave the frontier

### DIFF
--- a/openjiuwen/symphony/orchestration/planning/beam.py
+++ b/openjiuwen/symphony/orchestration/planning/beam.py
@@ -412,7 +412,13 @@ class BidirectionalBeamPlanner:
                 round_index = _round + 1
                 break
             retained = self._rank_and_trim(next_states, limit=self.top_k)
-            all_states = retained
+            # `frontier` drives expansion; `all_states` is what the final merge sees.
+            # Rebinding it here dropped every state retained in an earlier round that
+            # later fell out of the top-k - including terminal states, which can never
+            # be re-derived because `_apply_judgements` only emits extensions. Keep a
+            # monotone archive instead. Only retained states are archived, so it is
+            # bounded by len(seeds) + top_k * (max_depth - 1).
+            all_states = self._dedupe_states([*all_states, *retained])
             frontier = retained
             round_index = _round + 1
             await self._emit_beam_event(
@@ -421,7 +427,7 @@ class BidirectionalBeamPlanner:
                 graph=self._beam_graph.snapshot(),
             )
 
-        final_states = self._merge_converged_states(all_states)
+        final_states = self._merge_converged_states(self._drop_subsumed_states(all_states))
         plans = self._plans_from_states(final_states)[: self.top_k]
         recommended_plans = [self._plan_payload(plan, query=query) for plan in plans]
         final_rerank = await self._final_rerank_plans(
@@ -1222,6 +1228,25 @@ class BidirectionalBeamPlanner:
             if existing is None or self._state_score(state) > self._state_score(existing):
                 deduped[key] = state
         return list(deduped.values())
+
+    @staticmethod
+    def _drop_subsumed_states(states: list[BeamState]) -> list[BeamState]:
+        """Drop states whose edges are a strict subset of another state's.
+
+        The archive keeps every state that was ever retained, so it holds partial
+        plans alongside the extensions that superseded them. Recommending the
+        partial one would be a regression: before the archive existed only the last
+        round survived, so a superseded prefix was never a candidate plan. Terminal
+        states are subsumed by nothing and are unaffected - they are the states the
+        archive exists to preserve.
+
+        Apply this to the archive *before* merging, never after: a merged state
+        spans the edges of everything it merged, so filtering afterwards would
+        discard the individual paths that converged into it, which today are
+        recommended alongside the merged plan.
+        """
+        edge_sets = [(state, frozenset(state.edge_indices)) for state in states]
+        return [state for state, edges in edge_sets if not any(edges < other for _other_state, other in edge_sets)]
 
     def _rank_and_trim(
         self,

--- a/tests/unit_tests/symphony/test_beam_planner.py
+++ b/tests/unit_tests/symphony/test_beam_planner.py
@@ -554,6 +554,49 @@ async def test_beam_judge_reason_uses_english_without_seed_copy(tmp_path):
     assert result["reason"] == "skill-b is useful"
 
 
+@pytest.mark.asyncio
+async def test_beam_keeps_high_scoring_state_that_leaves_the_frontier(tmp_path):
+    """A state retained in an early round must survive to the final merge.
+
+    ``skill-t`` is the highest scoring candidate in the graph and cannot be
+    expanded, so it leaves the frontier after round one. Everything reached
+    later scores lower. It must still be recommended.
+    """
+    artifacts = _artifacts(
+        tmp_path,
+        edges=[
+            _edge("skill-a", "skill-t", confidence=0.95),
+            _edge("skill-a", "skill-m", confidence=0.92),
+            _edge("skill-m", "skill-n", confidence=0.91),
+            _edge("skill-m", "skill-p", confidence=0.90),
+        ],
+    )
+    llm = _FakeBeamLLM({"skill-t": 0.99, "skill-m": 0.85, "skill-n": 0.80, "skill-p": 0.79})
+
+    result = await _planner(
+        artifacts,
+        llm,
+        top_k=2,
+        max_depth=4,
+        candidate_skill_ids=["skill-a"],
+    ).plan("compose a plan")
+
+    assert ("skill-a", "skill-t") in _plan_signatures(result)
+    # The superseded prefix of an extended state is not a plan of its own.
+    assert ("skill-a", "skill-m") not in _plan_signatures(result)
+    # Expansion is unchanged: the archive feeds the final merge, not the frontier.
+    assert [
+        (
+            json.loads(call["user_content"])["current_skill"]["id"],
+            tuple(item["skill"]["id"] for item in json.loads(call["user_content"])["candidates"]),
+        )
+        for call in llm.judge_calls
+    ] == [
+        ("skill-a", ("skill-t", "skill-m")),
+        ("skill-m", ("skill-n", "skill-p")),
+    ]
+
+
 def _planner(
     artifacts: GraphArtifacts,
     llm: _FakeBeamLLM,


### PR DESCRIPTION
Paired: [GitHub #1066](https://github.com/openJiuwen-ai/agent-core/pull/1066) ↔ [GitCode !2595](https://gitcode.com/openJiuwen/agent-core/merge_requests/2595)

**What type of PR is this?**

/kind bug


**What does this PR do / why do we need it**:

`BidirectionalBeamPlanner._search` rebound `all_states` to each round's survivors instead of
accumulating them:

```python
retained = self._rank_and_trim(next_states, limit=self.top_k)
all_states = retained          # rebinds, never accumulates
frontier = retained
...
final_states = self._merge_converged_states(all_states)
```

`all_states` is the input to the final merge. Because it was rebound each round, any state
retained in an earlier round but absent from the last one never reached
`_merge_converged_states`. `_apply_judgements` emits only *extensions*, so a state that cannot
be expanded leaves the frontier permanently — it is not re-derivable. With the shipped defaults
(`top_k=3`, `max_depth=4`) the window is narrow enough that the search can discard its own
highest-scoring plan and return a worse one.

This restores accumulation. `frontier` still drives expansion, so search behaviour is unchanged;
only the merge input differs.

Two details worth a reviewer's attention:

1. **This looks like a restoration of the original intent, not new behaviour.** `all_states` is
   initialised at the top of the loop as `all_states = list(frontier)` — the seed states. Under
   the current code that initialisation is dead on arrival, because round one rebinds it before
   it is ever read. It only makes sense if accumulation was intended.

2. **An archive alone would introduce a regression, so it is filtered.** Keeping every retained
   state means partial plans sit beside the extensions that superseded them, and a prefix such
   as `a → m` would start being recommended alongside `a → m → n`. Before the archive existed
   only the last round survived, so a superseded prefix was never a candidate plan.
   `_drop_subsumed_states` removes any state whose edge set is a strict subset of another's.
   It is applied to the archive **before** the merge, deliberately: a merged state spans the
   edges of everything it merged, so filtering afterwards discards the individual paths that
   converged into it, which are recommended alongside the merged plan today. Applying it after
   the merge broke `test_beam_merges_converging_paths_into_dag_plan`; applying it before leaves
   that test untouched.

Scope: behaviour changes only under `planning_mode == "beam"`. `OrchestrationConfig.mode`
defaults to `"fast"`, so the default planning path is unaffected.


**Which issue(s) this PR fixes**:

Fixes #1065


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

**Function.** New regression test
`tests/unit_tests/symphony/test_beam_planner.py::test_beam_keeps_high_scoring_state_that_leaves_the_frontier`.

`skill-t` is the highest-scoring candidate in the graph (0.99) and has no outgoing edge, so it
leaves the frontier after round one; everything reached later scores lower. On `develop` the
test fails:

```
AssertionError: assert ('skill-a', 'skill-t') in {('skill-a', 'skill-m', 'skill-n'),
                                                  ('skill-a', 'skill-m', 'skill-p')}
```

The planner discards its best plan and returns the two worse ones. With this change the test
passes.

The same test also asserts that the judge-call sequence is exactly
`[('skill-a', ('skill-t', 'skill-m')), ('skill-m', ('skill-n', 'skill-p'))]`, byte-identical
before and after the change. That is the evidence that expansion is untouched and only the
merge input differs.

**Regression.** Verified against `139e8e3e`:

| Suite | Result |
|---|---|
| `tests/unit_tests/symphony/test_beam_planner.py` | 15 passed (14 before + the new one) |
| `tests/unit_tests/symphony` | 558 passed, 4 failed |
| `ruff check` / `ruff format --check` on both changed files | clean |

The 4 failures are pre-existing and unrelated to this change — 3 in `test_scanner.py`, 1 in
`test_index_output_writer.py`. Confirmed by stashing this patch and re-running on a clean tree,
which reproduces the same four.

**Performance.** Only retained states are archived, so the archive holds at most
`len(seeds) + top_k * (max_depth - 1)` states before dedupe — with shipped defaults that is
`len(seeds) + 9`. `_dedupe_states` runs once per round over that bounded list. No new
configuration and no measurable cost.

**Reliability.** The change is additive to the merge input and cannot make the search return
fewer or worse plans than before: every state that reached `_merge_converged_states` previously
still reaches it.


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [x] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed. — **No external interface change.** Both changed symbols are private (`_search` internals, new private helper `_drop_subsumed_states`); nothing in `openjiuwen/symphony/__init__.py` or any documented API is touched.
+ - [x] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner. — **No documentation change.** The corrected behaviour is what the existing docs already describe; no user-facing option or default changes.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #1065
<!-- /bot1-related-issues -->
