### PR TITLE
feat(observability): OTel metrics (config, recorder, runtime, emission, deploy)

### DIFF
--- a/deploy/observability/docker-compose.yml
+++ b/deploy/observability/docker-compose.yml
@@ -12,8 +12,20 @@ services:
     ports:
       - "4317:4317"
       - "4318:4318"
+      - "8889:8889"
     depends_on:
       langfuse-web:
+        condition: service_started
+
+  prometheus:
+    image: prom/prometheus:v2.53.0
+    container_name: langfuse-prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    depends_on:
+      otel-collector:
         condition: service_started
 
   langfuse-web:

--- a/deploy/observability/otel-collector-config.yaml
+++ b/deploy/observability/otel-collector-config.yaml
@@ -3,11 +3,15 @@
 # Pipeline:  application(otlp/grpc) -> memory_limiter -> batch
 #                                   -> transform/limit_strings
 #                                   -> langfuse / debug
+#            application(otlp)     -> memory_limiter -> batch
+#                                   -> prometheus / debug
 #
 # - The transform processor caps any string attribute at 16 KiB so that
 #   accidentally enormous prompts cannot OOM the backend.
 # - "debug" exporter prints a one-line span summary; remove from the
 #   pipeline once production traffic stabilises.
+# - The "prometheus" exporter exposes OTel metrics on :8889 for the
+#   bundled Prometheus scraper (see prometheus.yml).
 
 receivers:
   otlp:
@@ -45,9 +49,16 @@ exporters:
   debug:
     verbosity: basic
 
+  prometheus:
+    endpoint: 0.0.0.0:8889
+
 service:
   pipelines:
     traces:
       receivers: [otlp]
       processors: [memory_limiter, batch, transform/limit_strings]
       exporters: [otlphttp/langfuse, debug]
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [prometheus, debug]

--- a/deploy/observability/prometheus.yml
+++ b/deploy/observability/prometheus.yml
@@ -1,0 +1,5 @@
+scrape_configs:
+  - job_name: otel-collector
+    scrape_interval: 10s
+    static_configs:
+      - targets: ["otel-collector:8889"]

--- a/openjiuwen/extensions/observability/callback_handler.py
+++ b/openjiuwen/extensions/observability/callback_handler.py
@@ -1331,11 +1331,7 @@ class OtelCallbackHandler:
     @staticmethod
     def _metrics_model(span: Span) -> str:
         attributes = getattr(span, "attributes", None) or {}
-        return str(
-            attributes.get(GEN_AI_RESPONSE_MODEL)
-            or attributes.get(GEN_AI_REQUEST_MODEL)
-            or "unknown"
-        )
+        return str(attributes.get(GEN_AI_RESPONSE_MODEL) or attributes.get(GEN_AI_REQUEST_MODEL) or "unknown")
 
     def _emit_llm_metrics(self, state: LlmSpanState) -> None:
         rec = _metrics.get_metrics_recorder()
@@ -1350,11 +1346,7 @@ class OtelCallbackHandler:
         agent_id = self._metrics_agent_id(state.span)
         model = self._metrics_model(state.span)
         start_time = getattr(state.span, "start_time", None)
-        duration_ms = (
-            (time.time_ns() - start_time) / 1_000_000.0
-            if start_time is not None
-            else 0.0
-        )
+        duration_ms = (time.time_ns() - start_time) / 1_000_000.0 if start_time is not None else 0.0
         rec.record_llm_usage(agent_id, model, prompt, completion)
         rec.record_llm_duration(agent_id, model, duration_ms)
 
@@ -1365,7 +1357,8 @@ class OtelCallbackHandler:
             return 0.0
         return (time.time_ns() - start_time) / 1_000_000.0
 
-    def _emit_tool_metrics(self, tool_name: str, agent_id: str, duration_ms: float, is_error: bool) -> None:
+    @staticmethod
+    def _emit_tool_metrics(tool_name: str, agent_id: str, duration_ms: float, is_error: bool) -> None:
         rec = _metrics.get_metrics_recorder()
         if rec is None:
             return

--- a/openjiuwen/extensions/observability/callback_handler.py
+++ b/openjiuwen/extensions/observability/callback_handler.py
@@ -42,7 +42,7 @@ from openjiuwen.extensions.observability.semconv import (
     AT_AGENT_ID,
     AT_MEMBER_NAME,
     AT_SESSION_ID,
-
+    DA_AGENT_NAME,
     ERROR_TYPE,
     GEN_AI_AGENT_DESCRIPTION,
     GEN_AI_AGENT_ID,
@@ -167,6 +167,8 @@ from openjiuwen.core.foundation.llm.call_scope import (
     get_current_llm_call_id,
     is_llm_observation_suppressed,
 )
+
+from openjiuwen.extensions.observability import metrics as _metrics
 
 
 _TRACER_NAME = "openjiuwen.extensions.observability"
@@ -797,6 +799,12 @@ class OtelCallbackHandler:
             else:
                 span.set_attribute(ERROR_TYPE, TOOL_REPORTED_FAILURE)
                 span.set_status(Status(StatusCode.ERROR, failure_reason))
+            self._emit_tool_metrics(
+                tool_name,
+                self._metrics_agent_id(span),
+                self._tool_duration_ms(span),
+                is_error=failure_reason is not None,
+            )
             span.end()
         except Exception as exc:
             import traceback
@@ -838,6 +846,12 @@ class OtelCallbackHandler:
                     span.set_status(Status(StatusCode.ERROR, str(exc)))
                 else:
                     span.set_status(Status(StatusCode.ERROR, "tool call error"))
+                self._emit_tool_metrics(
+                    tool_name,
+                    self._metrics_agent_id(span),
+                    self._tool_duration_ms(span),
+                    is_error=True,
+                )
                 span.end()
         except Exception as exc:
             logger.exception("otel: on_tool_call_error failed: {}", exc)
@@ -1130,6 +1144,8 @@ class OtelCallbackHandler:
 
             self._maybe_record_response_attrs(state, response)
 
+            self._emit_llm_metrics(state)
+
             self._finalize_llm_span_output(
                 state, completion_text, reasoning_text,
                 tc_json=tc_json, response=response,
@@ -1301,6 +1317,61 @@ class OtelCallbackHandler:
         span.set_attribute(OJ_TRAJECTORY_RECORD_KIND, "inference")
         span.set_attribute(LANGFUSE_OBSERVATION_TYPE, "generation")
         span.set_attribute(GEN_AI_REQUEST_STREAM, state.is_streaming)
+
+    @staticmethod
+    def _metrics_agent_id(span: Span) -> str:
+        attributes = getattr(span, "attributes", None) or {}
+        return str(
+            attributes.get(GEN_AI_AGENT_NAME)
+            or attributes.get(DA_AGENT_NAME)
+            or attributes.get(GEN_AI_AGENT_ID)
+            or "unknown"
+        )
+
+    @staticmethod
+    def _metrics_model(span: Span) -> str:
+        attributes = getattr(span, "attributes", None) or {}
+        return str(
+            attributes.get(GEN_AI_RESPONSE_MODEL)
+            or attributes.get(GEN_AI_REQUEST_MODEL)
+            or "unknown"
+        )
+
+    def _emit_llm_metrics(self, state: LlmSpanState) -> None:
+        rec = _metrics.get_metrics_recorder()
+        if rec is None or not state.span.is_recording():
+            return
+        usage = getattr(state.span, "attributes", None) or {}
+        prompt = int(usage.get(GEN_AI_USAGE_INPUT_TOKENS, 0) or 0)
+        completion = int(usage.get(GEN_AI_USAGE_OUTPUT_TOKENS, 0) or 0)
+        if not prompt and not completion:
+            prompt = int(usage.get(GEN_AI_USAGE_PROMPT_TOKENS, 0) or 0)
+            completion = int(usage.get(GEN_AI_USAGE_COMPLETION_TOKENS, 0) or 0)
+        agent_id = self._metrics_agent_id(state.span)
+        model = self._metrics_model(state.span)
+        start_time = getattr(state.span, "start_time", None)
+        duration_ms = (
+            (time.time_ns() - start_time) / 1_000_000.0
+            if start_time is not None
+            else 0.0
+        )
+        rec.record_llm_usage(agent_id, model, prompt, completion)
+        rec.record_llm_duration(agent_id, model, duration_ms)
+
+    @staticmethod
+    def _tool_duration_ms(span: Span) -> float:
+        start_time = getattr(span, "start_time", None)
+        if start_time is None:
+            return 0.0
+        return (time.time_ns() - start_time) / 1_000_000.0
+
+    def _emit_tool_metrics(self, tool_name: str, agent_id: str, duration_ms: float, is_error: bool) -> None:
+        rec = _metrics.get_metrics_recorder()
+        if rec is None:
+            return
+        rec.record_tool_duration(tool_name, agent_id, duration_ms)
+        if is_error:
+            rec.record_tool_error(tool_name, agent_id)
 
     def _record_usage_attrs(self, state: LlmSpanState, usage: Any, *, skip_existing: bool = False) -> None:
         """Record usage attributes (tokens, model_name) from usage_metadata.

--- a/openjiuwen/extensions/observability/config.py
+++ b/openjiuwen/extensions/observability/config.py
@@ -48,6 +48,12 @@ class ObservabilityConfig(BaseModel):
             span-end does not block the business thread.
         file_retention_days: Trace files older than this (by mtime) are
             lazily deleted by the ``file`` exporter. Default 7 days.
+        metrics_enabled: Master switch for OTel metrics. When False (default),
+            no MeterProvider is created and tracing-only users see zero extra
+            provider/exporter side effects.
+        metrics_endpoint: OTLP metrics endpoint. Empty means fall back to
+            ``endpoint`` when exporting metrics over OTLP.
+        metrics_exporter: Metrics exporter backend. Default ``otlp_grpc``.
     """
 
     enabled: bool = True
@@ -67,3 +73,7 @@ class ObservabilityConfig(BaseModel):
     # file exporter
     traces_dir: str = "./traces"
     file_retention_days: int = 7
+    # metrics
+    metrics_enabled: bool = False
+    metrics_endpoint: str = ""
+    metrics_exporter: Literal["otlp_grpc", "otlp_http", "console"] = "otlp_grpc"

--- a/openjiuwen/extensions/observability/metrics.py
+++ b/openjiuwen/extensions/observability/metrics.py
@@ -1,0 +1,149 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Disabled-by-default OTel metrics for the observability subsystem."""
+
+from __future__ import annotations
+
+import threading
+
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import (
+    ConsoleMetricExporter,
+    PeriodicExportingMetricReader,
+)
+
+from openjiuwen.core.common.logging import logger
+from openjiuwen.extensions.observability.config import ObservabilityConfig
+
+_LABEL_MODEL = "model"
+_LABEL_AGENT_ID = "agent_id"
+_LABEL_KIND = "kind"
+_LABEL_TOOL_NAME = "tool_name"
+_LABEL_TEAM_ID = "team_id"
+
+_METER_NAME = "openjiuwen.extensions.observability"
+
+_recorder: MetricsRecorder | None = None
+_recorder_lock = threading.RLock()
+
+
+def set_metrics_recorder(rec: MetricsRecorder | None) -> None:
+    global _recorder
+    with _recorder_lock:
+        _recorder = rec
+
+
+def get_metrics_recorder() -> MetricsRecorder | None:
+    with _recorder_lock:
+        return _recorder
+
+
+def is_metrics_enabled() -> bool:
+    return get_metrics_recorder() is not None
+
+
+def _build_meter_provider(config: ObservabilityConfig) -> MeterProvider:
+    if config.metrics_exporter == "console":
+        exporter = ConsoleMetricExporter()
+    elif config.metrics_exporter == "otlp_http":
+        from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+        exporter = OTLPMetricExporter(endpoint=config.metrics_endpoint or config.endpoint)
+    else:
+        from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+        exporter = OTLPMetricExporter(
+            endpoint=config.metrics_endpoint or config.endpoint,
+            insecure=True,
+        )
+    reader = PeriodicExportingMetricReader(exporter)
+    return MeterProvider(metric_readers=[reader])
+
+
+class MetricsRecorder:
+    """Own one ``MeterProvider`` and the high-level record API."""
+
+    def __init__(self, config: ObservabilityConfig) -> None:
+        self._provider = _build_meter_provider(config)
+        # Do NOT call ``metrics.set_meter_provider``: this recorder is
+        # self-contained (it uses ``self._provider.get_meter`` directly), and
+        # touching the API-level global would override any coexisting meter
+        # provider and break tests that build two recorders.
+        meter = self._provider.get_meter(_METER_NAME)
+        self._llm_token_usage = meter.create_counter(
+            "llm.token_usage",
+            unit="1",
+            description="Prompt and completion tokens per LLM call",
+        )
+        self._llm_call_duration = meter.create_histogram(
+            "llm.call.duration",
+            unit="ms",
+            description="End-to-end LLM call latency",
+        )
+        self._tool_call_duration = meter.create_histogram(
+            "tool.call.duration",
+            unit="ms",
+            description="Tool execution latency",
+        )
+        self._tool_call_errors = meter.create_counter(
+            "tool.call.errors",
+            unit="1",
+            description="Tool calls that raised or reported failure",
+        )
+        self._iteration_duration = meter.create_histogram(
+            "deepagent.task.iteration.duration",
+            unit="ms",
+            description="Task-loop iteration latency",
+        )
+        self._iteration_errors = meter.create_counter(
+            "deepagent.task.iteration.errors",
+            unit="1",
+            description="Task-loop iterations that ended in error",
+        )
+
+    def _guarded(self, fn) -> None:
+        try:
+            fn()
+        except Exception as exc:
+            logger.warning("otel: metrics record failed - {}", exc)
+
+    def record_llm_usage(self, agent_id: str, model: str, prompt_tokens: int, completion_tokens: int) -> None:
+        self._guarded(lambda: self._llm_token_usage.add(
+            int(prompt_tokens),
+            {_LABEL_MODEL: model, _LABEL_AGENT_ID: agent_id, _LABEL_KIND: "prompt"},
+        ))
+        self._guarded(lambda: self._llm_token_usage.add(
+            int(completion_tokens),
+            {_LABEL_MODEL: model, _LABEL_AGENT_ID: agent_id, _LABEL_KIND: "completion"},
+        ))
+
+    def record_llm_duration(self, agent_id: str, model: str, duration_ms: float) -> None:
+        self._guarded(lambda: self._llm_call_duration.record(
+            float(duration_ms), {_LABEL_MODEL: model, _LABEL_AGENT_ID: agent_id},
+        ))
+
+    def record_tool_duration(self, tool_name: str, agent_id: str, duration_ms: float) -> None:
+        self._guarded(lambda: self._tool_call_duration.record(
+            float(duration_ms), {_LABEL_TOOL_NAME: tool_name, _LABEL_AGENT_ID: agent_id},
+        ))
+
+    def record_tool_error(self, tool_name: str, agent_id: str) -> None:
+        self._guarded(lambda: self._tool_call_errors.add(
+            1, {_LABEL_TOOL_NAME: tool_name, _LABEL_AGENT_ID: agent_id},
+        ))
+
+    def record_iteration_duration(self, agent_id: str, team_id: str, duration_ms: float) -> None:
+        self._guarded(lambda: self._iteration_duration.record(
+            float(duration_ms), {_LABEL_AGENT_ID: agent_id, _LABEL_TEAM_ID: team_id},
+        ))
+
+    def record_iteration_error(self, agent_id: str, team_id: str) -> None:
+        self._guarded(lambda: self._iteration_errors.add(
+            1, {_LABEL_AGENT_ID: agent_id, _LABEL_TEAM_ID: team_id},
+        ))
+
+    def shutdown(self) -> None:
+        with _recorder_lock:
+            try:
+                self._provider.shutdown()
+            except Exception as exc:
+                logger.warning("otel: metrics shutdown failed - {}", exc)

--- a/openjiuwen/extensions/observability/metrics.py
+++ b/openjiuwen/extensions/observability/metrics.py
@@ -48,9 +48,11 @@ def _build_meter_provider(config: ObservabilityConfig) -> MeterProvider:
         exporter = ConsoleMetricExporter()
     elif config.metrics_exporter == "otlp_http":
         from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+
         exporter = OTLPMetricExporter(endpoint=config.metrics_endpoint or config.endpoint)
     else:
         from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+
         exporter = OTLPMetricExporter(
             endpoint=config.metrics_endpoint or config.endpoint,
             insecure=True,
@@ -100,46 +102,66 @@ class MetricsRecorder:
             description="Task-loop iterations that ended in error",
         )
 
-    def _guarded(self, fn) -> None:
+    @staticmethod
+    def _guarded(fn) -> None:
         try:
             fn()
         except Exception as exc:
             logger.warning("otel: metrics record failed - {}", exc)
 
     def record_llm_usage(self, agent_id: str, model: str, prompt_tokens: int, completion_tokens: int) -> None:
-        self._guarded(lambda: self._llm_token_usage.add(
-            int(prompt_tokens),
-            {_LABEL_MODEL: model, _LABEL_AGENT_ID: agent_id, _LABEL_KIND: "prompt"},
-        ))
-        self._guarded(lambda: self._llm_token_usage.add(
-            int(completion_tokens),
-            {_LABEL_MODEL: model, _LABEL_AGENT_ID: agent_id, _LABEL_KIND: "completion"},
-        ))
+        self._guarded(
+            lambda: self._llm_token_usage.add(
+                int(prompt_tokens),
+                {_LABEL_MODEL: model, _LABEL_AGENT_ID: agent_id, _LABEL_KIND: "prompt"},
+            )
+        )
+        self._guarded(
+            lambda: self._llm_token_usage.add(
+                int(completion_tokens),
+                {_LABEL_MODEL: model, _LABEL_AGENT_ID: agent_id, _LABEL_KIND: "completion"},
+            )
+        )
 
     def record_llm_duration(self, agent_id: str, model: str, duration_ms: float) -> None:
-        self._guarded(lambda: self._llm_call_duration.record(
-            float(duration_ms), {_LABEL_MODEL: model, _LABEL_AGENT_ID: agent_id},
-        ))
+        self._guarded(
+            lambda: self._llm_call_duration.record(
+                float(duration_ms),
+                {_LABEL_MODEL: model, _LABEL_AGENT_ID: agent_id},
+            )
+        )
 
     def record_tool_duration(self, tool_name: str, agent_id: str, duration_ms: float) -> None:
-        self._guarded(lambda: self._tool_call_duration.record(
-            float(duration_ms), {_LABEL_TOOL_NAME: tool_name, _LABEL_AGENT_ID: agent_id},
-        ))
+        self._guarded(
+            lambda: self._tool_call_duration.record(
+                float(duration_ms),
+                {_LABEL_TOOL_NAME: tool_name, _LABEL_AGENT_ID: agent_id},
+            )
+        )
 
     def record_tool_error(self, tool_name: str, agent_id: str) -> None:
-        self._guarded(lambda: self._tool_call_errors.add(
-            1, {_LABEL_TOOL_NAME: tool_name, _LABEL_AGENT_ID: agent_id},
-        ))
+        self._guarded(
+            lambda: self._tool_call_errors.add(
+                1,
+                {_LABEL_TOOL_NAME: tool_name, _LABEL_AGENT_ID: agent_id},
+            )
+        )
 
     def record_iteration_duration(self, agent_id: str, team_id: str, duration_ms: float) -> None:
-        self._guarded(lambda: self._iteration_duration.record(
-            float(duration_ms), {_LABEL_AGENT_ID: agent_id, _LABEL_TEAM_ID: team_id},
-        ))
+        self._guarded(
+            lambda: self._iteration_duration.record(
+                float(duration_ms),
+                {_LABEL_AGENT_ID: agent_id, _LABEL_TEAM_ID: team_id},
+            )
+        )
 
     def record_iteration_error(self, agent_id: str, team_id: str) -> None:
-        self._guarded(lambda: self._iteration_errors.add(
-            1, {_LABEL_AGENT_ID: agent_id, _LABEL_TEAM_ID: team_id},
-        ))
+        self._guarded(
+            lambda: self._iteration_errors.add(
+                1,
+                {_LABEL_AGENT_ID: agent_id, _LABEL_TEAM_ID: team_id},
+            )
+        )
 
     def shutdown(self) -> None:
         with _recorder_lock:

--- a/openjiuwen/extensions/observability/runtime.py
+++ b/openjiuwen/extensions/observability/runtime.py
@@ -103,6 +103,7 @@ class ObservabilityRuntime:
         self._tracker: ActiveSpanTracker | None = None
         self._callback_handler: OtelCallbackHandler | None = None
         self._context_compression_handler: ContextCompressionObservabilityBridge | None = None
+        self._metrics_recorder: Any | None = None
         self._registered_callbacks: list[tuple[str, Any]] = []
         self._callback_framework: Any | None = None
         self._callback_namespace = "extensions.observability"
@@ -129,6 +130,11 @@ class ObservabilityRuntime:
                 if span_exporter_override is not None:
                     self._provider.add_span_processor(SimpleSpanProcessor(span_exporter_override))
                 self.add_span_processors(additional_span_processors)
+                # metrics: independent of the trace provider; build lazily if requested
+                if config.metrics_enabled and self._metrics_recorder is None:
+                    from openjiuwen.extensions.observability import metrics as metrics_module
+                    self._metrics_recorder = metrics_module.MetricsRecorder(config)
+                    metrics_module.set_metrics_recorder(self._metrics_recorder)
                 return
             if self._initializing:
                 raise RuntimeError("observability initialization is already in progress")
@@ -165,6 +171,11 @@ class ObservabilityRuntime:
                 set_active_span_tracker(tracker)
                 self._additional_processors.extend(additional_processors)
 
+                from openjiuwen.extensions.observability import metrics as metrics_module
+                if config.metrics_enabled:
+                    self._metrics_recorder = metrics_module.MetricsRecorder(config)
+                metrics_module.set_metrics_recorder(self._metrics_recorder)
+
                 callback_handler = OtelCallbackHandler(
                     config,
                     tracer=provider.get_tracer("openjiuwen.extensions.observability"),
@@ -183,6 +194,14 @@ class ObservabilityRuntime:
                     logger.warning("otel: set_tracer_provider failed - {}", exc)
             except Exception:
                 self._unregister_callbacks()
+                if self._metrics_recorder is not None:
+                    try:
+                        self._metrics_recorder.shutdown()
+                    except Exception as exc:
+                        logger.warning("otel: metrics rollback shutdown failed - {}", exc)
+                self._metrics_recorder = None
+                from openjiuwen.extensions.observability import metrics as metrics_module
+                metrics_module.set_metrics_recorder(None)
                 if provider is not None:
                     try:
                         provider.shutdown()
@@ -255,6 +274,14 @@ class ObservabilityRuntime:
                     except Exception as exc:
                         logger.warning("otel: provider shutdown failed - {}", exc)
             finally:
+                from openjiuwen.extensions.observability import metrics as metrics_module
+                if self._metrics_recorder is not None:
+                    try:
+                        self._metrics_recorder.shutdown()
+                    except Exception as exc:
+                        logger.warning("otel: metrics shutdown failed - {}", exc)
+                self._metrics_recorder = None
+                metrics_module.set_metrics_recorder(None)
                 self._provider = None
                 self._config = None
                 self._tracker = None

--- a/openjiuwen/extensions/observability/runtime.py
+++ b/openjiuwen/extensions/observability/runtime.py
@@ -133,6 +133,7 @@ class ObservabilityRuntime:
                 # metrics: independent of the trace provider; build lazily if requested
                 if config.metrics_enabled and self._metrics_recorder is None:
                     from openjiuwen.extensions.observability import metrics as metrics_module
+
                     self._metrics_recorder = metrics_module.MetricsRecorder(config)
                     metrics_module.set_metrics_recorder(self._metrics_recorder)
                 return
@@ -172,6 +173,7 @@ class ObservabilityRuntime:
                 self._additional_processors.extend(additional_processors)
 
                 from openjiuwen.extensions.observability import metrics as metrics_module
+
                 if config.metrics_enabled:
                     self._metrics_recorder = metrics_module.MetricsRecorder(config)
                 metrics_module.set_metrics_recorder(self._metrics_recorder)
@@ -201,6 +203,7 @@ class ObservabilityRuntime:
                         logger.warning("otel: metrics rollback shutdown failed - {}", exc)
                 self._metrics_recorder = None
                 from openjiuwen.extensions.observability import metrics as metrics_module
+
                 metrics_module.set_metrics_recorder(None)
                 if provider is not None:
                     try:
@@ -275,6 +278,7 @@ class ObservabilityRuntime:
                         logger.warning("otel: provider shutdown failed - {}", exc)
             finally:
                 from openjiuwen.extensions.observability import metrics as metrics_module
+
                 if self._metrics_recorder is not None:
                     try:
                         self._metrics_recorder.shutdown()

--- a/openjiuwen/extensions/observability/setup.py
+++ b/openjiuwen/extensions/observability/setup.py
@@ -69,12 +69,30 @@ def get_observability_runtime() -> ObservabilityRuntime:
     return _runtime
 
 
+def get_metrics_recorder() -> Any:
+    """Return the shared metrics recorder, or None when metrics are disabled."""
+
+    from openjiuwen.extensions.observability.metrics import get_metrics_recorder as _get
+
+    return _get()
+
+
+def is_metrics_enabled() -> bool:
+    """Return whether the shared runtime owns an active metrics recorder."""
+
+    from openjiuwen.extensions.observability.metrics import is_metrics_enabled as _is
+
+    return _is()
+
+
 __all__ = [
     "force_flush_provider",
     "get_config",
+    "get_metrics_recorder",
     "get_observability_runtime",
     "get_tracer",
     "init_observability",
     "is_initialized",
+    "is_metrics_enabled",
     "shutdown_observability",
 ]

--- a/openjiuwen/harness/observability/rail.py
+++ b/openjiuwen/harness/observability/rail.py
@@ -28,6 +28,7 @@ contribution belongs to.
 from __future__ import annotations
 
 import json
+import time
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any
@@ -89,6 +90,7 @@ from openjiuwen.extensions.observability.semconv import (
     OJ_EXECUTION_SUBJECT_SESSION_ID,
     OJ_STEP_ID,
     OJ_STEP_NUMBER,
+    OJ_TEAM_ID,
     OJ_TOOL_AUTHORITATIVE,
     OJ_TOOL_RESOURCE_ID,
     OJ_TOOL_TYPE,
@@ -544,6 +546,7 @@ class AgentObservabilityRail(DeepAgentRail):
             if inputs is not None:
                 output = getattr(inputs, "result", None)
 
+            self._emit_iteration_metrics(scope, exception=ctx.exception)
             scope.close(output=output, exception=ctx.exception)
 
             # Iteration close restores current to None (parent_agent_span is
@@ -563,6 +566,28 @@ class AgentObservabilityRail(DeepAgentRail):
             )
         except Exception as exc:
             logger.warning("[AgentObservability] after_task_iteration failed: %s", exc)
+
+    def _emit_iteration_metrics(self, scope, exception: BaseException | None) -> None:
+        from openjiuwen.extensions.observability import metrics as _metrics
+
+        rec = _metrics.get_metrics_recorder()
+        if rec is None:
+            return
+        span = scope.span
+        if not span.is_recording():
+            return
+        attributes = getattr(span, "attributes", None) or {}
+        agent_id = str(attributes.get(DA_AGENT_NAME) or "unknown")
+        team_id = str(attributes.get(OJ_TEAM_ID) or "")
+        start_time = getattr(span, "start_time", None)
+        duration_ms = (
+            (time.time_ns() - start_time) / 1_000_000.0
+            if start_time is not None
+            else 0.0
+        )
+        rec.record_iteration_duration(agent_id, team_id, duration_ms)
+        if exception is not None:
+            rec.record_iteration_error(agent_id, team_id)
 
     # ------------------------------------------------------------------
     # Invoke-level fallback (covers single-round agents and sub-agents)

--- a/openjiuwen/harness/observability/rail.py
+++ b/openjiuwen/harness/observability/rail.py
@@ -580,11 +580,7 @@ class AgentObservabilityRail(DeepAgentRail):
         agent_id = str(attributes.get(DA_AGENT_NAME) or "unknown")
         team_id = str(attributes.get(OJ_TEAM_ID) or "")
         start_time = getattr(span, "start_time", None)
-        duration_ms = (
-            (time.time_ns() - start_time) / 1_000_000.0
-            if start_time is not None
-            else 0.0
-        )
+        duration_ms = (time.time_ns() - start_time) / 1_000_000.0 if start_time is not None else 0.0
         rec.record_iteration_duration(agent_id, team_id, duration_ms)
         if exception is not None:
             rec.record_iteration_error(agent_id, team_id)

--- a/tests/unit_tests/extensions/observability/test_deploy_wiring.py
+++ b/tests/unit_tests/extensions/observability/test_deploy_wiring.py
@@ -1,0 +1,66 @@
+# coding: utf-8
+
+"""Structural checks for the deploy/observability metrics wiring."""
+
+from pathlib import Path
+
+import yaml
+
+DEPLOY_DIR = Path(__file__).resolve().parents[4] / "deploy" / "observability"
+
+
+def _collector_config() -> dict:
+    with (DEPLOY_DIR / "otel-collector-config.yaml").open() as handle:
+        return yaml.safe_load(handle)
+
+
+def _compose_config() -> dict:
+    with (DEPLOY_DIR / "docker-compose.yml").open() as handle:
+        return yaml.safe_load(handle)
+
+
+def _prometheus_config() -> dict:
+    with (DEPLOY_DIR / "prometheus.yml").open() as handle:
+        return yaml.safe_load(handle)
+
+
+def test_collector_exposes_a_metrics_pipeline() -> None:
+    config = _collector_config()
+    pipelines = config["service"]["pipelines"]
+    assert "metrics" in pipelines
+    metrics = pipelines["metrics"]
+    assert metrics["receivers"] == ["otlp"]
+    assert "prometheus" in metrics["exporters"]
+    assert "debug" in metrics["exporters"]
+
+
+def test_collector_defines_prometheus_exporter() -> None:
+    exporters = _collector_config()["exporters"]
+    assert exporters["prometheus"]["endpoint"] == "0.0.0.0:8889"
+
+
+def test_trace_pipeline_keeps_its_existing_shape() -> None:
+    traces = _collector_config()["service"]["pipelines"]["traces"]
+    assert traces["exporters"] == ["otlphttp/langfuse", "debug"]
+
+
+def test_compose_exposes_collector_metrics_port() -> None:
+    collector = _compose_config()["services"]["otel-collector"]
+    assert "8889:8889" in collector["ports"]
+
+
+def test_compose_adds_a_prometheus_service() -> None:
+    services = _compose_config()["services"]
+    prometheus = services["prometheus"]
+    assert prometheus["image"].startswith("prom/prometheus:")
+    assert "9090:9090" in prometheus["ports"]
+    mount = prometheus["volumes"][0]
+    assert mount.startswith("./prometheus.yml:")
+    assert mount.endswith(":ro")
+
+
+def test_prometheus_scrapes_the_collector() -> None:
+    jobs = _prometheus_config()["scrape_configs"]
+    assert jobs[0]["job_name"] == "otel-collector"
+    targets = jobs[0]["static_configs"][0]["targets"]
+    assert targets == ["otel-collector:8889"]

--- a/tests/unit_tests/extensions/observability/test_metrics.py
+++ b/tests/unit_tests/extensions/observability/test_metrics.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 
+from openjiuwen.extensions.observability import metrics as metrics_mod
 from openjiuwen.extensions.observability.config import ObservabilityConfig
 
 
@@ -19,3 +20,32 @@ def test_metrics_exporter_rejects_unknown_value():
     from pydantic import ValidationError
     with pytest.raises(ValidationError):
         ObservabilityConfig(metrics_exporter="bogus")
+
+
+def test_recorder_builds_instruments():
+    cfg = ObservabilityConfig(metrics_enabled=True, metrics_exporter="console")
+    rec = metrics_mod.MetricsRecorder(cfg)
+    try:
+        assert rec._llm_token_usage.name == "llm.token_usage"
+        assert rec._llm_call_duration.name == "llm.call.duration"
+        assert rec._tool_call_duration.name == "tool.call.duration"
+        assert rec._tool_call_errors.name == "tool.call.errors"
+        assert rec._iteration_duration.name == "deepagent.task.iteration.duration"
+        assert rec._iteration_errors.name == "deepagent.task.iteration.errors"
+    finally:
+        rec.shutdown()
+
+
+def test_recorder_record_methods_do_not_raise(monkeypatch):
+    cfg = ObservabilityConfig(metrics_enabled=True, metrics_exporter="console")
+    rec = metrics_mod.MetricsRecorder(cfg)
+    try:
+        rec.record_llm_usage("agent-1", "gpt-4o", 10, 20)
+        rec.record_llm_duration("agent-1", "gpt-4o", 123.0)
+        rec.record_tool_duration("bash", "agent-1", 50.0)
+        rec.record_tool_error("bash", "agent-1")
+        rec.record_iteration_duration("agent-1", "team-1", 400.0)
+        rec.record_iteration_error("agent-1", "team-1")
+    finally:
+        rec.shutdown()
+

--- a/tests/unit_tests/extensions/observability/test_metrics.py
+++ b/tests/unit_tests/extensions/observability/test_metrics.py
@@ -1,0 +1,21 @@
+# coding: utf-8
+
+from openjiuwen.extensions.observability.config import ObservabilityConfig
+
+
+def test_metrics_disabled_by_default():
+    cfg = ObservabilityConfig()
+    assert cfg.metrics_enabled is False
+
+
+def test_metrics_fields_defaults():
+    cfg = ObservabilityConfig(metrics_enabled=True)
+    assert cfg.metrics_endpoint == ""
+    assert cfg.metrics_exporter == "otlp_grpc"
+
+
+def test_metrics_exporter_rejects_unknown_value():
+    import pytest
+    from pydantic import ValidationError
+    with pytest.raises(ValidationError):
+        ObservabilityConfig(metrics_exporter="bogus")

--- a/tests/unit_tests/extensions/observability/test_metrics.py
+++ b/tests/unit_tests/extensions/observability/test_metrics.py
@@ -18,6 +18,7 @@ def test_metrics_fields_defaults():
 def test_metrics_exporter_rejects_unknown_value():
     import pytest
     from pydantic import ValidationError
+
     with pytest.raises(ValidationError):
         ObservabilityConfig(metrics_exporter="bogus")
 
@@ -48,4 +49,3 @@ def test_recorder_record_methods_do_not_raise(monkeypatch):
         rec.record_iteration_error("agent-1", "team-1")
     finally:
         rec.shutdown()
-

--- a/tests/unit_tests/extensions/observability/test_metrics_emission.py
+++ b/tests/unit_tests/extensions/observability/test_metrics_emission.py
@@ -1,0 +1,77 @@
+# coding: utf-8
+
+from types import SimpleNamespace
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.trace import set_span_in_context
+
+from openjiuwen.extensions.observability import metrics as metrics_mod
+from openjiuwen.extensions.observability.callback_handler import OtelCallbackHandler
+from openjiuwen.extensions.observability.config import ObservabilityConfig
+
+
+class _FakeMetricsRecorder:
+    def __init__(self) -> None:
+        self.llm_usage_calls: list[tuple] = []
+        self.llm_duration_calls: list[tuple] = []
+        self.tool_duration_calls: list[tuple] = []
+        self.tool_error_calls: list[tuple] = []
+
+    def record_llm_usage(self, agent_id, model, prompt, completion) -> None:
+        self.llm_usage_calls.append((agent_id, model, prompt, completion))
+
+    def record_llm_duration(self, agent_id, model, duration_ms) -> None:
+        self.llm_duration_calls.append((agent_id, model, duration_ms))
+
+    def record_tool_duration(self, tool_name, agent_id, duration_ms) -> None:
+        self.tool_duration_calls.append((tool_name, agent_id, duration_ms))
+
+    def record_tool_error(self, tool_name, agent_id) -> None:
+        self.tool_error_calls.append((tool_name, agent_id))
+
+
+def _handler(monkeypatch, recorder):
+    provider = TracerProvider()
+    tracer = provider.get_tracer("metrics-test")
+    root = tracer.start_span("agent.root")
+    handler = OtelCallbackHandler(
+        ObservabilityConfig(enabled=True, service_name="metrics-test"),
+        tracer=tracer,
+    )
+    monkeypatch.setattr(handler, "_get_parent_context_for_llm_tool", lambda: set_span_in_context(root))
+    monkeypatch.setattr(metrics_mod, "get_metrics_recorder", lambda: recorder)
+    return provider, root, handler
+
+
+def test_llm_close_emits_metrics_when_enabled(monkeypatch):
+    rec = _FakeMetricsRecorder()
+    provider, _root, handler = _handler(monkeypatch, rec)
+
+    span = handler._open_llm_span({"messages": [], "model": "gpt-4o"})
+    assert span is not None
+    span.set_attribute("gen_ai.usage.input_tokens", 10)
+    span.set_attribute("gen_ai.usage.output_tokens", 20)
+    span.set_attribute("gen_ai.response.model", "gpt-4o")
+    span.set_attribute("gen_ai.agent.name", "agent-1")
+    state = getattr(span, "otel_llm_state")
+
+    handler._close_llm_span(state, SimpleNamespace())
+
+    assert rec.llm_usage_calls == [("agent-1", "gpt-4o", 10, 20)]
+    assert len(rec.llm_duration_calls) == 1
+    provider.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_tool_error_emits_error_metric(monkeypatch):
+    rec = _FakeMetricsRecorder()
+    provider, _root, handler = _handler(monkeypatch, rec)
+    monkeypatch.setattr(handler, "_metrics_agent_id", lambda span: "agent-1")
+
+    await handler.on_tool_call_started(tool_name="bash", tool_id=None, inputs=None)
+    await handler.on_tool_call_error(tool_name="bash", error=RuntimeError("boom"), tool_id=None)
+
+    assert ("bash", "agent-1") in rec.tool_error_calls
+    assert rec.tool_duration_calls
+    provider.shutdown()

--- a/tests/unit_tests/extensions/observability/test_runtime.py
+++ b/tests/unit_tests/extensions/observability/test_runtime.py
@@ -18,6 +18,19 @@ from openjiuwen.extensions.observability.config import ObservabilityConfig
 from openjiuwen.extensions.observability.runtime import ObservabilityRuntime
 
 
+@pytest.fixture
+def reset_observability_runtime():
+    from openjiuwen.extensions.observability import metrics as _metrics
+    from openjiuwen.extensions.observability.demand import reset_observability_demands
+    from openjiuwen.extensions.observability.setup import shutdown_observability
+    shutdown_observability()
+    _metrics.set_metrics_recorder(None)
+    reset_observability_demands()
+    yield
+    shutdown_observability()
+    _metrics.set_metrics_recorder(None)
+
+
 class _RecordingProcessor(SpanProcessor):
     def __init__(self, events: list[str] | None = None) -> None:
         self.spans: list[ReadableSpan] = []
@@ -182,3 +195,50 @@ def test_initialization_failure_clears_runtime_state(monkeypatch: Any) -> None:
 
     assert not runtime.is_initialized()
     assert runtime.get_config() is None
+
+
+def test_metrics_initialized_when_enabled(reset_observability_runtime):
+    from openjiuwen.extensions.observability.setup import (
+        get_metrics_recorder,
+        init_observability,
+        is_metrics_enabled,
+        shutdown_observability,
+    )
+    cfg = ObservabilityConfig(metrics_enabled=True, metrics_exporter="console")
+    init_observability(cfg)
+    try:
+        assert is_metrics_enabled()
+        assert get_metrics_recorder() is not None
+    finally:
+        shutdown_observability()
+    assert not is_metrics_enabled()
+
+
+def test_metrics_not_initialized_by_default(reset_observability_runtime):
+    from openjiuwen.extensions.observability.setup import (
+        init_observability,
+        is_metrics_enabled,
+        shutdown_observability,
+    )
+    init_observability(ObservabilityConfig())
+    try:
+        assert not is_metrics_enabled()
+    finally:
+        shutdown_observability()
+
+
+def test_metrics_initialized_on_second_runtime_when_enabled(reset_observability_runtime):
+    from openjiuwen.extensions.observability.setup import (
+        get_metrics_recorder,
+        init_observability,
+        is_metrics_enabled,
+        shutdown_observability,
+    )
+    init_observability(ObservabilityConfig())  # first init: tracing only
+    assert not is_metrics_enabled()
+    init_observability(ObservabilityConfig(metrics_enabled=True, metrics_exporter="console"))
+    try:
+        assert is_metrics_enabled()
+        assert get_metrics_recorder() is not None
+    finally:
+        shutdown_observability()

--- a/tests/unit_tests/extensions/observability/test_runtime.py
+++ b/tests/unit_tests/extensions/observability/test_runtime.py
@@ -23,6 +23,7 @@ def reset_observability_runtime():
     from openjiuwen.extensions.observability import metrics as _metrics
     from openjiuwen.extensions.observability.demand import reset_observability_demands
     from openjiuwen.extensions.observability.setup import shutdown_observability
+
     shutdown_observability()
     _metrics.set_metrics_recorder(None)
     reset_observability_demands()
@@ -204,6 +205,7 @@ def test_metrics_initialized_when_enabled(reset_observability_runtime):
         is_metrics_enabled,
         shutdown_observability,
     )
+
     cfg = ObservabilityConfig(metrics_enabled=True, metrics_exporter="console")
     init_observability(cfg)
     try:
@@ -220,6 +222,7 @@ def test_metrics_not_initialized_by_default(reset_observability_runtime):
         is_metrics_enabled,
         shutdown_observability,
     )
+
     init_observability(ObservabilityConfig())
     try:
         assert not is_metrics_enabled()
@@ -234,6 +237,7 @@ def test_metrics_initialized_on_second_runtime_when_enabled(reset_observability_
         is_metrics_enabled,
         shutdown_observability,
     )
+
     init_observability(ObservabilityConfig())  # first init: tracing only
     assert not is_metrics_enabled()
     init_observability(ObservabilityConfig(metrics_enabled=True, metrics_exporter="console"))

--- a/tests/unit_tests/harness/observability/test_rail.py
+++ b/tests/unit_tests/harness/observability/test_rail.py
@@ -246,6 +246,56 @@ async def test_no_agent_span_without_a_run_root(tracing):
     assert _finished(tracing.exporter, "agent.solo.task_iteration.1") == []
 
 
+class _FakeMetricsRecorder:
+    def __init__(self) -> None:
+        self.iteration_duration_calls: list[tuple] = []
+        self.iteration_error_calls: list[tuple] = []
+
+    def record_iteration_duration(self, agent_id, team_id, duration_ms) -> None:
+        self.iteration_duration_calls.append((agent_id, team_id, duration_ms))
+
+    def record_iteration_error(self, agent_id, team_id) -> None:
+        self.iteration_error_calls.append((agent_id, team_id))
+
+
+@pytest.mark.asyncio
+async def test_iteration_close_emits_iteration_metrics(tracing, monkeypatch):
+    from openjiuwen.extensions.observability import metrics as metrics_mod
+
+    rec = _FakeMetricsRecorder()
+    monkeypatch.setattr(metrics_mod, "get_metrics_recorder", lambda: rec)
+    rail = AgentObservabilityRail(tracer=tracing.tracer)
+    ctx = _iteration_ctx(_agent())
+
+    await rail.before_task_iteration(ctx)
+    ctx.inputs.result = "the answer"
+    await rail.after_task_iteration(ctx)
+
+    assert len(rec.iteration_duration_calls) == 1
+    agent_id, team_id, _duration = rec.iteration_duration_calls[0]
+    assert agent_id == "solo"
+    assert team_id == ""
+    assert rec.iteration_error_calls == []
+
+
+@pytest.mark.asyncio
+async def test_iteration_error_emits_error_metric(tracing, monkeypatch):
+    from openjiuwen.extensions.observability import metrics as metrics_mod
+
+    rec = _FakeMetricsRecorder()
+    monkeypatch.setattr(metrics_mod, "get_metrics_recorder", lambda: rec)
+    rail = AgentObservabilityRail(tracer=tracing.tracer)
+    ctx = _iteration_ctx(_agent())
+    ctx.exception = RuntimeError("boom")
+
+    await rail.before_task_iteration(ctx)
+    ctx.inputs.result = None
+    await rail.after_task_iteration(ctx)
+
+    assert len(rec.iteration_duration_calls) == 1
+    assert ("solo", "") in rec.iteration_error_calls
+
+
 @pytest.mark.asyncio
 async def test_a_contributed_decoration_is_applied_on_open_and_at_close(tracing):
     """This is how a layer extends the span without subclassing or re-opening it."""


### PR DESCRIPTION
Paired: [GitHub #1099](https://github.com/openJiuwen-ai/agent-core/pull/1099) ↔ [GitCode !2622](https://gitcode.com/openJiuwen/agent-core/merge_requests/2622)

Part A of the revised observability roadmap (RFC #426): **disabled-by-default OTel metrics** on top of the existing observability runtime. Implements PLAN.md Tasks 1–5.

> Related to #426 (RFC stays open). Source of truth: `docs/openjiuwen/observability/PLAN.md`.

## Tasks covered (PLAN.md Part A)

| Task | What | Files |
| --- | --- | --- |
| 1 | Metrics config fields | `extensions/observability/config.py` |
| 2 | `MetricsRecorder` + core instruments | `extensions/observability/metrics.py` (new) |
| 3 | Runtime integration (init/shutdown in both branches) | `extensions/observability/runtime.py`, `setup.py` |
| 4 | LLM/tool/iteration emission | `extensions/observability/callback_handler.py`, `harness/observability/rail.py` |
| 5 | Collector metrics pipeline + Prometheus | `deploy/observability/*` |

## Details

- **Config**: `metrics_enabled` (default False) / `metrics_endpoint` / `metrics_exporter` (`otlp_grpc` | `otlp_http` | `console`).
- **MetricsRecorder**: self-contained `MeterProvider` + `PeriodicExportingMetricReader`; no API-level `set_meter_provider` (never overrides a coexisting provider).
- **Runtime**: recorder owned by `ObservabilityRuntime`, created in both first-init and already-initialized branches; torn down on rollback and shutdown; `setup.get_metrics_recorder()` / `is_metrics_enabled()` passthroughs.
- **Emission**: `OtelCallbackHandler._emit_llm_metrics` at LLM close (usage + duration), tool duration/errors at finish/error; `AgentObservabilityRail._emit_iteration_metrics` for `deepagent.task.iteration.*`.
- **Deploy**: `metrics` pipeline (`otlp → memory_limiter → batch → prometheus/debug`) exposing :8889, plus a Prometheus service in compose.

## Commits
- 97503ecf1 feat(observability): add metrics config fields
- a035269c2 feat(observability): add MetricsRecorder with core instruments
- 7b5f21a70 feat(observability): own metrics recorder in ObservabilityRuntime
- 6626a9f46 feat(observability): emit LLM/tool/iteration metrics
- ddf77521a feat(observability): add metrics pipeline and Prometheus

## Tests
- New: `test_metrics.py`, `test_metrics_emission.py`, `test_deploy_wiring.py`; extended `test_runtime.py`, `test_rail.py`.
- Suites: extensions+harness observability 178 pass; agent_teams observability 80 pass. Ruff/mypy clean on new code.

Refs: #426

Closes #1158

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #426
- Fixes #1158
<!-- /bot1-related-issues -->

