### PR TITLE
fix(sys_operation): safe stream chunk log level selection

### DIFF
--- a/openjiuwen/core/sys_operation/local/fs_operation.py
+++ b/openjiuwen/core/sys_operation/local/fs_operation.py
@@ -1701,7 +1701,7 @@ class FsOperation(BaseFsOperation):
             method_exec_time_ms=exec_time_ms
         )
 
-        if not stream_chunk.data.is_last_chunk:
-            sys_operation_logger.debug(stream_log, event=event)
-        else:
+        if log_event_type == LogEventType.SYS_OP_END:
             sys_operation_logger.info(end_stream_log, event=event)
+        else:
+            sys_operation_logger.debug(stream_log, event=event)


### PR DESCRIPTION
Paired: [GitHub #1236](https://github.com/openJiuwen-ai/agent-core/pull/1236) ↔ [GitCode !2816](https://gitcode.com/openJiuwen/agent-core/merge_requests/2816)

﻿## Summary
- `_log_stream_chunk` already computed a safe `LogEventType`, then still dereferenced `stream_chunk.data.is_last_chunk` for debug vs info.
- Use `log_event_type == LogEventType.SYS_OP_END` instead.

Fixes #1069

## Test plan
- [ ] Exercise a sys_operation stream path with a non-standard / partial chunk object
- [ ] Confirm no AttributeError when `stream_chunk` or `.data` is missing

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #1069
<!-- /bot1-related-issues -->
