### PR TITLE
fix(session): add group_id() to AgentTeamSession

### DIFF
--- a/openjiuwen/core/session/internal/agent_team.py
+++ b/openjiuwen/core/session/internal/agent_team.py
@@ -64,3 +64,7 @@ class AgentTeamSession(BaseSession):
 
     def team_id(self) -> str:
         return self._team_id
+
+    def group_id(self) -> str:
+        """Alias of team_id for Redis checkpointer / AgentGroupStorage."""
+        return self._team_id

--- a/tests/unit_tests/core/session/test_agent_team_session_group_id.py
+++ b/tests/unit_tests/core/session/test_agent_team_session_group_id.py
@@ -1,0 +1,11 @@
+# -*- coding: UTF-8 -*-
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+from openjiuwen.core.session.internal.agent_team import AgentTeamSession
+
+
+def test_agent_team_session_group_id_aliases_team_id():
+    session = AgentTeamSession(session_id="s1", team_id="team-42")
+    assert session.team_id() == "team-42"
+    assert session.group_id() == "team-42"
+    assert session.session_id() == "s1"


### PR DESCRIPTION
Paired: [GitHub #1281](https://github.com/openJiuwen-ai/agent-core/pull/1281) ↔ [GitCode !2818](https://gitcode.com/openJiuwen/agent-core/merge_requests/2818)

﻿## Summary
- Redis checkpointer / `AgentGroupStorage` call `session.group_id()`.
- `AgentTeamSession` only had `team_id()` → `AttributeError`.
- Add `group_id()` as an alias of `team_id()`.

Fixes #983

## Test plan
- [x] Unit test `test_agent_team_session_group_id_aliases_team_id`

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #983
<!-- /bot1-related-issues -->
