### PR TITLE
docs(session): use session.pre_run in streaming examples

### DIFF
--- a/docs/en/2.Development Guide/Advanced Usage/Session/Streaming Output.md
+++ b/docs/en/2.Development Guide/Advanced Usage/Session/Streaming Output.md
@@ -124,7 +124,6 @@ from openjiuwen.core.single_agent import AgentCard
 from openjiuwen.core.single_agent import BaseAgent
 from openjiuwen.core.single_agent import Session, create_agent_session
 from openjiuwen.core.session.stream import OutputSchema, CustomSchema, StreamMode
-from openjiuwen.core.session import get_default_inmemory_checkpointer
 
 class MockModel:
     def __init__(self, model_name: str):
@@ -174,8 +173,8 @@ class CustomAgent(BaseAgent):
         # Create current runtime
         session = create_agent_session(session_id=session_id, card=self.card)
 
-        # Temporary solution, will be removed in future versions
-        await get_default_inmemory_checkpointer().pre_agent_execute(getattr(getattr(session, "_inner"), "_inner"), inputs)
+        # Restore session state via checkpointer (default InMemory)
+        await session.pre_run(inputs=inputs)
 
         async def stream_process():
             try:

--- a/docs/zh/2.开发指南/高阶用法/Session/流式输出.md
+++ b/docs/zh/2.开发指南/高阶用法/Session/流式输出.md
@@ -124,7 +124,6 @@ from openjiuwen.core.single_agent import AgentCard
 from openjiuwen.core.single_agent import BaseAgent
 from openjiuwen.core.single_agent import Session, create_agent_session
 from openjiuwen.core.session.stream import OutputSchema, CustomSchema, StreamMode
-from openjiuwen.core.session import get_default_inmemory_checkpointer
 
 class MockModel:
     def __init__(self, model_name: str):
@@ -174,8 +173,8 @@ class CustomAgent(BaseAgent):
         # 创建当前运行时
         session = create_agent_session(session_id=session_id, card=self.card)
 
-        # 临时使用方案，将在后续的版本中删除
-        await get_default_inmemory_checkpointer().pre_agent_execute(getattr(getattr(session, "_inner"), "_inner"), inputs)
+        # 通过 checkpointer 恢复会话状态（默认 InMemory）
+        await session.pre_run(inputs=inputs)
 
         async def stream_process():
             try:


### PR DESCRIPTION
Paired: [GitHub #1284](https://github.com/openJiuwen-ai/agent-core/pull/1284) ↔ [GitCode !2820](https://gitcode.com/openJiuwen/agent-core/merge_requests/2820)

## Summary
- Replace obsolete `get_default_inmemory_checkpointer` (removed from public API) with `await session.pre_run(inputs=inputs)` in Agent streaming docs (EN + ZH).

Fixes #1131

## Test plan
- [ ] Docs no longer import `get_default_inmemory_checkpointer`
- [ ] Example uses `session.pre_run` after `create_agent_session`

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #1131
<!-- /bot1-related-issues -->
