### PR TITLE
docs(mcp): construct SseClient with McpServerConfig

### DIFF
--- a/docs/en/2.Development Guide/Basic Functions/Custom Tools.md
+++ b/docs/en/2.Development Guide/Basic Functions/Custom Tools.md
@@ -132,8 +132,15 @@ After developers implement and deploy custom MCP services, they can use the `MCP
 import asyncio
 
 from openjiuwen.core.foundation.tool import MCPTool, SseClient
+from openjiuwen.core.foundation.tool.mcp.base import McpServerConfig
 
-mcp_client = SseClient(server_path="your weather mcp url", name="MockSseClient")
+mcp_client = SseClient(
+    McpServerConfig(
+        server_name="MockSseClient",
+        server_path="your weather mcp url",
+        client_type="sse",
+    )
+)
 asyncio.run(mcp_client.connect(timeout=10))
 tool_info_list = asyncio.run(mcp_client.list_tools())
 for tool_info in tool_info_list:

--- a/docs/zh/2.开发指南/基础功能/自定义工具.md
+++ b/docs/zh/2.开发指南/基础功能/自定义工具.md
@@ -134,8 +134,15 @@ openJiuwen提供`MCPTool`类，用于封装MCP服务，生成的`MCPTool`类可�
 import asyncio
 
 from openjiuwen.core.foundation.tool import MCPTool, SseClient
+from openjiuwen.core.foundation.tool.mcp.base import McpServerConfig
 
-mcp_client = SseClient(server_path="your weather mcp url", name="MockSseClient")
+mcp_client = SseClient(
+    McpServerConfig(
+        server_name="MockSseClient",
+        server_path="your weather mcp url",
+        client_type="sse",
+    )
+)
 asyncio.run(mcp_client.connect(timeout=10))
 tool_info_list = asyncio.run(mcp_client.list_tools())
 for tool_info in tool_info_list:


### PR DESCRIPTION
Paired: [GitHub #1286](https://github.com/openJiuwen-ai/agent-core/pull/1286) ↔ [GitCode !2822](https://gitcode.com/openJiuwen/agent-core/merge_requests/2822)

## Summary
- Update Custom Tools MCP examples (EN + ZH) to construct `SseClient(McpServerConfig(...))` instead of invalid `SseClient(server_path=..., name=...)` kwargs.

Fixes #1020

## Test plan
- [ ] Example matches `SseClient.__init__(self, config: McpServerConfig)`
- [ ] ReActAgent docs already use `McpServerConfig` (unchanged)

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #1020
<!-- /bot1-related-issues -->
