### PR TITLE
docs: remove extra parenthesis in RestfulApi example

### DIFF
--- a/docs/zh/2.开发指南/基础功能/自定义工具.md
+++ b/docs/zh/2.开发指南/基础功能/自定义工具.md
@@ -92,7 +92,6 @@ mock_data = RestfulApi(
         method="GET",
     ),
 )
-)
 ```
 
 ## 调用工具


### PR DESCRIPTION
Paired: [GitHub #1287](https://github.com/openJiuwen-ai/agent-core/pull/1287) ↔ [GitCode !2823](https://gitcode.com/openJiuwen/agent-core/merge_requests/2823)

## Summary
- Remove the stray closing parenthesis in the Chinese Custom Tools `RestfulApi` example.

Fixes #1015

## Test plan
- [ ] Code fence parses as valid Python

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #1015
<!-- /bot1-related-issues -->
