### PR TITLE
fix(retrieval): count MilvusLite list results in delete_index

### DIFF
--- a/openjiuwen/core/retrieval/indexing/indexer/milvus_indexer.py
+++ b/openjiuwen/core/retrieval/indexing/indexer/milvus_indexer.py
@@ -245,6 +245,11 @@ class MilvusIndexer(Indexer):
 
             if isinstance(result, dict):
                 delete_count = result.get("delete_count", 0)
+            elif isinstance(result, (list, tuple)):
+                # MilvusLite returns the list of deleted primary keys instead
+                # of a stats dict (openJiuwen/agent-studio#1482): int(list)
+                # raises TypeError, so count the deleted primary keys.
+                delete_count = len(result)
             else:
                 delete_count = int(result) if result else 0
 

--- a/tests/unit_tests/core/retrieval/indexing/indexer/test_milvus_indexer.py
+++ b/tests/unit_tests/core/retrieval/indexing/indexer/test_milvus_indexer.py
@@ -351,6 +351,32 @@ class TestMilvusIndexer:
 
     @pytest.mark.asyncio
     @patch("openjiuwen.core.retrieval.indexing.indexer.milvus_indexer.MilvusVectorStore.create_client")
+    async def test_delete_index_milvuslite_list_result(self, mock_client_class):
+        """MilvusLite returns the list of deleted primary keys, not a stats dict (agent-studio#1482)"""
+        mock_client = MagicMock()
+        mock_client.delete.return_value = ["pk-1", "pk-2", "pk-3"]
+        mock_client_class.return_value = mock_client
+
+        config = VectorStoreConfig(store_provider="milvus", collection_name="test_collection")
+        indexer = MilvusIndexer(config=config, milvus_uri="http://localhost:19530")
+        result = await indexer.delete_index("doc_1", "test_index")
+        assert result is True
+
+    @pytest.mark.asyncio
+    @patch("openjiuwen.core.retrieval.indexing.indexer.milvus_indexer.MilvusVectorStore.create_client")
+    async def test_delete_index_milvuslite_empty_list(self, mock_client_class):
+        """An empty MilvusLite list means nothing was deleted"""
+        mock_client = MagicMock()
+        mock_client.delete.return_value = []
+        mock_client_class.return_value = mock_client
+
+        config = VectorStoreConfig(store_provider="milvus", collection_name="test_collection")
+        indexer = MilvusIndexer(config=config, milvus_uri="http://localhost:19530")
+        result = await indexer.delete_index("doc_1", "test_index")
+        assert result is False
+
+    @pytest.mark.asyncio
+    @patch("openjiuwen.core.retrieval.indexing.indexer.milvus_indexer.MilvusVectorStore.create_client")
     async def test_index_exists_true(self, mock_client_class):
         """Test index exists"""
         mock_client = MagicMock()


### PR DESCRIPTION
Paired: [GitHub #1344](https://github.com/openJiuwen-ai/agent-core/pull/1344) ↔ [GitCode !2790](https://gitcode.com/openJiuwen/agent-core/merge_requests/2790)

## Problem

The Agent Studio knowledge-base bulk delete fails with `openjiuwen.03000000` while single delete silently "succeeds" (tracked in openJiuwen/agent-studio#1482).

Root cause: on **Milvus Lite**, `MilvusClient.delete()` returns the **list of deleted primary keys** instead of a stats dict. `MilvusIndexer.delete_index` handled the dict shape and otherwise did `int(result)` — and `int(["pk-1", …])` raises `TypeError`, which the local `except` swallows and turns into `return False`.

## What changed

`openjiuwen/core/retrieval/indexing/indexer/milvus_indexer.py` — one branch in `delete_index`:

```python
elif isinstance(result, (list, tuple)):
    delete_count = len(result)
```

- list/tuple results (Milvus Lite) count the deleted primary keys;
- the dict shape (cluster Milvus) and the scalar fallback path are unchanged.

## Testing

`tests/unit_tests/core/retrieval/indexing/indexer/test_milvus_indexer.py` gains two cases in the existing style:

- MilvusLite list result (`["pk-1", "pk-2", "pk-3"]`) → `delete_index` returns **True** — this case raised `TypeError` before the fix;
- empty list → returns **False** (nothing deleted), still no exception.

Full file: 21 passed (`pytest tests/unit_tests/core/retrieval/indexing/indexer/test_milvus_indexer.py`). On the unpatched code the list case fails exactly as #1482 describes, and is restored to passing by this change.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #369
<!-- /bot1-related-issues -->
