### PR TITLE
fix(tools/web): verify TLS by default for the web tools transport

### DIFF
--- a/openjiuwen/harness/tools/web/_common.py
+++ b/openjiuwen/harness/tools/web/_common.py
@@ -271,8 +271,15 @@ def _get_web_proxy_url(configured_proxy: str | None = None) -> str:
 
 
 def _free_search_ssl_verify() -> bool:
-    """Whether to verify TLS certificates (default off for intranet usage)."""
-    return _env_flag(_FREE_SEARCH_SSL_VERIFY_ENV, default=False)
+    """Whether to verify TLS certificates.
+
+    Verification is on by default: the tools' fetch target is chosen by the
+    model and the response body is injected into the agent's context, so a
+    MITM with a self-signed certificate would be indirect prompt injection.
+    Intranet deployments that terminate TLS with a private CA can set
+    ``FREE_SEARCH_SSL_VERIFY=0`` to opt out.
+    """
+    return _env_flag(_FREE_SEARCH_SSL_VERIFY_ENV, default=True)
 
 
 def _no_proxy_entries() -> list[str]:

--- a/openjiuwen/harness/tools/web/_http.py
+++ b/openjiuwen/harness/tools/web/_http.py
@@ -31,8 +31,9 @@ _CONNECT_TIMEOUT_CAP = 10
 def _make_connector() -> aiohttp.TCPConnector:
     """Build a TCP connector honoring the SSL-verify configuration.
 
-    ``ssl=True`` uses aiohttp's default verification (equivalent to requests
-    ``verify=True``); ``ssl=False`` disables it (default, for intranet usage).
+    TLS verification is on by default (``ssl=True``, aiohttp's default
+    verification, equivalent to requests ``verify=True``); setting
+    ``FREE_SEARCH_SSL_VERIFY=0`` disables it for intranet deployments (#1339).
     """
     if _free_search_ssl_verify():
         return aiohttp.TCPConnector(ssl=True)

--- a/tests/unit_tests/harness/tools/web/test_ssl_verify_default.py
+++ b/tests/unit_tests/harness/tools/web/test_ssl_verify_default.py
@@ -1,0 +1,62 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""TLS verification defaults for the web tools' HTTP transport (#1339).
+
+``fetch_webpage`` / ``free_search`` hand the model-chosen URL's response body
+straight into the agent's context. With verification off by default, a MITM
+with a self-signed certificate could forge that content — indirect prompt
+injection — so the default must be verify-on, with an explicit env opt-out
+for intranet deployments that terminate TLS themselves.
+"""
+
+import pytest
+
+from openjiuwen.harness.tools.web._common import _free_search_ssl_verify
+from openjiuwen.harness.tools.web._http import _make_connector
+
+
+@pytest.fixture(autouse=True)
+def clean_ssl_env(monkeypatch):
+    """Keep the env var out of every test's default state."""
+    monkeypatch.delenv("FREE_SEARCH_SSL_VERIFY", raising=False)
+    yield
+
+
+def test_ssl_verify_defaults_to_on(monkeypatch):
+    """Unset env → verification on (the #1339 fix)."""
+    assert _free_search_ssl_verify() is True
+
+
+def test_ssl_verify_can_be_opted_out_for_intranet(monkeypatch):
+    """Explicit opt-out keeps the intranet escape hatch working."""
+    for value in ("0", "false", "no", "off"):
+        monkeypatch.setenv("FREE_SEARCH_SSL_VERIFY", value)
+        assert _free_search_ssl_verify() is False, value
+
+
+def test_ssl_verify_stays_on_for_explicit_truthy(monkeypatch):
+    for value in ("1", "true", "yes", "on"):
+        monkeypatch.setenv("FREE_SEARCH_SSL_VERIFY", value)
+        assert _free_search_ssl_verify() is True, value
+
+
+@pytest.mark.asyncio
+async def test_make_connector_verifies_by_default():
+    """The default connector must not carry the ssl=False opt-out."""
+    connector = _make_connector()
+    try:
+        assert connector._ssl is not False
+    finally:
+        await connector.close()
+
+
+@pytest.mark.asyncio
+async def test_make_connector_honors_intranet_opt_out(monkeypatch):
+    """The env opt-out still produces the verify-off connector."""
+    monkeypatch.setenv("FREE_SEARCH_SSL_VERIFY", "0")
+    connector = _make_connector()
+    try:
+        assert connector._ssl is False
+    finally:
+        await connector.close()


### PR DESCRIPTION
Paired: [GitHub #1350](https://github.com/openJiuwen-ai/agent-core/pull/1350) ↔ [GitCode !2795](https://gitcode.com/openJiuwen/agent-core/merge_requests/2795)

## Problem

Fixes #1339. All web tools (`fetch_webpage` / `free_search`) defaulted their HTTP transport to **TLS verification off** (`ssl=False`), with an env opt-in (`FREE_SEARCH_SSL_VERIFY`) nobody would set:

```python
def _free_search_ssl_verify() -> bool:
    """Whether to verify TLS certificates (default off for intranet usage)."""
    return _env_flag(_FREE_SEARCH_SSL_VERIFY_ENV, default=False)
```

The fetch target is chosen by the model and the response body is injected straight into the agent's context (ToolMessage), so a MITM with a self-signed certificate could forge page content — indirect prompt injection (hijacking later tool calls, exfiltrating data through them) plus interception of the TLS session itself. The issue includes a working repro: a self-signed HTTPS server whose forged body is returned by `fetch_webpage` with no error.

## What changed

- `openjiuwen/harness/tools/web/_common.py` — `_free_search_ssl_verify` now defaults to `True`. The docstring states the security rationale and the escape hatch. `FREE_SEARCH_SSL_VERIFY=0/false/no/off` remains a working opt-out for intranet deployments that terminate TLS with a private CA (`_env_flag`'s parsing is unchanged — only the default flips).
- `openjiuwen/harness/tools/web/_http.py` — `_make_connector`'s docstring updated to match (verify-on default; env opt-out). No behavior change beyond the default.

## Security justification for the default flip

- The threat is not hypothetical self-signed intranet breakage — it is *silent content injection into the agent's reasoning* from any network-position attacker (same LAN, ARP spoofing, malicious proxy), which is strictly worse than a failed fetch.
- A verify-on default that breaks an intranet deployment fails **loudly** (certificate error the operator can diagnose and opt out of with one env var); the old default failed **silently** (forged content accepted).
- Opt-out is one line (`FREE_SEARCH_SSL_VERIFY=0`), documented in both docstrings.

## Testing

`tests/unit_tests/harness/tools/web/test_ssl_verify_default.py` (new):

- `_free_search_ssl_verify()` is `True` with the env unset — fails on the pre-fix default, passes after;
- every falsy spelling (`0/false/no/off`) opts out; every truthy spelling stays on;
- `_make_connector()` does not carry the `ssl=False` opt-out by default, and does with `FREE_SEARCH_SSL_VERIFY=0`.

5/5 pass on this branch; on the unpatched default the two default-state tests fail (verified by reverting the one-line default locally and re-running).

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #1339
<!-- /bot1-related-issues -->
