### PR TITLE
fix(session): re-export InMemoryCheckpointer and CheckpointerConfig from the checkpointer package

### DIFF
--- a/openjiuwen/core/session/checkpointer/__init__.py
+++ b/openjiuwen/core/session/checkpointer/__init__.py
@@ -12,14 +12,18 @@ from openjiuwen.core.session.checkpointer.base import (
     WORKFLOW_NAMESPACE_GRAPH,
 )
 from openjiuwen.core.session.checkpointer.checkpointer import (
+    CheckpointerConfig,
     CheckpointerFactory,
     CheckpointerProvider,
 )
+from openjiuwen.core.session.checkpointer.inmemory import InMemoryCheckpointer
 
 __all__ = [
     "CheckpointerFactory",
     "CheckpointerProvider",
     "Checkpointer",
+    "CheckpointerConfig",
+    "InMemoryCheckpointer",
     "Storage",
     "build_key",
     "build_key_with_namespace",


### PR DESCRIPTION
Paired: [GitHub #1351](https://github.com/openJiuwen-ai/agent-core/pull/1351) ↔ [GitCode !2796](https://gitcode.com/openJiuwen/agent-core/merge_requests/2796)

## Problem

Fixes #1298. The Checkpointer guide (docs/zh/2.开发指南/高阶用法/Checkpointer检查点机制.md and its English counterpart) imports `InMemoryCheckpointer` and `CheckpointerConfig` from `openjiuwen.core.session.checkpointer`, but the package `__init__.py` never re-exports them — every doc snippet raises `ImportError` on the first line.

## What changed

`openjiuwen/core/session/checkpointer/__init__.py`:

- import `InMemoryCheckpointer` from `.inmemory` and `CheckpointerConfig` from `.checkpointer`;
- add both to `__all__`.

Both classes already exist in the package; only the package exports were missing.

## Testing

- `from openjiuwen.core.session.checkpointer import InMemoryCheckpointer, CheckpointerConfig, CheckpointerFactory` — all three import successfully (previously `InMemoryCheckpointer` and `CheckpointerConfig` both raised ImportError);
- existing checkpointer tests: `tests/unit_tests/core/session/checkpointer/` 16 passed, `tests/unit_tests/extensions/checkpointer/` untouched.

Docs change: none needed — the guide's imports were already correct; the package was missing the exports they rely on.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #1298
<!-- /bot1-related-issues -->
