### PR TITLE
docs: fix the IntelliRouter install command (intelli-router is not on PyPI)

### DIFF
--- a/docs/zh/2.开发指南/高阶用法/IntelliRouter智能路由.md
+++ b/docs/zh/2.开发指南/高阶用法/IntelliRouter智能路由.md
@@ -40,7 +40,7 @@ ReliableRouter (intelli_router 包)
 IntelliRouter 是 agent-core 的**可选依赖**，需要单独安装：
 
 ```bash
-pip install intelli-router
+pip install "intelli-router @ git+https://gitcode.com/openJiuwen/agent-protocol.git@feature/intelliRouter#subdirectory=intelli_router"
 ```
 
 验证安装是否成功：
@@ -602,7 +602,7 @@ model_client_config = ModelClientConfig(
 
 **Q: `intelli-router` 包未安装会怎样？**
 
-A: agent-core 模块可正常加载（import 不会失败），但在实际创建 IntelliRouter 客户端时会抛出 `MODEL_SERVICE_CONFIG_ERROR` 错误，并提示 `pip install intelli-router`。
+A: agent-core 模块可正常加载（import 不会失败），但在实际创建 IntelliRouter 客户端时会抛出 `MODEL_SERVICE_CONFIG_ERROR` 错误，并提示 `pip install "intelli-router @ git+https://gitcode.com/openJiuwen/agent-protocol.git@feature/intelliRouter#subdirectory=intelli_router"`。
 
 **Q: `api_key` 和 `api_base` 为什么要填 placeholder？**
 


### PR DESCRIPTION
Paired: [GitHub #1352](https://github.com/openJiuwen-ai/agent-core/pull/1352) ↔ [GitCode !2797](https://gitcode.com/openJiuwen/agent-core/merge_requests/2797)

intelli-router is not on PyPI; it installs from the GitCode agent-protocol repo. Use the same git+URL form as the pyproject extra. Fixes #1294.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md
## Problem

Fixes #1294. The IntelliRouter guide tells users to `pip install intelli-router`, but **`intelli-router` is not on PyPI** — the install command fails with "No matching distribution found", and the screenshot in the issue shows exactly that error.

## What changed

Both the Chinese and English IntelliRouter guides (`docs/zh/2.开发指南/高阶用法/IntelliRouter智能路由.md`, `docs/en/2.Development Guide/Advanced Usage/IntelliRouter.md`) now use the working install command — the same git+URL form already declared in `pyproject.toml`'s `intelli-router` extra:

```bash
pip install "intelli-router @ git+https://gitcode.com/openJiuwen/agent-protocol.git@feature/intelliRouter#subdirectory=intelli_router"
```

The PyPI-related FAQ entry in the English doc is also updated to reference this command instead of the broken `pip install intelli-router`.

## Verification

- `pyproject.toml` declares `intelli-router = ["intelli-router @ git+…#subdirectory=intelli_router"]` — this PR makes the doc match that source of truth.
- Confirmed `intelli-router` / `intelli_router` return 404 on the PyPI registry API, which is why the documented `pip install intelli-router` always fails.

2) If you want to contribute your code but don't know who will review and merge, please add label `openJiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
Choose one label from `bug`, `task`, `feature` and `refactor`, and replace `<label>` below the comment block. 

If this pr is not only bugfix/task/feature and also a refactor, you can append `/kind refactor` label after `/kind bug`, `/kind task` and `/kind feature`.
-->
/kind <label>


**What does this PR do / why do we need it**:
* Need to describe clearly


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：
* Need to describe clearly


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [ ] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [ ] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #1294
<!-- /bot1-related-issues -->
